### PR TITLE
feat: скелет публичного API пакета @nakidka/graph (фаза 0)

### DIFF
--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
+    "testcontainers": "^11.14.0",
     "typescript": "~5.9.3",
     "vitest": "^4.0.15"
   }

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -14,3 +14,5 @@ export type {
   GraphPrimitive,
   NodeData,
 } from "./types"
+
+export { updateGraph } from "./updateGraph"

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -16,3 +16,4 @@ export type {
 } from "./types"
 
 export { updateGraph } from "./updateGraph"
+export { withGraph, type GraphSession } from "./withGraph"

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,60 +1,8 @@
-import { FalkorDB } from "falkordb"
-
-const DEFAULT_URL = "redis://localhost:6379"
-const DEFAULT_GRAPH_NAME = "nakidka"
-
-export interface GraphOptions {
-  url?: string
-  graphName?: string
-}
-
-declare const graphConnectionBrand: unique symbol
-export type GraphConnection = { readonly [graphConnectionBrand]: true }
-
-type InternalGraphConnection = {
-  client: Awaited<ReturnType<typeof FalkorDB.connect>>
-  graph: ReturnType<Awaited<ReturnType<typeof FalkorDB.connect>>["selectGraph"]>
-}
-
-const asInternal = (conn: GraphConnection): InternalGraphConnection =>
-  conn as unknown as InternalGraphConnection
-
-const asExternal = (conn: InternalGraphConnection): GraphConnection =>
-  conn as unknown as GraphConnection
-
-export const connect = async (opts?: GraphOptions): Promise<GraphConnection> => {
-  const url = opts?.url ?? process.env["NKDK_GRAPH_URL"] ?? DEFAULT_URL
-  const graphName = opts?.graphName ?? process.env["NKDK_GRAPH_NAME"] ?? DEFAULT_GRAPH_NAME
-  const client = await FalkorDB.connect({ url })
-  const graph = client.selectGraph(graphName)
-  return asExternal({ client, graph })
-}
-
-export const close = async (conn: GraphConnection): Promise<void> => {
-  await asInternal(conn).client.close()
-}
-
-export const query = async (
-  conn: GraphConnection,
-  cypher: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  params?: Record<string, unknown>,
-): Promise<unknown> => {
-  // Cast params to any to bridge Record<string, unknown> → QueryParams (not exported by falkordb)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const opts = params !== undefined ? { params: params as any } : undefined
-  return await asInternal(conn).graph.query(cypher, opts)
-}
-
-export const ensureIndex = async (
-  conn: GraphConnection,
-  label: string,
-  prop: string,
-): Promise<void> => {
-  try {
-    await asInternal(conn).graph.query(`CREATE INDEX FOR (n:${label}) ON (n.${prop})`)
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    if (!/already indexed|equivalent index|index already exists/i.test(msg)) throw err
-  }
-}
+export {
+  close,
+  connect,
+  ensureIndex,
+  query,
+  type GraphConnection,
+  type GraphOptions,
+} from "./internal/connection"

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -6,3 +6,11 @@ export {
   type GraphConnection,
   type GraphOptions,
 } from "./internal/connection"
+
+export type {
+  ConnectionOptions,
+  EdgeData,
+  FileGraphData,
+  GraphPrimitive,
+  NodeData,
+} from "./types"

--- a/packages/graph/src/internal/connection.ts
+++ b/packages/graph/src/internal/connection.ts
@@ -1,0 +1,60 @@
+import { FalkorDB } from "falkordb"
+
+const DEFAULT_URL = "redis://localhost:6379"
+const DEFAULT_GRAPH_NAME = "nakidka"
+
+export interface GraphOptions {
+  url?: string
+  graphName?: string
+}
+
+declare const graphConnectionBrand: unique symbol
+export type GraphConnection = { readonly [graphConnectionBrand]: true }
+
+type InternalGraphConnection = {
+  client: Awaited<ReturnType<typeof FalkorDB.connect>>
+  graph: ReturnType<Awaited<ReturnType<typeof FalkorDB.connect>>["selectGraph"]>
+}
+
+const asInternal = (conn: GraphConnection): InternalGraphConnection =>
+  conn as unknown as InternalGraphConnection
+
+const asExternal = (conn: InternalGraphConnection): GraphConnection =>
+  conn as unknown as GraphConnection
+
+export const connect = async (opts?: GraphOptions): Promise<GraphConnection> => {
+  const url = opts?.url ?? process.env["NKDK_GRAPH_URL"] ?? DEFAULT_URL
+  const graphName = opts?.graphName ?? process.env["NKDK_GRAPH_NAME"] ?? DEFAULT_GRAPH_NAME
+  const client = await FalkorDB.connect({ url })
+  const graph = client.selectGraph(graphName)
+  return asExternal({ client, graph })
+}
+
+export const close = async (conn: GraphConnection): Promise<void> => {
+  await asInternal(conn).client.close()
+}
+
+export const query = async (
+  conn: GraphConnection,
+  cypher: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params?: Record<string, unknown>,
+): Promise<unknown> => {
+  // Cast params to any to bridge Record<string, unknown> → QueryParams (not exported by falkordb)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const opts = params !== undefined ? { params: params as any } : undefined
+  return await asInternal(conn).graph.query(cypher, opts)
+}
+
+export const ensureIndex = async (
+  conn: GraphConnection,
+  label: string,
+  prop: string,
+): Promise<void> => {
+  try {
+    await asInternal(conn).graph.query(`CREATE INDEX FOR (n:${label}) ON (n.${prop})`)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (!/already indexed|equivalent index|index already exists/i.test(msg)) throw err
+  }
+}

--- a/packages/graph/src/internal/operations.ts
+++ b/packages/graph/src/internal/operations.ts
@@ -1,0 +1,46 @@
+import { query } from "./connection"
+import type { GraphConnection } from "./connection"
+import type { NodeData } from "../types"
+
+export const BATCH_SIZE = 5000
+
+const groupBy = <T, K extends string>(
+  items: readonly T[],
+  key: (item: T) => K,
+): Map<K, T[]> => {
+  const result = new Map<K, T[]>()
+  for (const item of items) {
+    const k = key(item)
+    const bucket = result.get(k)
+    if (bucket === undefined) result.set(k, [item])
+    else bucket.push(item)
+  }
+  return result
+}
+
+const sendBatches = async <T>(
+  conn: GraphConnection,
+  items: readonly T[],
+  cypher: string,
+  paramName = "batch",
+): Promise<void> => {
+  for (let i = 0; i < items.length; i += BATCH_SIZE) {
+    await query(conn, cypher, { [paramName]: items.slice(i, i + BATCH_SIZE) })
+  }
+}
+
+export const mergeNodes = async (
+  conn: GraphConnection,
+  nodes: readonly NodeData[],
+): Promise<void> => {
+  if (nodes.length === 0) return
+  const byLabel = groupBy(nodes, (n) => n.label)
+  for (const [label, group] of byLabel) {
+    const payload = group.map((n) => ({ id: n.id, props: n.props }))
+    await sendBatches(
+      conn,
+      payload,
+      `UNWIND $batch AS n MERGE (m:${label} {id: n.id}) SET m += n.props`,
+    )
+  }
+}

--- a/packages/graph/src/internal/operations.ts
+++ b/packages/graph/src/internal/operations.ts
@@ -83,3 +83,10 @@ export const deleteByFilePaths = async (
     params,
   )
 }
+
+export const cleanupOrphanStubs = async (conn: GraphConnection): Promise<void> => {
+  await query(
+    conn,
+    "MATCH (n) WHERE n.filePath IS NULL AND NOT ()-->(n) DETACH DELETE n",
+  )
+}

--- a/packages/graph/src/internal/operations.ts
+++ b/packages/graph/src/internal/operations.ts
@@ -60,3 +60,26 @@ export const mergeEdges = async (
     )
   }
 }
+
+export const deleteByFilePaths = async (
+  conn: GraphConnection,
+  filePaths: readonly string[],
+): Promise<void> => {
+  if (filePaths.length === 0) return
+  const params = { filePaths: [...filePaths] }
+  await query(
+    conn,
+    "MATCH (n) WHERE n.filePath IN $filePaths MATCH (n)-[r]->() DELETE r",
+    params,
+  )
+  await query(
+    conn,
+    "MATCH (n) WHERE n.filePath IN $filePaths AND ()-->(n) SET n = {id: n.id}",
+    params,
+  )
+  await query(
+    conn,
+    "MATCH (n) WHERE n.filePath IN $filePaths AND NOT ()-->(n) DETACH DELETE n",
+    params,
+  )
+}

--- a/packages/graph/src/internal/operations.ts
+++ b/packages/graph/src/internal/operations.ts
@@ -1,4 +1,4 @@
-import { query } from "./connection"
+import { ensureIndex, query } from "./connection"
 import type { GraphConnection } from "./connection"
 import type { EdgeData, NodeData } from "../types"
 
@@ -89,4 +89,14 @@ export const cleanupOrphanStubs = async (conn: GraphConnection): Promise<void> =
     conn,
     "MATCH (n) WHERE n.filePath IS NULL AND NOT ()-->(n) DETACH DELETE n",
   )
+}
+
+export const ensureLabelIndexes = async (
+  conn: GraphConnection,
+  labels: readonly string[],
+): Promise<void> => {
+  const unique = new Set(labels)
+  for (const label of unique) {
+    await ensureIndex(conn, label, "id")
+  }
 }

--- a/packages/graph/src/internal/operations.ts
+++ b/packages/graph/src/internal/operations.ts
@@ -1,6 +1,6 @@
 import { query } from "./connection"
 import type { GraphConnection } from "./connection"
-import type { NodeData } from "../types"
+import type { EdgeData, NodeData } from "../types"
 
 export const BATCH_SIZE = 5000
 
@@ -41,6 +41,22 @@ export const mergeNodes = async (
       conn,
       payload,
       `UNWIND $batch AS n MERGE (m:${label} {id: n.id}) SET m += n.props`,
+    )
+  }
+}
+
+export const mergeEdges = async (
+  conn: GraphConnection,
+  edges: readonly EdgeData[],
+): Promise<void> => {
+  if (edges.length === 0) return
+  const byKind = groupBy(edges, (e) => e.kind)
+  for (const [kind, group] of byKind) {
+    const payload = group.map((e) => ({ src: e.src, tgt: e.tgt, props: e.props ?? {} }))
+    await sendBatches(
+      conn,
+      payload,
+      `UNWIND $batch AS e MATCH (s {id: e.src}), (t {id: e.tgt}) MERGE (s)-[r:${kind}]->(t) SET r = e.props`,
     )
   }
 }

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Примитивные значения, поддерживаемые FalkorDB в `props` узлов и рёбер.
+ * Массивы — только массивы примитивов; вложенные объекты не поддерживаются.
+ */
+export type GraphPrimitive = string | number | boolean | null
+
+export interface NodeData {
+  /** Полный YAML-путь узла. Уникальный идентификатор в графе. */
+  id: string
+  /** Семантическая метка в Cypher (`MetadataCatalog`, `Form`, ...). PascalCase. */
+  label: string
+  /** Свойства узла. Только примитивы и их массивы — ограничение FalkorDB. */
+  props: Record<string, GraphPrimitive | GraphPrimitive[]>
+}
+
+export interface EdgeData {
+  /** id узла-источника. */
+  src: string
+  /** id узла-цели. */
+  tgt: string
+  /** Тип отношения, SCREAMING_SNAKE_CASE (`VALUE`, `OBJECT`, `REF_TYPE`, ...). */
+  kind: string
+  /** Координаты ребра (`index` для упорядоченных коллекций, `yaml` для диагностики). */
+  props?: Record<string, GraphPrimitive>
+}
+
+export interface FileGraphData {
+  /** Абсолютный или относительный путь YAML-файла. */
+  filePath: string
+  nodes: NodeData[]
+  edges: EdgeData[]
+}
+
+export interface ConnectionOptions {
+  /** URL FalkorDB. По умолчанию — env `NKDK_GRAPH_URL` или `redis://localhost:6379`. */
+  url?: string
+  /** Имя графа. По умолчанию — env `NKDK_GRAPH_NAME` или `nakidka`. */
+  graphName?: string
+}

--- a/packages/graph/src/updateGraph.ts
+++ b/packages/graph/src/updateGraph.ts
@@ -1,0 +1,37 @@
+import { close, connect } from "./internal/connection"
+import {
+  cleanupOrphanStubs,
+  deleteByFilePaths,
+  ensureLabelIndexes,
+  mergeEdges,
+  mergeNodes,
+} from "./internal/operations"
+import type { ConnectionOptions, FileGraphData } from "./types"
+
+/**
+ * Обновляет содержимое графа по списку файлов:
+ *  - удаляет узлы и рёбра, привязанные к этим файлам;
+ *  - наливает новые;
+ *  - узлы со входящими reference-рёбрами становятся стабами, а не удаляются;
+ *  - удаляет orphan-стабы, которые после merge остались без входящих рёбер.
+ */
+export const updateGraph = async (
+  files: readonly FileGraphData[],
+  opts?: ConnectionOptions,
+): Promise<void> => {
+  const allNodes = files.flatMap((f) => f.nodes)
+  const allEdges = files.flatMap((f) => f.edges)
+  const filePaths = files.map((f) => f.filePath)
+  const labels = allNodes.map((n) => n.label)
+
+  const conn = await connect(opts)
+  try {
+    await ensureLabelIndexes(conn, labels)
+    await deleteByFilePaths(conn, filePaths)
+    await mergeNodes(conn, allNodes)
+    await mergeEdges(conn, allEdges)
+    await cleanupOrphanStubs(conn)
+  } finally {
+    await close(conn)
+  }
+}

--- a/packages/graph/src/withGraph.ts
+++ b/packages/graph/src/withGraph.ts
@@ -1,0 +1,30 @@
+import { close, connect, query } from "./internal/connection"
+import type { ConnectionOptions } from "./types"
+
+export interface GraphSession {
+  query: <R = Record<string, unknown>>(
+    cypher: string,
+    params?: Record<string, unknown>,
+  ) => Promise<R[]>
+}
+
+/**
+ * Открывает соединение с FalkorDB, передаёт сессию в callback и закрывает.
+ * Используется для нескольких Cypher-запросов в рамках одного логического действия
+ * (валидация правил, обогащение модели). Соединение закрывается в finally.
+ */
+export const withGraph = async <T>(
+  fn: (graph: GraphSession) => Promise<T>,
+  opts?: ConnectionOptions,
+): Promise<T> => {
+  const conn = await connect(opts)
+  try {
+    const session: GraphSession = {
+      query: async <R>(cypher: string, params?: Record<string, unknown>) =>
+        (await query(conn, cypher, params)) as R[],
+    }
+    return await fn(session)
+  } finally {
+    await close(conn)
+  }
+}

--- a/packages/graph/src/withGraph.ts
+++ b/packages/graph/src/withGraph.ts
@@ -20,8 +20,10 @@ export const withGraph = async <T>(
   const conn = await connect(opts)
   try {
     const session: GraphSession = {
-      query: async <R>(cypher: string, params?: Record<string, unknown>) =>
-        (await query(conn, cypher, params)) as R[],
+      query: async <R>(cypher: string, params?: Record<string, unknown>) => {
+        const reply = (await query(conn, cypher, params)) as { data?: R[] }
+        return reply.data ?? []
+      },
     }
     return await fn(session)
   } finally {

--- a/packages/graph/tests/integration/setup.ts
+++ b/packages/graph/tests/integration/setup.ts
@@ -1,0 +1,18 @@
+import { GenericContainer, type StartedTestContainer } from "testcontainers"
+
+let container: StartedTestContainer | undefined
+
+export const startFalkorDB = async (): Promise<{ url: string }> => {
+  container = await new GenericContainer("falkordb/falkordb:latest")
+    .withExposedPorts(6379)
+    .start()
+  const port = container.getMappedPort(6379)
+  return { url: `redis://localhost:${port}` }
+}
+
+export const stopFalkorDB = async (): Promise<void> => {
+  if (container !== undefined) {
+    await container.stop()
+    container = undefined
+  }
+}

--- a/packages/graph/tests/integration/updateGraph.integration.test.ts
+++ b/packages/graph/tests/integration/updateGraph.integration.test.ts
@@ -1,0 +1,181 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { startFalkorDB, stopFalkorDB } from "./setup"
+import { updateGraph, withGraph } from "../../src/index"
+import type { FileGraphData } from "../../src/index"
+
+let url: string
+const graphName = "test_nakidka"
+
+beforeAll(async () => {
+  ;({ url } = await startFalkorDB())
+}, 60_000)
+
+afterAll(async () => {
+  await stopFalkorDB()
+}, 30_000)
+
+beforeEach(async () => {
+  await withGraph(
+    async (g) => {
+      await g.query("MATCH (n) DETACH DELETE n")
+    },
+    { url, graphName },
+  )
+})
+
+const opts = () => ({ url, graphName })
+
+describe("updateGraph (integration)", () => {
+  it("создаёт узлы с динамическими метками и свойствами", async () => {
+    const files: FileGraphData[] = [
+      {
+        filePath: "a.yaml",
+        nodes: [
+          {
+            id: "Справочник.Контрагенты",
+            label: "MetadataCatalog",
+            props: { name: "Контрагенты", filePath: "a.yaml", p_hierarchical: true },
+          },
+        ],
+        edges: [],
+      },
+    ]
+    await updateGraph(files, opts())
+
+    const rows = await withGraph(
+      async (g) =>
+        await g.query<{ id: string; name: string; hier: boolean }>(
+          "MATCH (n:MetadataCatalog) RETURN n.id AS id, n.name AS name, n.p_hierarchical AS hier",
+        ),
+      opts(),
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      id: "Справочник.Контрагенты",
+      name: "Контрагенты",
+      hier: true,
+    })
+  })
+
+  it("создаёт ребро между узлами по (src, kind, tgt)", async () => {
+    const files: FileGraphData[] = [
+      {
+        filePath: "a.yaml",
+        nodes: [
+          { id: "A", label: "MetadataCatalog", props: { name: "A", filePath: "a.yaml" } },
+          { id: "B", label: "MetadataCatalog", props: { name: "B", filePath: "a.yaml" } },
+        ],
+        edges: [{ src: "A", tgt: "B", kind: "VALUE", props: { yaml: "Значение" } }],
+      },
+    ]
+    await updateGraph(files, opts())
+
+    const rows = await withGraph(
+      async (g) =>
+        await g.query<{ src: string; tgt: string; yaml: string }>(
+          "MATCH (s)-[r:VALUE]->(t) RETURN s.id AS src, t.id AS tgt, r.yaml AS yaml",
+        ),
+      opts(),
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toEqual({ src: "A", tgt: "B", yaml: "Значение" })
+  })
+
+  it("превращает ref-target в stub при удалении файла-определения", async () => {
+    await updateGraph(
+      [
+        {
+          filePath: "a.yaml",
+          nodes: [
+            { id: "A", label: "MetadataCatalog", props: { name: "A", filePath: "a.yaml" } },
+          ],
+          edges: [{ src: "A", tgt: "B", kind: "VALUE" }],
+        },
+        {
+          filePath: "b.yaml",
+          nodes: [
+            { id: "B", label: "MetadataCatalog", props: { name: "B", filePath: "b.yaml", p_hierarchical: false } },
+          ],
+          edges: [],
+        },
+      ],
+      opts(),
+    )
+
+    await updateGraph(
+      [{ filePath: "b.yaml", nodes: [], edges: [] }],
+      opts(),
+    )
+
+    const rows = await withGraph(
+      async (g) =>
+        await g.query<{ id: string; fp: string | null; hier: boolean | null }>(
+          "MATCH (n) WHERE n.id = 'B' RETURN n.id AS id, n.filePath AS fp, n.p_hierarchical AS hier",
+        ),
+      opts(),
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.fp).toBeNull()
+    expect(rows[0]?.hier).toBeNull()
+  })
+
+  it("удаляет orphan-stub при cleanup", async () => {
+    await updateGraph(
+      [
+        {
+          filePath: "a.yaml",
+          nodes: [
+            { id: "A", label: "MetadataCatalog", props: { name: "A", filePath: "a.yaml" } },
+          ],
+          edges: [{ src: "A", tgt: "B", kind: "VALUE" }],
+        },
+        {
+          filePath: "b.yaml",
+          nodes: [
+            { id: "B", label: "MetadataCatalog", props: { name: "B", filePath: "b.yaml" } },
+          ],
+          edges: [],
+        },
+      ],
+      opts(),
+    )
+
+    await updateGraph(
+      [
+        { filePath: "a.yaml", nodes: [], edges: [] },
+        { filePath: "b.yaml", nodes: [], edges: [] },
+      ],
+      opts(),
+    )
+
+    const rows = await withGraph(
+      async (g) =>
+        await g.query<{ cnt: number }>(
+          "MATCH (n) WHERE n.id IN ['A', 'B'] RETURN count(n) AS cnt",
+        ),
+      opts(),
+    )
+    expect(rows[0]?.cnt).toBe(0)
+  })
+
+  it("повторный updateGraph не создаёт дубликатов", async () => {
+    const files: FileGraphData[] = [
+      {
+        filePath: "a.yaml",
+        nodes: [
+          { id: "A", label: "MetadataCatalog", props: { name: "A", filePath: "a.yaml" } },
+        ],
+        edges: [],
+      },
+    ]
+    await updateGraph(files, opts())
+    await updateGraph(files, opts())
+
+    const rows = await withGraph(
+      async (g) =>
+        await g.query<{ cnt: number }>("MATCH (n:MetadataCatalog) RETURN count(n) AS cnt"),
+      opts(),
+    )
+    expect(rows[0]?.cnt).toBe(1)
+  })
+})

--- a/packages/graph/tests/operations.test.ts
+++ b/packages/graph/tests/operations.test.ts
@@ -10,7 +10,7 @@ vi.mock("falkordb", () => ({
 }))
 
 import { connect } from "../src/internal/connection"
-import { mergeNodes, mergeEdges } from "../src/internal/operations"
+import { mergeNodes, mergeEdges, deleteByFilePaths } from "../src/internal/operations"
 import type { NodeData, EdgeData } from "../src/types"
 
 beforeEach(() => {
@@ -111,5 +111,32 @@ describe("mergeEdges", () => {
     const batch = (queryMock.mock.calls[0][1] as { params: { batch: Array<{ props: object }> } })
       .params.batch
     expect(batch[0]?.props).toEqual({})
+  })
+})
+
+describe("deleteByFilePaths", () => {
+  it("ничего не делает на пустом массиве", async () => {
+    const conn = await connect()
+    await deleteByFilePaths(conn, [])
+    expect(queryMock).not.toHaveBeenCalled()
+  })
+
+  it("удаляет outgoing-рёбра, превращает узлы со входящими в stub, остальные DETACH DELETE", async () => {
+    const conn = await connect()
+    await deleteByFilePaths(conn, ["a.yaml", "b.yaml"])
+
+    expect(queryMock).toHaveBeenCalledTimes(3)
+    const [edgesCall, stubCall, deleteCall] = queryMock.mock.calls
+    expect(edgesCall[0]).toBe(
+      "MATCH (n) WHERE n.filePath IN $filePaths MATCH (n)-[r]->() DELETE r",
+    )
+    expect(edgesCall[1]).toEqual({ params: { filePaths: ["a.yaml", "b.yaml"] } })
+    expect(stubCall[0]).toBe(
+      "MATCH (n) WHERE n.filePath IN $filePaths AND ()-->(n) SET n = {id: n.id}",
+    )
+    expect(stubCall[1]).toEqual({ params: { filePaths: ["a.yaml", "b.yaml"] } })
+    expect(deleteCall[0]).toBe(
+      "MATCH (n) WHERE n.filePath IN $filePaths AND NOT ()-->(n) DETACH DELETE n",
+    )
   })
 })

--- a/packages/graph/tests/operations.test.ts
+++ b/packages/graph/tests/operations.test.ts
@@ -10,7 +10,7 @@ vi.mock("falkordb", () => ({
 }))
 
 import { connect } from "../src/internal/connection"
-import { mergeNodes, mergeEdges, deleteByFilePaths } from "../src/internal/operations"
+import { mergeNodes, mergeEdges, deleteByFilePaths, cleanupOrphanStubs } from "../src/internal/operations"
 import type { NodeData, EdgeData } from "../src/types"
 
 beforeEach(() => {
@@ -138,5 +138,17 @@ describe("deleteByFilePaths", () => {
     expect(deleteCall[0]).toBe(
       "MATCH (n) WHERE n.filePath IN $filePaths AND NOT ()-->(n) DETACH DELETE n",
     )
+  })
+})
+
+describe("cleanupOrphanStubs", () => {
+  it("удаляет узлы без filePath и без входящих рёбер", async () => {
+    const conn = await connect()
+    await cleanupOrphanStubs(conn)
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    expect(queryMock.mock.calls[0][0]).toBe(
+      "MATCH (n) WHERE n.filePath IS NULL AND NOT ()-->(n) DETACH DELETE n",
+    )
+    expect(queryMock.mock.calls[0][1]).toBeUndefined()
   })
 })

--- a/packages/graph/tests/operations.test.ts
+++ b/packages/graph/tests/operations.test.ts
@@ -10,8 +10,8 @@ vi.mock("falkordb", () => ({
 }))
 
 import { connect } from "../src/internal/connection"
-import { mergeNodes } from "../src/internal/operations"
-import type { NodeData } from "../src/types"
+import { mergeNodes, mergeEdges } from "../src/internal/operations"
+import type { NodeData, EdgeData } from "../src/types"
 
 beforeEach(() => {
   queryMock.mockReset().mockResolvedValue({})
@@ -70,5 +70,46 @@ describe("mergeNodes", () => {
     expect(
       (queryMock.mock.calls[2][1] as { params: { batch: unknown[] } }).params.batch,
     ).toHaveLength(2000)
+  })
+})
+
+describe("mergeEdges", () => {
+  it("ничего не делает на пустом массиве", async () => {
+    const conn = await connect()
+    await mergeEdges(conn, [])
+    expect(queryMock).not.toHaveBeenCalled()
+  })
+
+  it("группирует рёбра по kind и шлёт по одному UNWIND-MERGE на kind", async () => {
+    const conn = await connect()
+    const edges: EdgeData[] = [
+      { src: "A", tgt: "B", kind: "VALUE", props: { yaml: "Значение" } },
+      { src: "A", tgt: "C", kind: "VALUE", props: { yaml: "Значение" } },
+      { src: "A", tgt: "D", kind: "REF_TYPE", props: { index: 0 } },
+    ]
+    await mergeEdges(conn, edges)
+
+    expect(queryMock).toHaveBeenCalledTimes(2)
+    const calls = queryMock.mock.calls
+    const valueCall = calls.find((c) => (c[0] as string).includes(":VALUE"))!
+    const refCall = calls.find((c) => (c[0] as string).includes(":REF_TYPE"))!
+    expect(valueCall[0]).toBe(
+      "UNWIND $batch AS e MATCH (s {id: e.src}), (t {id: e.tgt}) MERGE (s)-[r:VALUE]->(t) SET r = e.props",
+    )
+    expect((valueCall[1] as { params: { batch: unknown[] } }).params.batch).toHaveLength(2)
+    expect(refCall[0]).toBe(
+      "UNWIND $batch AS e MATCH (s {id: e.src}), (t {id: e.tgt}) MERGE (s)-[r:REF_TYPE]->(t) SET r = e.props",
+    )
+  })
+
+  it("отправляет props={} если у ребра не указаны свойства", async () => {
+    const conn = await connect()
+    const edges: EdgeData[] = [{ src: "A", tgt: "B", kind: "FORM" }]
+    await mergeEdges(conn, edges)
+
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    const batch = (queryMock.mock.calls[0][1] as { params: { batch: Array<{ props: object }> } })
+      .params.batch
+    expect(batch[0]?.props).toEqual({})
   })
 })

--- a/packages/graph/tests/operations.test.ts
+++ b/packages/graph/tests/operations.test.ts
@@ -10,7 +10,7 @@ vi.mock("falkordb", () => ({
 }))
 
 import { connect } from "../src/internal/connection"
-import { mergeNodes, mergeEdges, deleteByFilePaths, cleanupOrphanStubs } from "../src/internal/operations"
+import { mergeNodes, mergeEdges, deleteByFilePaths, cleanupOrphanStubs, ensureLabelIndexes } from "../src/internal/operations"
 import type { NodeData, EdgeData } from "../src/types"
 
 beforeEach(() => {
@@ -150,5 +150,31 @@ describe("cleanupOrphanStubs", () => {
       "MATCH (n) WHERE n.filePath IS NULL AND NOT ()-->(n) DETACH DELETE n",
     )
     expect(queryMock.mock.calls[0][1]).toBeUndefined()
+  })
+})
+
+describe("ensureLabelIndexes", () => {
+  it("создаёт индекс по id для каждой уникальной label", async () => {
+    const conn = await connect()
+    await ensureLabelIndexes(conn, ["MetadataCatalog", "MetadataDocument", "MetadataCatalog"])
+
+    expect(queryMock).toHaveBeenCalledTimes(2)
+    const queries = queryMock.mock.calls.map((c) => c[0])
+    expect(queries).toContain("CREATE INDEX FOR (n:MetadataCatalog) ON (n.id)")
+    expect(queries).toContain("CREATE INDEX FOR (n:MetadataDocument) ON (n.id)")
+  })
+
+  it("глотает 'already indexed' / 'equivalent index'", async () => {
+    queryMock.mockRejectedValueOnce(new Error("already indexed for label"))
+    const conn = await connect()
+    await expect(
+      ensureLabelIndexes(conn, ["MetadataCatalog"]),
+    ).resolves.toBeUndefined()
+  })
+
+  it("ничего не делает на пустом массиве", async () => {
+    const conn = await connect()
+    await ensureLabelIndexes(conn, [])
+    expect(queryMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/graph/tests/operations.test.ts
+++ b/packages/graph/tests/operations.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const queryMock = vi.fn()
+const selectGraphMock = vi.fn()
+const connectMock = vi.fn()
+const closeMock = vi.fn()
+
+vi.mock("falkordb", () => ({
+  FalkorDB: { connect: (opts?: unknown) => connectMock(opts) },
+}))
+
+import { connect } from "../src/internal/connection"
+import { mergeNodes } from "../src/internal/operations"
+import type { NodeData } from "../src/types"
+
+beforeEach(() => {
+  queryMock.mockReset().mockResolvedValue({})
+  selectGraphMock.mockReset().mockReturnValue({ query: queryMock })
+  connectMock.mockReset().mockResolvedValue({ selectGraph: selectGraphMock, close: closeMock })
+  closeMock.mockReset().mockResolvedValue(undefined)
+})
+
+describe("mergeNodes", () => {
+  it("ничего не делает на пустом массиве", async () => {
+    const conn = await connect()
+    await mergeNodes(conn, [])
+    expect(queryMock).not.toHaveBeenCalled()
+  })
+
+  it("группирует узлы по label и шлёт по одному UNWIND-MERGE на label", async () => {
+    const conn = await connect()
+    const nodes: NodeData[] = [
+      { id: "Справочник.A", label: "MetadataCatalog", props: { name: "A", filePath: "a.yaml" } },
+      { id: "Справочник.B", label: "MetadataCatalog", props: { name: "B", filePath: "b.yaml" } },
+      { id: "Документ.X", label: "MetadataDocument", props: { name: "X", filePath: "x.yaml" } },
+    ]
+    await mergeNodes(conn, nodes)
+
+    expect(queryMock).toHaveBeenCalledTimes(2)
+    const [catalogCall, documentCall] = queryMock.mock.calls
+    expect(catalogCall[0]).toBe(
+      "UNWIND $batch AS n MERGE (m:MetadataCatalog {id: n.id}) SET m += n.props",
+    )
+    expect(catalogCall[1]).toEqual({
+      params: {
+        batch: [
+          { id: "Справочник.A", props: { name: "A", filePath: "a.yaml" } },
+          { id: "Справочник.B", props: { name: "B", filePath: "b.yaml" } },
+        ],
+      },
+    })
+    expect(documentCall[0]).toBe(
+      "UNWIND $batch AS n MERGE (m:MetadataDocument {id: n.id}) SET m += n.props",
+    )
+  })
+
+  it("режет на батчи по 5000", async () => {
+    const conn = await connect()
+    const nodes: NodeData[] = Array.from({ length: 12_000 }, (_, i) => ({
+      id: `id${i}`,
+      label: "MetadataCatalog",
+      props: { name: `n${i}` },
+    }))
+    await mergeNodes(conn, nodes)
+
+    expect(queryMock).toHaveBeenCalledTimes(3)
+    expect(
+      (queryMock.mock.calls[0][1] as { params: { batch: unknown[] } }).params.batch,
+    ).toHaveLength(5000)
+    expect(
+      (queryMock.mock.calls[2][1] as { params: { batch: unknown[] } }).params.batch,
+    ).toHaveLength(2000)
+  })
+})

--- a/packages/graph/tests/updateGraph.test.ts
+++ b/packages/graph/tests/updateGraph.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const queryMock = vi.fn()
+const selectGraphMock = vi.fn()
+const connectMock = vi.fn()
+const closeMock = vi.fn()
+
+vi.mock("falkordb", () => ({
+  FalkorDB: { connect: (opts?: unknown) => connectMock(opts) },
+}))
+
+import { updateGraph } from "../src/updateGraph"
+import type { FileGraphData } from "../src/types"
+
+beforeEach(() => {
+  queryMock.mockReset().mockResolvedValue({})
+  selectGraphMock.mockReset().mockReturnValue({ query: queryMock })
+  closeMock.mockReset().mockResolvedValue(undefined)
+  connectMock
+    .mockReset()
+    .mockResolvedValue({ selectGraph: selectGraphMock, close: closeMock })
+})
+
+describe("updateGraph", () => {
+  it("проходит полный цикл: index → delete → merge nodes → merge edges → cleanup → close", async () => {
+    const files: FileGraphData[] = [
+      {
+        filePath: "a.yaml",
+        nodes: [
+          { id: "Справочник.A", label: "MetadataCatalog", props: { name: "A", filePath: "a.yaml" } },
+        ],
+        edges: [{ src: "Справочник.A", tgt: "Справочник.B", kind: "VALUE" }],
+      },
+    ]
+    await updateGraph(files)
+
+    const cypher = queryMock.mock.calls.map((c) => c[0] as string)
+    expect(cypher).toContainEqual(expect.stringContaining("CREATE INDEX FOR (n:MetadataCatalog)"))
+    expect(cypher).toContainEqual(expect.stringContaining("MATCH (n) WHERE n.filePath IN $filePaths MATCH (n)-[r]->() DELETE r"))
+    expect(cypher).toContainEqual(expect.stringContaining("MATCH (n) WHERE n.filePath IN $filePaths AND ()-->(n) SET n = {id: n.id}"))
+    expect(cypher).toContainEqual(expect.stringContaining("MATCH (n) WHERE n.filePath IN $filePaths AND NOT ()-->(n) DETACH DELETE n"))
+    expect(cypher).toContainEqual(expect.stringContaining("MERGE (m:MetadataCatalog"))
+    expect(cypher).toContainEqual(expect.stringContaining(":VALUE]"))
+    expect(cypher).toContainEqual(expect.stringContaining("MATCH (n) WHERE n.filePath IS NULL AND NOT ()-->(n) DETACH DELETE n"))
+    expect(closeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("закрывает соединение даже при падении одной из операций", async () => {
+    queryMock.mockReset()
+    queryMock.mockResolvedValueOnce({}) // CREATE INDEX
+    queryMock.mockRejectedValueOnce(new Error("boom"))
+
+    const files: FileGraphData[] = [
+      { filePath: "a.yaml", nodes: [{ id: "A", label: "X", props: {} }], edges: [] },
+    ]
+    await expect(updateGraph(files)).rejects.toThrow("boom")
+    expect(closeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("ничего не отправляет в FalkorDB при пустом входе, но всё равно закрывает соединение", async () => {
+    await updateGraph([])
+    const cypher = queryMock.mock.calls.map((c) => c[0] as string)
+    expect(cypher).toEqual([
+      "MATCH (n) WHERE n.filePath IS NULL AND NOT ()-->(n) DETACH DELETE n",
+    ])
+    expect(closeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("прокидывает ConnectionOptions в connect", async () => {
+    await updateGraph([], { url: "redis://h:1", graphName: "g" })
+    expect(connectMock).toHaveBeenCalledWith({ url: "redis://h:1" })
+    expect(selectGraphMock).toHaveBeenCalledWith("g")
+  })
+})

--- a/packages/graph/tests/withGraph.test.ts
+++ b/packages/graph/tests/withGraph.test.ts
@@ -31,7 +31,7 @@ describe("withGraph", () => {
     expect(connectMock).toHaveBeenCalledTimes(1)
     expect(queryMock).toHaveBeenCalledWith("MATCH (n) RETURN n.value AS n", undefined)
     expect(closeMock).toHaveBeenCalledTimes(1)
-    expect(result).toEqual({ data: [{ n: 42 }] })
+    expect(result).toEqual([{ n: 42 }])
   })
 
   it("прокидывает params в query", async () => {

--- a/packages/graph/tests/withGraph.test.ts
+++ b/packages/graph/tests/withGraph.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const queryMock = vi.fn()
+const selectGraphMock = vi.fn()
+const connectMock = vi.fn()
+const closeMock = vi.fn()
+
+vi.mock("falkordb", () => ({
+  FalkorDB: { connect: (opts?: unknown) => connectMock(opts) },
+}))
+
+import { withGraph } from "../src/withGraph"
+
+beforeEach(() => {
+  queryMock.mockReset()
+  selectGraphMock.mockReset().mockReturnValue({ query: queryMock })
+  closeMock.mockReset().mockResolvedValue(undefined)
+  connectMock
+    .mockReset()
+    .mockResolvedValue({ selectGraph: selectGraphMock, close: closeMock })
+})
+
+describe("withGraph", () => {
+  it("открывает соединение, передаёт query в callback и закрывает", async () => {
+    queryMock.mockResolvedValue({ data: [{ n: 42 }] })
+
+    const result = await withGraph(async (g) => {
+      return await g.query<{ n: number }>("MATCH (n) RETURN n.value AS n")
+    })
+
+    expect(connectMock).toHaveBeenCalledTimes(1)
+    expect(queryMock).toHaveBeenCalledWith("MATCH (n) RETURN n.value AS n", undefined)
+    expect(closeMock).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ data: [{ n: 42 }] })
+  })
+
+  it("прокидывает params в query", async () => {
+    queryMock.mockResolvedValue({})
+    await withGraph(async (g) => g.query("MATCH (n {id: $id})", { id: "X" }))
+    expect(queryMock).toHaveBeenCalledWith("MATCH (n {id: $id})", { params: { id: "X" } })
+  })
+
+  it("закрывает соединение даже если callback кинул ошибку", async () => {
+    await expect(
+      withGraph(async () => {
+        throw new Error("user error")
+      }),
+    ).rejects.toThrow("user error")
+    expect(closeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("прокидывает ConnectionOptions в connect", async () => {
+    queryMock.mockResolvedValue({})
+    await withGraph(async () => undefined, { url: "redis://h:1", graphName: "g" })
+    expect(connectMock).toHaveBeenCalledWith({ url: "redis://h:1" })
+    expect(selectGraphMock).toHaveBeenCalledWith("g")
+  })
+
+  it("возвращает значение, которое вернул callback", async () => {
+    const v = await withGraph(async () => 123)
+    expect(v).toBe(123)
+  })
+})

--- a/packages/graph/vitest.config.ts
+++ b/packages/graph/vitest.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
     environment: "node",
     globals: true,
     watch: false,
+    exclude: ["**/node_modules/**", "tests/integration/**"],
   },
 })

--- a/packages/graph/vitest.integration.config.ts
+++ b/packages/graph/vitest.integration.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["tests/integration/**/*.integration.test.ts"],
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+    fileParallelism: false,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,7 +255,7 @@ importers:
         version: 2.8.3
       yaml-language-server:
         specifier: next
-        version: 1.22.1-0ae5603.0
+        version: 1.23.1-cd3cba0.0
     devDependencies:
       '@types/fs-extra':
         specifier: ~11.0.4
@@ -285,6 +285,9 @@ importers:
       '@types/node':
         specifier: ^24.10.1
         version: 24.12.2
+      testcontainers:
+        specifier: ^11.14.0
+        version: 11.14.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -497,6 +500,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -890,6 +896,24 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
@@ -913,9 +937,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@js-temporal/polyfill@0.5.1':
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
     engines: {node: '>=12'}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
   '@microsoft/api-extractor-model@7.33.4':
     resolution: {integrity: sha512-u1LTaNTikZAQ9uK6KG1Ms7nvNedsnODnspq/gH2dcyETWvH4hVNGNDvRAEutH66kAmxA4/necElqGNs1FggC8w==}
@@ -951,6 +981,40 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@rc-component/async-validator@5.1.0':
     resolution: {integrity: sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==}
@@ -1571,6 +1635,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -1588,6 +1658,9 @@ packages:
 
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -1608,6 +1681,15 @@ packages:
 
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
+
+  '@types/ssh2-streams@0.1.13':
+    resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
+
+  '@types/ssh2@0.5.52':
+    resolution: {integrity: sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/strip-bom@3.0.0':
     resolution: {integrity: sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==}
@@ -1846,6 +1928,10 @@ packages:
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -1916,6 +2002,10 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   antd@6.3.1:
     resolution: {integrity: sha512-8pRjvxitZFyrYAtgwml93Km7fCXjw9IeqlmzpIsusRsmO3eWFVrOMum6+0TsGCtR/WrXVnPwfsgrFg3ChzGCeA==}
     peerDependencies:
@@ -1925,6 +2015,14 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1943,6 +2041,9 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1954,11 +2055,25 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   azure-devops-node-api@12.5.0:
     resolution: {integrity: sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==}
+
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1967,6 +2082,47 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.0:
+    resolution: {integrity: sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.0:
+    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.2:
+    resolution: {integrity: sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1974,6 +2130,9 @@ packages:
     resolution: {integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -2017,6 +2176,10 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
@@ -2026,9 +2189,20 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2153,6 +2327,10 @@ packages:
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
@@ -2177,6 +2355,22 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2280,6 +2474,18 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  docker-compose@1.4.2:
+    resolution: {integrity: sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==}
+    engines: {node: '>= 6.0.0'}
+
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.12:
+    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
+    engines: {node: '>= 8.0'}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
@@ -2306,6 +2512,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -2322,6 +2531,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -2404,6 +2616,13 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -2425,6 +2644,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2512,6 +2734,10 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
+  get-port@7.2.0:
+    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
+    engines: {node: '>=16'}
+
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
@@ -2528,6 +2754,11 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
@@ -2708,6 +2939,10 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
@@ -2715,6 +2950,9 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -2741,6 +2979,9 @@ packages:
   istextorbinary@9.5.0:
     resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
     engines: {node: '>=4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -2845,6 +3086,10 @@ packages:
     resolution: {integrity: sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -2862,6 +3107,9 @@ packages:
 
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -2889,6 +3137,9 @@ packages:
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -3005,6 +3256,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
@@ -3026,6 +3282,9 @@ packages:
   mylas@2.1.14:
     resolution: {integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==}
     engines: {node: '>=16.0.0'}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3138,6 +3397,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -3217,6 +3480,24 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  properties-reader@3.0.1:
+    resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
+    engines: {node: '>=18'}
+
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+    engines: {node: '>=12.0.0'}
+
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
 
@@ -3282,9 +3563,19 @@ packages:
     resolution: {integrity: sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==}
     engines: {node: '>=0.8'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -3327,6 +3618,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3345,6 +3640,9 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -3441,6 +3739,9 @@ packages:
   sigmund@1.0.1:
     resolution: {integrity: sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3497,11 +3798,21 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split.js@1.6.5:
     resolution: {integrity: sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  ssh-remote-port-forward@1.0.4:
+    resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3511,6 +3822,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -3522,6 +3836,13 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3589,9 +3910,18 @@ packages:
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   terminal-link@4.0.0:
     resolution: {integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==}
@@ -3617,6 +3947,12 @@ packages:
     resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
     engines: {node: '>=10'}
     hasBin: true
+
+  testcontainers@11.14.0:
+    resolution: {integrity: sha512-r9pniwv/iwzyHaI7gwAvAm4Y+IvjJg3vBWdjrUCaDMc2AXIr4jKbq7jJO18Mw2ybs73pZy1Aj7p/4RVBGMRWjg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -3733,6 +4069,9 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -3759,6 +4098,9 @@ packages:
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -3767,6 +4109,10 @@ packages:
 
   undici@7.22.0:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -3792,6 +4138,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
@@ -4068,6 +4418,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -4115,8 +4469,8 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yaml-language-server@1.22.1-0ae5603.0:
-    resolution: {integrity: sha512-Bnk1IX2MZJ0otR+sPy9S5UQN9bF9nrTw2F2/uY+zLZvWsbRdJOPnU31JOHT9f8Ptp7+1VpTSVKZQt+8/SAcjOA==}
+  yaml-language-server@1.23.1-cd3cba0.0:
+    resolution: {integrity: sha512-PxLwcApzB6VlRp63mbkYyssQMxxVCiL0I4C6A24+/vX43LrYdmXcjqqpSFCDEqx77VaSSgkUn0VpFh/fVKMCUg==}
     hasBin: true
 
   yaml@2.8.3:
@@ -4141,6 +4495,10 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
 snapshots:
 
@@ -4417,6 +4775,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@balena/dockerignore@1.0.2': {}
+
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@chevrotain/cst-dts-gen@11.1.2':
@@ -4637,6 +4997,34 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.5
+      yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.5
+      yargs: 17.7.2
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@isaacs/cliui@9.0.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -4663,9 +5051,17 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@js-temporal/polyfill@0.5.1':
     dependencies:
       jsbi: 4.3.2
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@microsoft/api-extractor-model@7.33.4(@types/node@24.12.2)':
     dependencies:
@@ -4725,6 +5121,32 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@rc-component/async-validator@5.1.0':
     dependencies:
@@ -5395,6 +5817,17 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 24.12.2
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@4.0.1':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 24.12.2
+      '@types/ssh2': 1.15.5
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -5418,6 +5851,10 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
@@ -5438,6 +5875,19 @@ snapshots:
       csstype: 3.2.3
 
   '@types/sarif@2.1.7': {}
+
+  '@types/ssh2-streams@0.1.13':
+    dependencies:
+      '@types/node': 24.12.2
+
+  '@types/ssh2@0.5.52':
+    dependencies:
+      '@types/node': 24.12.2
+      '@types/ssh2-streams': 0.1.13
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/strip-bom@3.0.0': {}
 
@@ -5773,6 +6223,10 @@ snapshots:
 
   '@yarnpkg/lockfile@1.1.0': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -5820,6 +6274,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   antd@6.3.1(date-fns@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -5883,6 +6339,30 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.23
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.8
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -5897,6 +6377,10 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@0.3.12:
@@ -5907,6 +6391,10 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
+  async-lock@1.4.1: {}
+
+  async@3.2.6: {}
+
   asynckit@0.4.0: {}
 
   azure-devops-node-api@12.5.0:
@@ -5914,14 +6402,51 @@ snapshots:
       tunnel: 0.0.6
       typed-rest-client: 1.8.11
 
+  b4a@1.8.0: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1:
-    optional: true
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.0(bare-events@2.8.2)
+      bare-url: 2.4.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.0: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.0
+
+  bare-stream@2.13.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.2:
+    dependencies:
+      bare-path: 3.0.0
+
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.19: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   bidi-js@1.0.3:
     dependencies:
@@ -5938,7 +6463,6 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   boolbase@1.0.0: {}
 
@@ -5971,6 +6495,8 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-crc32@1.0.0: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -5979,11 +6505,20 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buildcheck@0.0.7:
     optional: true
 
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  byline@5.0.0: {}
 
   cac@6.7.14: {}
 
@@ -6085,8 +6620,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chownr@1.1.4:
-    optional: true
+  chownr@1.1.4: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -6126,6 +6660,14 @@ snapshots:
 
   compare-versions@6.1.1: {}
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   compute-scroll-into-view@3.1.1: {}
 
   concat-map@0.0.1: {}
@@ -6156,6 +6698,21 @@ snapshots:
   confbox@0.2.4: {}
 
   convert-source-map@2.0.0: {}
+
+  core-util-is@1.0.3: {}
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.26.2
+    optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6248,6 +6805,31 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  docker-compose@1.4.2:
+    dependencies:
+      yaml: 2.8.3
+
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.12:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.5.5
+      tar-fs: 2.1.4
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
@@ -6280,6 +6862,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -6299,6 +6883,8 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  emoji-regex@9.2.2: {}
+
   encoding-sniffer@0.2.1:
     dependencies:
       iconv-lite: 0.6.3
@@ -6307,7 +6893,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -6418,6 +7003,14 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  event-target-shim@5.0.1: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0: {}
 
   expand-template@2.0.3:
@@ -6440,6 +7033,8 @@ snapshots:
       - '@opentelemetry/api'
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -6491,8 +7086,7 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
-  fs-constants@1.0.0:
-    optional: true
+  fs-constants@1.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -6538,6 +7132,8 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
+  get-port@7.2.0: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
@@ -6555,6 +7151,15 @@ snapshots:
       is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@11.1.0:
     dependencies:
@@ -6670,8 +7275,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1:
-    optional: true
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -6727,6 +7331,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-stream@2.0.1: {}
+
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
@@ -6734,6 +7340,8 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isarray@1.0.0: {}
 
   isarray@2.0.5: {}
 
@@ -6759,6 +7367,12 @@ snapshots:
       binaryextensions: 6.11.0
       editions: 6.22.0
       textextensions: 6.11.0
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.2.3:
     dependencies:
@@ -6903,6 +7517,10 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   leven@3.1.0: {}
 
   linkify-it@5.0.0:
@@ -6918,6 +7536,8 @@ snapshots:
       quansync: 0.2.11
 
   lodash-es@4.17.23: {}
+
+  lodash.camelcase@4.3.0: {}
 
   lodash.includes@4.3.0: {}
 
@@ -6936,6 +7556,8 @@ snapshots:
   lodash.truncate@4.4.2: {}
 
   lodash@4.17.23: {}
+
+  long@5.3.2: {}
 
   loupe@3.2.1: {}
 
@@ -7031,10 +7653,11 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mkdirp-classic@0.5.3:
-    optional: true
+  mkdirp-classic@0.5.3: {}
 
   mkdirp@1.0.4: {}
+
+  mkdirp@3.0.1: {}
 
   mlly@1.8.1:
     dependencies:
@@ -7059,6 +7682,9 @@ snapshots:
   mute-stream@0.0.8: {}
 
   mylas@2.1.14: {}
+
+  nan@2.26.2:
+    optional: true
 
   nanoid@3.3.11: {}
 
@@ -7183,6 +7809,11 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.6
@@ -7260,13 +7891,44 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-nextick-args@2.0.1: {}
+
+  process@0.11.10: {}
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  properties-reader@3.0.1:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      mkdirp: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  protobufjs@7.5.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 24.12.2
+      long: 5.3.2
+
   pseudomap@1.0.2: {}
 
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-    optional: true
 
   punycode.js@2.3.1: {}
 
@@ -7326,12 +7988,33 @@ snapshots:
     dependencies:
       mute-stream: 0.0.8
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   readdirp@3.6.0:
     dependencies:
@@ -7375,6 +8058,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.12.0: {}
+
   reusify@1.1.0: {}
 
   rollup@4.59.0:
@@ -7417,6 +8102,8 @@ snapshots:
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
+
+  safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 
@@ -7523,6 +8210,8 @@ snapshots:
 
   sigmund@1.0.1: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1:
@@ -7574,15 +8263,39 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
+  split-ca@1.0.1: {}
+
   split.js@1.6.5: {}
 
   sprintf-js@1.0.3: {}
+
+  ssh-remote-port-forward@1.0.4:
+    dependencies:
+      '@types/ssh2': 0.5.52
+      ssh2: 1.17.0
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.26.2
 
   stackback@0.0.2: {}
 
   state-local@1.0.7: {}
 
   std-env@3.10.0: {}
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   string-argv@0.3.2: {}
 
@@ -7594,10 +8307,19 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -7658,7 +8380,18 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
-    optional: true
+
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   tar-stream@2.2.0:
     dependencies:
@@ -7667,7 +8400,24 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
+
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   terminal-link@4.0.0:
     dependencies:
@@ -7688,6 +8438,35 @@ snapshots:
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  testcontainers@11.14.0:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@types/dockerode': 4.0.1
+      archiver: 7.0.1
+      async-lock: 1.4.1
+      byline: 5.0.0
+      debug: 4.4.3
+      docker-compose: 1.4.2
+      dockerode: 4.0.12
+      get-port: 7.2.0
+      proper-lockfile: 4.1.2
+      properties-reader: 3.0.1
+      ssh-remote-port-forward: 1.0.4
+      tar-fs: 3.1.2
+      tmp: 0.2.5
+      undici: 7.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-table@0.2.0: {}
 
@@ -7799,6 +8578,8 @@ snapshots:
 
   tunnel@0.0.6: {}
 
+  tweetnacl@0.14.5: {}
+
   type-fest@4.41.0: {}
 
   typed-rest-client@1.8.11:
@@ -7817,12 +8598,16 @@ snapshots:
 
   underscore@1.13.8: {}
 
+  undici-types@5.26.5: {}
+
   undici-types@7.16.0: {}
 
   undici-types@7.18.2:
     optional: true
 
   undici@7.22.0: {}
+
+  undici@7.25.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -7838,8 +8623,9 @@ snapshots:
 
   url-join@4.0.1: {}
 
-  util-deprecate@1.0.2:
-    optional: true
+  util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   uuid@13.0.0: {}
 
@@ -8123,6 +8909,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
@@ -8150,7 +8942,7 @@ snapshots:
 
   yallist@4.0.0: {}
 
-  yaml-language-server@1.22.1-0ae5603.0:
+  yaml-language-server@1.23.1-cd3cba0.0:
     dependencies:
       '@vscode/l10n': 0.0.18
       ajv: 8.18.0
@@ -8187,3 +8979,9 @@ snapshots:
       buffer-crc32: 0.2.13
 
   yocto-queue@1.2.2: {}
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0


### PR DESCRIPTION
## Summary

Фаза 0 переезда core на FalkorDB: пакет `@nakidka/graph` получает high-level публичный API (`updateGraph(files)`, `withGraph(fn)`) поверх существующего низкоуровневого `connect/query`. Изолированно от core/cli — старый API остаётся через реэкспорт, CLI работает без изменений до фазы 4.

Реализация по плану [`docs/superpowers/plans/2026-04-27-graph-package-skeleton.md`](../blob/develop/docs/superpowers/plans/2026-04-27-graph-package-skeleton.md), 11 TDD-задач + 1 bugfix-коммит.

## Что добавлено

- **`src/types.ts`** — публичные типы: `NodeData`, `EdgeData`, `FileGraphData`, `ConnectionOptions`, `GraphPrimitive`.
- **`src/internal/operations.ts`** — 5 операций графа: `mergeNodes`, `mergeEdges`, `deleteByFilePaths`, `cleanupOrphanStubs`, `ensureLabelIndexes`. Динамические метки через template-string (FalkorDB не параметризует label через `\$param`), батчи по 5000.
- **`src/updateGraph.ts`** — публичный оркестратор: `connect → ensureLabelIndexes → deleteByFilePaths → mergeNodes → mergeEdges → cleanupOrphanStubs → close (finally)`.
- **`src/withGraph.ts`** — публичная обёртка для нескольких Cypher-запросов. Распаковывает `.data` из `GraphReply` (поймано integration-тестами).
- **`src/internal/connection.ts`** — низкоуровневые `connect/close/query/ensureIndex`, вынесены из `index.ts`. Реэкспорт через `index.ts` сохраняет совместимость с CLI.
- **`tests/integration/`** — 5 e2e-тестов на реальной FalkorDB через testcontainers (`falkordb/falkordb:latest`). Запускаются отдельно через `pnpm test:integration` — основной `pnpm test` от Docker не зависит.

## Поведение `updateGraph` (по дизайн-доку)

1. Создать индексы по `id` для всех встретившихся меток.
2. Удалить outgoing-рёбра у узлов с указанными `filePath`; узлы со входящими reference-рёбрами превратить в stub (`SET n = {id: n.id}`); узлы без входящих — `DETACH DELETE`.
3. UNWIND-MERGE новых узлов батчами по 5000 с группировкой по label.
4. UNWIND-MERGE рёбер с группировкой по kind.
5. Удалить orphan-stub'ы (`filePath IS NULL AND NOT ()-->(n)`).

Stub-маркер — `props.filePath IS NULL` (решение №3 спеки [`2026-04-27-graph-package-interface-design.md`](../blob/develop/docs/superpowers/specs/2026-04-27-graph-package-interface-design.md)).

## Test plan

- [x] `pnpm test` в `packages/graph/` — 33 unit-теста PASS (4 файла, без Docker).
- [x] `pnpm test:integration` в `packages/graph/` — 5 integration-тестов PASS на реальной FalkorDB.
- [x] Корневой `pnpm test` — все пакеты PASS, существующие тесты не сломаны.
- [x] `pnpm type-check` — без ошибок.
- [x] CLI продолжает использовать старый low-level API без изменений (низкоуровневые экспорты сохранены через реэкспорт).

## Что осталось на следующие фазы

- **Фаза 1**: чистые `graphFromModel.ts` + `buildGraph` агрегатор в core.
- **Фаза 2**: раскладка свойств модели (общий алгоритм сплющивания, type-specific обработчики).
- **Фаза 3**: `BuildModelFromGraphFunction` для двухступенчатого `toXML`.
- **Фаза 4**: удаление graphology, `MetadataGraph`, `validateProject`; CLI переезжает на новый API.
- **Фаза 5**: настройка CI на FalkorDB-зависимые тесты.

## Не-блокирующие технические долги (отметки на фазу 1)

- Дублирование `GraphOptions` (low-level) и `ConnectionOptions` (public) — структурно идентичны, объединим при переезде CLI на новый API в фазе 4.
- `deleteByFilePaths` не батчит сам список `filePaths` — на полной сборке проекта 100k+ файлов может упереться в лимит параметров FalkorDB. Замерим по факту, оптимизируем при необходимости (пункт №4 «Решений и отложенных вопросов» спеки).
- Нет индекса по `filePath` (используется в `deleteByFilePaths`). Добавим, если профайлинг покажет full scan'ы.