### PR TITLE
refactor: graphFromModel.ts на чистые функции — фаза 1b

### DIFF
--- a/.claude/architecture-orchestration.md
+++ b/.claude/architecture-orchestration.md
@@ -80,3 +80,17 @@ xmlRoot: {
 2. Через `exportMetadataItemToXML` с правилом объекта собирает основной XML; `referenceData` подгружается из эталонного XML.
 3. Для свойств с `filePath`: импортирует эталон внешнего файла как `referenceValue`, экспортирует модель через `exportPropertyToXML` с `referenceMetadata: referenceValue`. Записывает результат во внешний файл.
 4. Вызывает `syncExternalToXML` для `Module`/`Help`/`Template`.
+
+## Граф связей метаданных
+
+`buildGraphFromModel` (`orchestration/buildGraphFromModel.ts`) обходит модель параллельно с YAML AST и для каждого свойства смотрит зарегистрированные на его типе обработчики:
+
+- `extractGraph` — одиночные reference-свойства (`MetadataField`, `MetadataItemLink`, `TypeDescription`); возвращает `GraphOps` с `references`.
+- `buildGraphFromModel` — типы с кастомной логикой (`MetadataValue`, `FormAttributeColumns`, `DataPath`, `CommandName`, …); это **чистая функция** `BuildGraphFromModelFunction → GraphOps | GraphOps[] | undefined | void`. Обработчик не имеет доступа к графу, не делает побочных эффектов.
+- `graphChild` — декларативное создание дочерних узлов из коллекций (`FormAttributes`, `FormCommands`, `FormParameters`).
+
+`GraphOps`-секции имеют поля: `children` (owned-узлы с filePath), `references` (stub-узлы), `formLocalReferences` (рёбра, цель которых резолвится через `resolveFormLocalPath`), `recurse` (рекурсивные обходы подмодели по правилу), плюс `edgeKind`/`edgeYaml`. Для children и formLocalReferences опционально `parentOverride` — источник ребра ≠ ctx.parentNodeId. У references override намеренно не поддерживается (см. JSDoc типа).
+
+Оркестратор нормализует возврат к массиву секций, для каждой непустой секции вызывает `applyGraphOps(section, ctx)` (единственный шлюз мутации `MetadataGraph`), затем разворачивает `recurse`-задачи через рекурсивный вызов `buildGraphFromModel`. Обработка `recurse` живёт **вне** проверки «непустой секции», чтобы секция с одним лишь `recurse` не отбрасывалась.
+
+Параллельный обход `forms/elements/graphFromModel.ts::buildElementChildrenGraph` (свойства элементов формы) реализует тот же контракт, продолжая мутировать граф напрямую через `graph.promoteNode/ensureEdge` для коллекций и singletons — единственный legacy-обходчик после фазы 1b. В фазе 1c планируется его перевод на чистую форму и вынос общего хелпера `applyBuildGraphResult` для устранения дубликата normalize-блока с основным оркестратором.

--- a/docs/superpowers/plans/2026-04-28-graph-pure-functions-1b.md
+++ b/docs/superpowers/plans/2026-04-28-graph-pure-functions-1b.md
@@ -1,0 +1,1267 @@
+# Чистые `graphFromModel.ts` — фаза 1b (массовая миграция)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Завершить перевод всех `graphFromModel.ts`-файлов с `BuildGraphFromModelFunction`-обработчиками на чистый контракт «возврат `GraphOps`», начатый в фазе 1a (`metadataField`). После этой фазы ни одна чистая функция не использует параметр `graph`, и параметр снимается с сигнатуры.
+
+**Architecture:** В фазе 1a уже добавлены поля `edgeKind`/`edgeYaml` в `GraphOps` и расширен возврат `BuildGraphFromModelFunction` до `GraphOps | undefined | void`. Здесь по очереди переводим оставшиеся 6 файлов с `BuildGraphFromModelFunction`. По мере необходимости расширяем `GraphOps` дополнительными декларативными полями (`item` на children, `formLocalReferences` для `resolveFormLocalPath`, `recurse` для рекурсивного обхода подмодели по правилу) и обработку этих полей в `applyGraphOps` / оркестраторе. Поведение в `MetadataGraph` идентично прежнему — все integration-тесты остаются зелёными.
+
+Файлы `forms/commonObjects/formCommand/graphFromModel.ts`, `forms/commonObjects/formParameter/graphFromModel.ts`, `commonObjects/typeDescription/graphFromModel.ts` уже чистые — содержат только `registerTypeRule(..., "graphChild" | "extractGraph")`, без `BuildGraphFromModelFunction`, и в этой фазе не трогаются.
+
+**Tech Stack:** TypeScript 5.9, vitest 4. Никаких новых зависимостей.
+
+---
+
+## Структура файлов
+
+**Modify (расширение инфраструктуры):**
+- `packages/core/metadata/orchestration/property/fn.ts` — добавить `GraphOpsChild.item?`, `GraphOpsChild.absoluteId?`, `GraphOpsChild.edgeFrom?`, `GraphOps.formLocalReferences?`, `GraphOps.recurse?`. Снять `graph: MetadataGraph` из `BuildGraphFromModelFunction` финальной задачей.
+- `packages/core/metadata/relations/applyGraphOps.ts` — обработать новые поля.
+- `packages/core/metadata/orchestration/buildGraphFromModel.ts` — поддержать `recurse` в результате обработчика, передавая `extra` дальше.
+
+**Modify (миграция файлов):**
+- `packages/core/metadata/commonObjects/metadataRef/graphFromModel.ts`
+- `packages/core/metadata/commonObjects/metadataValue/graphFromModel.ts`
+- `packages/core/metadata/forms/commonObjects/commandName/graphFromModel.ts`
+- `packages/core/metadata/forms/commonObjects/associatedTable/graphFromModel.ts`
+- `packages/core/metadata/forms/commonObjects/dataPath/graphFromModel.ts`
+- `packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts`
+
+**Не трогаем:**
+- `packages/core/metadata/forms/elements/graphFromModel.ts` — самая сложная миграция, плоская раскладка узлов через `formNodeId.Элемент.<name>` с ребром-источником, отличным от `parentNodeId`. Уезжает в отдельную фазу 1c, чтобы 1b остался обозримым по объёму. После 1b у `forms/elements` останется единственный legacy-обработчик с `graph`-параметром; снятие `graph` из сигнатуры (Task 8) сместится в 1c.
+- Существующие `*.test.ts` — integration-тесты через `MetadataGraph`/`importMetadataFileWithGraph` остаются как контрактная проверка. Поведение не меняется.
+- `applyGraphOps` продолжает писать в `MetadataGraph` — удаление graphology в фазе 1d.
+
+**Уточнение области:** Поскольку `forms/elements` остаётся в 1b с legacy-сигнатурой, **Task 8 (удаление `graph` из сигнатуры) переносится в фазу 1c** — план фазы 1b завершается на Task 7. Финальный шаг 1b — прогон полного `pnpm test` и подведение итога.
+
+---
+
+## Task 1: Перевести `metadataRef/graphFromModel.ts` на чистую форму
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/metadataRef/graphFromModel.ts`
+
+- [ ] **Step 1: Заменить тело `buildMetadataItemLinksGraph`**
+
+Целиком заменить содержимое `packages/core/metadata/commonObjects/metadataRef/graphFromModel.ts` на:
+
+```ts
+import { isPair, isScalar, isSeq, YAMLSeq } from "yaml"
+import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
+import {
+  BuildGraphFromModelFunction,
+  ExtractGraphFromModelFunction,
+  GraphOps,
+} from "~/metadata/orchestration/property/fn"
+import { findSeqItemOffset } from "~/metadata/orchestration/property/position"
+import { extractReferenceFromPath } from "~/metadata/orchestration/property/extractReferenceFromPath"
+import { MetadataItemLink, MetadataItemLinks } from "./types"
+
+const EDGE_KIND = "OBJECT"
+const EDGE_YAML = "Объект"
+
+const extractMetadataItemLinkGraph: ExtractGraphFromModelFunction = (
+  model,
+  position,
+): GraphOps | undefined => {
+  const link = model as MetadataItemLink
+  if (!link) return undefined
+  const ref = extractReferenceFromPath(link, position)
+  if (!ref) return undefined
+  return { references: [ref] }
+}
+
+const buildMetadataItemLinksGraph: BuildGraphFromModelFunction = ({
+  model,
+  yamlMap,
+  propRule,
+}): GraphOps | undefined => {
+  const links = model as MetadataItemLinks | undefined
+  if (!Array.isArray(links) || links.length === 0) return undefined
+
+  let yamlSeq: YAMLSeq | undefined
+  if (yamlMap && propRule.yaml) {
+    const pair = yamlMap.items.find(
+      (i) => isPair(i) && isScalar(i.key) && i.key.value === propRule.yaml,
+    )
+    if (pair && isPair(pair) && isSeq(pair.value)) {
+      yamlSeq = pair.value as YAMLSeq
+    }
+  }
+
+  const references = links
+    .map((link, index) => {
+      const offset = yamlSeq ? findSeqItemOffset(yamlSeq, index) : undefined
+      const position = offset !== undefined ? { offset } : undefined
+      return extractReferenceFromPath(link, position)
+    })
+    .filter((ref): ref is NonNullable<typeof ref> => ref !== undefined)
+
+  if (references.length === 0) return undefined
+
+  return { references, edgeKind: EDGE_KIND, edgeYaml: EDGE_YAML }
+}
+
+registerTypeRule("MetadataItemLink", "extractGraph", extractMetadataItemLinkGraph)
+registerTypeRule("MetadataItemLink", "graphEdgeFromParent", { kind: EDGE_KIND, yaml: EDGE_YAML })
+registerTypeRule("MetadataItemLinks", "buildGraphFromModel", buildMetadataItemLinksGraph)
+```
+
+Изменения:
+- Удалён импорт `applyGraphOps`.
+- Из деструктуризации `buildMetadataItemLinksGraph` убраны `parentNodeId`, `filePath`, `graph`.
+- Тело собирает массив `references` и возвращает `GraphOps` с `edgeKind: "OBJECT"`, `edgeYaml: "Объект"`. Пустой результат — `undefined`.
+
+- [ ] **Step 2: Прогнать type-check**
+
+```bash
+cd /Users/nikita/git/nakidka-core/.claude/worktrees/graph-pure-functions
+pnpm --filter @nakidka/core run type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Прогнать тесты ядра**
+
+```bash
+pnpm --filter @nakidka/core test
+```
+
+Expected: PASS — поведение не меняется, оркестратор сам прогоняет результат через `applyGraphOps`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/metadata/commonObjects/metadataRef/graphFromModel.ts
+git commit -m "$(cat <<'EOF'
+refactor: :recycle: перевести buildMetadataItemLinksGraph на чистую форму
+
+Функция возвращает GraphOps { references, edgeKind, edgeYaml } вместо
+прямой мутации graph через applyGraphOps. Поведение в MetadataGraph
+идентично прежнему — оркестратор сам прогоняет результат через тот же
+applyGraphOps.
+EOF
+)"
+```
+
+---
+
+## Task 2: Перевести `metadataValue/graphFromModel.ts` на чистую форму
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/metadataValue/graphFromModel.ts`
+
+`buildMetadataValueGraph` имеет три ветки: `fixedArray`, `formChoiceListDesTimeValue`, простой `ref`/`objectRef`. В fixedArray-ветке элементы могут давать рёбра двух разных kinds (`VALUE` и `OBJECT`), но один вызов `applyGraphOps` берёт только один `edgeKind`. Чтобы не разбивать `GraphOps` на «секции по kind», в этой задаче делаем компромисс: на уровне функции возвращаем `GraphOps` с одним kind'ом, а смешанный fixedArray (редкий случай) обрабатываем через расширение возврата — допускаем, что функция может вернуть **массив** `GraphOps[]`, и оркестратор разворачивает каждую секцию отдельно.
+
+- [ ] **Step 1: Расширить возвращаемый тип `BuildGraphFromModelFunction` до union с массивом**
+
+В `packages/core/metadata/orchestration/property/fn.ts` найти:
+
+```ts
+}) => GraphOps | undefined | void
+```
+
+Заменить на:
+
+```ts
+}) => GraphOps | GraphOps[] | undefined | void
+```
+
+- [ ] **Step 2: Адаптировать оркестратор для массива GraphOps**
+
+В `packages/core/metadata/orchestration/buildGraphFromModel.ts` найти ветку `if (buildGraphFn) { ... }`. Заменить блок обработки результата на:
+
+```ts
+if (buildGraphFn) {
+  const result = buildGraphFn({
+    model: model[key],
+    parentNodeId,
+    filePath,
+    yamlMap,
+    propRule,
+    graph,
+    extra,
+  })
+  const sections = Array.isArray(result) ? result : result ? [result] : []
+  for (const section of sections) {
+    if (!section.children?.length && !section.references?.length) continue
+    if (!section.edgeKind || !section.edgeYaml) {
+      throw new Error(
+        `buildGraphFromModel: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +
+          `Чистые функции должны указывать оба поля в результате.`,
+      )
+    }
+    applyGraphOps(section, {
+      graph,
+      parentNodeId,
+      filePath,
+      edgeKind: section.edgeKind,
+      edgeYaml: section.edgeYaml,
+    })
+  }
+  continue
+}
+```
+
+Поведение для одиночного `GraphOps` не меняется (одна секция в массиве). `void`/`undefined` пропускается. Массив развёртывается посекционно — каждая секция со своим `edgeKind`.
+
+- [ ] **Step 3: Заменить тело `buildMetadataValueGraph` на чистую форму**
+
+Целиком заменить содержимое `packages/core/metadata/commonObjects/metadataValue/graphFromModel.ts` на:
+
+```ts
+import { isPair, isScalar, isSeq, YAMLSeq } from "yaml"
+import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+  GraphOpsReference,
+} from "~/metadata/orchestration/property/fn"
+import { computeValuePosition, findSeqItemOffset, findSubmap } from "~/metadata/orchestration/property/position"
+import { extractReferenceFromPath } from "~/metadata/orchestration/property/extractReferenceFromPath"
+import { convertPath } from "~/metadata/commonObjects/metadataPath/helper"
+import { MetadataValuesRulesToYAML } from "~/metadata/commonObjects/metadataPath/types"
+import {
+  MetadataFixedArrayValue,
+  MetadataFormChoiceListValue,
+  MetadataObjectRefValue,
+  MetadataRefValue,
+  MetadataTypedValue,
+  MetadataValue,
+} from "./types"
+
+const REF_EDGE_KIND = "VALUE"
+const REF_EDGE_YAML = "Значение"
+const OBJECT_REF_EDGE_KIND = "OBJECT"
+const OBJECT_REF_EDGE_YAML = "Объект"
+
+function convertRefValueToNodeId(refValue: string): string | undefined {
+  if (!refValue) return undefined
+  let processedPath = refValue
+  if (refValue.startsWith("Enum.")) {
+    processedPath = refValue.split(".").filter((p) => p !== "EnumValue").join(".")
+  }
+  const nodeId = convertPath(MetadataValuesRulesToYAML, processedPath)
+  const dotInInput = processedPath.indexOf(".")
+  const dotInOutput = nodeId.indexOf(".")
+  if (dotInInput === -1 || dotInOutput === -1) return undefined
+  if (processedPath.substring(0, dotInInput) === nodeId.substring(0, dotInOutput)) return undefined
+  return nodeId
+}
+
+export function extractSingleValueRef(
+  value: MetadataTypedValue,
+  position?: { offset: number },
+): { ref: GraphOpsReference; kind: string; yaml: string } | undefined {
+  if (value.type === "ref") {
+    const nodeId = convertRefValueToNodeId((value as MetadataRefValue).value)
+    if (!nodeId) return undefined
+    const parts = nodeId.split(".")
+    const name = parts[parts.length - 1]
+    return {
+      ref: { id: nodeId, name, positionFrom: position },
+      kind: REF_EDGE_KIND,
+      yaml: REF_EDGE_YAML,
+    }
+  }
+  if (value.type === "objectRef") {
+    const ref = extractReferenceFromPath((value as MetadataObjectRefValue).value, position)
+    if (!ref) return undefined
+    return { ref, kind: OBJECT_REF_EDGE_KIND, yaml: OBJECT_REF_EDGE_YAML }
+  }
+  return undefined
+}
+
+export const buildMetadataValueGraph: BuildGraphFromModelFunction = ({
+  model,
+  yamlMap,
+  propRule,
+}): GraphOps[] | undefined => {
+  const value = model as MetadataValue | undefined
+  if (!value) return undefined
+
+  if (value.type === "fixedArray") {
+    const items = (value as MetadataFixedArrayValue).value
+    if (items.length === 0) return undefined
+
+    let yamlSeq: YAMLSeq | undefined
+    if (yamlMap && propRule.yaml) {
+      const pair = yamlMap.items.find(
+        (i) => isPair(i) && isScalar(i.key) && i.key.value === propRule.yaml,
+      )
+      if (pair && isPair(pair) && isSeq(pair.value)) {
+        yamlSeq = pair.value as YAMLSeq
+      }
+    }
+
+    const refsByKind = new Map<string, { yaml: string; refs: GraphOpsReference[] }>()
+    items.forEach((item, index) => {
+      const offset = yamlSeq ? findSeqItemOffset(yamlSeq, index) : undefined
+      const position = offset !== undefined ? { offset } : undefined
+      const extracted = extractSingleValueRef(item, position)
+      if (!extracted) return
+      const { ref, kind, yaml } = extracted
+      let bucket = refsByKind.get(kind)
+      if (!bucket) {
+        bucket = { yaml, refs: [] }
+        refsByKind.set(kind, bucket)
+      }
+      bucket.refs.push(ref)
+    })
+
+    if (refsByKind.size === 0) return undefined
+    const sections: GraphOps[] = []
+    for (const [kind, { yaml, refs }] of refsByKind) {
+      sections.push({ references: refs, edgeKind: kind, edgeYaml: yaml })
+    }
+    return sections
+  }
+
+  if (value.type === "formChoiceListDesTimeValue") {
+    const inner = (value as MetadataFormChoiceListValue).value
+    if (!inner) return undefined
+    let innerPosition: { offset: number } | undefined
+    if (yamlMap && propRule.yaml) {
+      const innerMap = findSubmap(yamlMap, propRule.yaml)
+      if (innerMap) {
+        innerPosition = computeValuePosition(innerMap, "Значение")
+      } else {
+        innerPosition = computeValuePosition(yamlMap, propRule.yaml)
+      }
+    }
+    const extracted = extractSingleValueRef(inner, innerPosition)
+    if (!extracted) return undefined
+    return [{ references: [extracted.ref], edgeKind: extracted.kind, edgeYaml: extracted.yaml }]
+  }
+
+  const position =
+    yamlMap && propRule.yaml ? computeValuePosition(yamlMap, propRule.yaml) : undefined
+  const extracted = extractSingleValueRef(value, position ?? undefined)
+  if (!extracted) return undefined
+  return [{ references: [extracted.ref], edgeKind: extracted.kind, edgeYaml: extracted.yaml }]
+}
+
+registerTypeRule("MetadataValue", "buildGraphFromModel", buildMetadataValueGraph)
+```
+
+Изменения:
+- Удалён импорт `applyGraphOps`.
+- Из деструктуризации `buildMetadataValueGraph` убраны `parentNodeId`, `filePath`, `graph`.
+- Каждая ветка возвращает либо `undefined`, либо массив секций `GraphOps[]` с готовыми `edgeKind`/`edgeYaml`. Простой одиночный `ref`/`objectRef` тоже отдаётся массивом из одной секции — это унифицирует тип возврата.
+
+- [ ] **Step 4: Обновить existing-тест `metadataValue/graphFromModel.test.ts`**
+
+В `packages/core/metadata/commonObjects/metadataValue/graphFromModel.test.ts` каждый вызов `buildMetadataValueGraph({ ..., graph })` использует параметр `graph` для проверки рёбер через `outEdgeEntries`. Поведение функции изменилось — она теперь возвращает `GraphOps[]` вместо мутации graph. Чтобы тесты остались валидными контрактом, нужно либо:
+1. Переписать их на проверку возвращённых `GraphOps[]` напрямую, либо
+2. Прогонять результат через `applyGraphOps` в самом тесте.
+
+Выбираем (2) — это сохраняет integration-характер тестов и даёт меньше изменений. Найти в начале файла:
+
+```ts
+import { extractSingleValueRef, buildMetadataValueGraph } from "./graphFromModel"
+```
+
+И добавить ниже:
+
+```ts
+import { applyGraphOps } from "~/metadata/relations/applyGraphOps"
+```
+
+Создать локальный helper после `makeGraph`:
+
+```ts
+function runBuild(params: Parameters<typeof buildMetadataValueGraph>[0]) {
+  const result = buildMetadataValueGraph(params)
+  const sections = Array.isArray(result) ? result : result ? [result] : []
+  for (const section of sections) {
+    if (!section.edgeKind || !section.edgeYaml) continue
+    applyGraphOps(section, {
+      graph: params.graph,
+      parentNodeId: params.parentNodeId,
+      filePath: params.filePath,
+      edgeKind: section.edgeKind,
+      edgeYaml: section.edgeYaml,
+    })
+  }
+}
+```
+
+Заменить все вызовы `buildMetadataValueGraph({...})` в `describe("buildMetadataValueGraph", ...)` на `runBuild({...})`.
+
+- [ ] **Step 5: Прогнать тесты ядра**
+
+```bash
+pnpm --filter @nakidka/core test
+```
+
+Expected: PASS — все ~2531 тестов остаются зелёными.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  packages/core/metadata/orchestration/property/fn.ts \
+  packages/core/metadata/orchestration/buildGraphFromModel.ts \
+  packages/core/metadata/commonObjects/metadataValue/graphFromModel.ts \
+  packages/core/metadata/commonObjects/metadataValue/graphFromModel.test.ts
+git commit -m "$(cat <<'EOF'
+refactor: :recycle: перевести buildMetadataValueGraph на чистую форму
+
+Функция возвращает GraphOps[] (массив секций по edgeKind) вместо мутации
+graph. Расширен возврат BuildGraphFromModelFunction до GraphOps | GraphOps[] |
+undefined | void; оркестратор разворачивает каждую секцию через applyGraphOps.
+Это нужно для fixedArray-ветки, где элементы могут давать рёбра kind=VALUE и
+kind=OBJECT одновременно — разделение на секции позволяет описать обе.
+
+Тесты graphFromModel.test.ts адаптированы через локальный helper runBuild,
+прогоняющий результат через applyGraphOps — поведение в MetadataGraph
+идентично прежнему.
+EOF
+)"
+```
+
+---
+
+## Task 3: Перевести `commandName/graphFromModel.ts` на чистую форму
+
+**Files:**
+- Modify: `packages/core/metadata/forms/commonObjects/commandName/graphFromModel.ts`
+
+Текущая функция создаёт stub-узел и reference-ребро на узел команды формы. Это укладывается в `references` секцию `GraphOps`.
+
+- [ ] **Step 1: Заменить тело обработчика на чистую форму**
+
+Целиком заменить содержимое `packages/core/metadata/forms/commonObjects/commandName/graphFromModel.ts` на:
+
+```ts
+/**
+ * Регистрирует buildGraphFromModel для типа CommandName.
+ *
+ * PRD #121: свойство commandName на кнопках формы — имя команды в текущей форме.
+ * Материализуется как reference-ребро «ИмяКоманды» от узла кнопки к узлу команды формы.
+ *
+ * Если команды с таким именем нет в форме — создаётся заглушка через ensureNode
+ * в applyGraphOps. formNodeId пробрасывается через extra от forms/elements.
+ */
+
+import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
+import { registerEdgeKind } from "~/metadata/relations/edgeKinds"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+} from "~/metadata/orchestration/property/fn"
+
+const EDGE_KIND = "COMMAND_NAME"
+const EDGE_YAML = "ИмяКоманды"
+
+registerEdgeKind(EDGE_KIND, { yaml: EDGE_YAML, owning: false })
+
+const buildCommandNameGraph: BuildGraphFromModelFunction = ({
+  model,
+  extra,
+}): GraphOps | undefined => {
+  if (typeof model !== "string" || !model) return undefined
+  const formNodeId = extra?.formNodeId as string | undefined
+  if (!formNodeId) return undefined
+
+  const targetId = `${formNodeId}.Команда.${model}`
+  return {
+    references: [{ id: targetId, name: model }],
+    edgeKind: EDGE_KIND,
+    edgeYaml: EDGE_YAML,
+  }
+}
+
+registerTypeRule("CommandName", "buildGraphFromModel", buildCommandNameGraph)
+```
+
+Изменения:
+- Из деструктуризации убраны `parentNodeId`, `graph`.
+- Возвращается `GraphOps` с одним reference на узел команды; оркестратор сам сделает `ensureNode` + `ensureEdge` через `applyGraphOps`.
+
+- [ ] **Step 2: Прогнать тесты ядра**
+
+```bash
+pnpm --filter @nakidka/core test
+```
+
+Expected: PASS — `commandName/graphFromModel.test.ts` остаётся зелёным.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/metadata/forms/commonObjects/commandName/graphFromModel.ts
+git commit -m "$(cat <<'EOF'
+refactor: :recycle: перевести CommandName buildGraphFromModel на чистую форму
+
+Функция возвращает GraphOps с одним reference вместо ensureNode+ensureEdge
+напрямую. Оркестратор прогоняет результат через applyGraphOps — поведение
+идентично.
+EOF
+)"
+```
+
+---
+
+## Task 4: Перевести `associatedTable/graphFromModel.ts` на чистую форму
+
+**Files:**
+- Modify: `packages/core/metadata/forms/commonObjects/associatedTable/graphFromModel.ts`
+
+Идентичная структура с `commandName`: один stub-узел + reference-ребро.
+
+- [ ] **Step 1: Заменить тело обработчика на чистую форму**
+
+Целиком заменить содержимое `packages/core/metadata/forms/commonObjects/associatedTable/graphFromModel.ts` на:
+
+```ts
+/**
+ * Регистрирует buildGraphFromModel для типа AssociatedTable.
+ *
+ * PRD #119: свойство table на элементах формы и командах формы — ссылка на
+ * элемент-таблицу внутри той же формы (по имени элемента). Материализуется как
+ * reference-ребро «СвязаннаяТаблица» от узла элемента к узлу таблицы.
+ *
+ * Если узел таблицы не существует — applyGraphOps создаст заглушку.
+ * formNodeId пробрасывается через extra от forms/elements.
+ */
+
+import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
+import { registerEdgeKind } from "~/metadata/relations/edgeKinds"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+} from "~/metadata/orchestration/property/fn"
+
+const EDGE_KIND = "ASSOCIATED_TABLE"
+const EDGE_YAML = "СвязаннаяТаблица"
+
+registerEdgeKind(EDGE_KIND, { yaml: EDGE_YAML, owning: false })
+
+const buildAssociatedTableGraph: BuildGraphFromModelFunction = ({
+  model,
+  extra,
+}): GraphOps | undefined => {
+  if (typeof model !== "string" || !model) return undefined
+  const formNodeId = extra?.formNodeId as string | undefined
+  if (!formNodeId) return undefined
+
+  const targetId = `${formNodeId}.Элемент.${model}`
+  return {
+    references: [{ id: targetId, name: model }],
+    edgeKind: EDGE_KIND,
+    edgeYaml: EDGE_YAML,
+  }
+}
+
+registerTypeRule("AssociatedTable", "buildGraphFromModel", buildAssociatedTableGraph)
+```
+
+- [ ] **Step 2: Прогнать тесты ядра**
+
+```bash
+pnpm --filter @nakidka/core test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/metadata/forms/commonObjects/associatedTable/graphFromModel.ts
+git commit -m "$(cat <<'EOF'
+refactor: :recycle: перевести AssociatedTable buildGraphFromModel на чистую форму
+
+Функция возвращает GraphOps с одним reference вместо прямой мутации graph.
+Поведение идентично: applyGraphOps создаёт заглушку и ребро.
+EOF
+)"
+```
+
+---
+
+## Task 5: Расширить `GraphOps` декларациями `formLocalReferences`, мигрировать `dataPath`
+
+**Files:**
+- Modify: `packages/core/metadata/orchestration/property/fn.ts`
+- Modify: `packages/core/metadata/relations/applyGraphOps.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/dataPath/graphFromModel.ts`
+
+`dataPath` отличается от `commandName`/`associatedTable` тем, что цель ссылки резолвится через `resolveFormLocalPath` — функцию, которая обходит граф (рёбра формы) и при необходимости создаёт заглушку. Чтобы вынести `graph` из чистой функции, добавляем декларацию `formLocalReferences` — оркестратор сам вызывает `resolveFormLocalPath` при применении.
+
+- [ ] **Step 1: Добавить тип `GraphOpsFormLocalReference` и поле в `GraphOps`**
+
+В `packages/core/metadata/orchestration/property/fn.ts` после интерфейса `GraphOpsReference` (около строки 95) добавить:
+
+```ts
+export interface GraphOpsFormLocalReference {
+  /** Form-local путь, например "Объект.Договор.Владелец". */
+  formLocalPath: string
+  /** Корневой узел формы — стартовая точка резолвинга. */
+  formNodeId: string
+  positionFrom?: { offset: number; length?: number }
+}
+```
+
+Расширить `GraphOps`:
+
+```ts
+export interface GraphOps {
+  children?: GraphOpsChild[]
+  references?: GraphOpsReference[]
+  /** Reference-рёбра, цель которых нужно резолвить через resolveFormLocalPath. */
+  formLocalReferences?: GraphOpsFormLocalReference[]
+  edgeKind?: string
+  edgeYaml?: string
+}
+```
+
+- [ ] **Step 2: Расширить `applyGraphOps` обработкой `formLocalReferences`**
+
+В `packages/core/metadata/relations/applyGraphOps.ts` заменить файл целиком на:
+
+```ts
+import { GraphOps } from "../orchestration/property/fn"
+import { resolveFormLocalPath } from "./resolveFormLocalPath"
+import { MetadataGraph } from "./MetadataGraph"
+
+export interface ApplyGraphOpsContext {
+  graph: MetadataGraph
+  parentNodeId: string
+  filePath: string
+  edgeKind: string
+  edgeYaml: string
+}
+
+export function applyGraphOps(ops: GraphOps, ctx: ApplyGraphOpsContext): void {
+  const { graph, parentNodeId, filePath, edgeKind, edgeYaml } = ctx
+
+  for (const child of ops.children ?? []) {
+    const childNodeId = `${parentNodeId}.${child.idSuffix}`
+    graph.promoteNode(childNodeId, {
+      name: child.name,
+      filePaths: [filePath],
+      positionFrom: child.positionFrom,
+    })
+    const edgeKey = `${parentNodeId}:${edgeKind}:${childNodeId}`
+    graph.ensureEdge(edgeKey, parentNodeId, childNodeId, {
+      yaml: edgeYaml,
+      kind: edgeKind,
+    })
+  }
+
+  for (const ref of ops.references ?? []) {
+    graph.ensureNode(ref.id, { name: ref.name })
+    const edgeKey = `${parentNodeId}:${edgeKind}:${ref.id}`
+    graph.ensureEdge(edgeKey, parentNodeId, ref.id, {
+      yaml: edgeYaml,
+      kind: edgeKind,
+      positionFrom: ref.positionFrom,
+    })
+  }
+
+  for (const local of ops.formLocalReferences ?? []) {
+    const resolved = resolveFormLocalPath({
+      formNodeId: local.formNodeId,
+      path: local.formLocalPath,
+      graph,
+    })
+    if (!resolved) continue
+    const edgeKey = `${parentNodeId}:${edgeKind}:${resolved.targetId}`
+    graph.ensureEdge(edgeKey, parentNodeId, resolved.targetId, {
+      yaml: edgeYaml,
+      kind: edgeKind,
+      positionFrom: local.positionFrom,
+    })
+  }
+}
+```
+
+- [ ] **Step 3: Заменить тело `dataPath`-обработчика на чистую форму**
+
+Целиком заменить содержимое `packages/core/metadata/forms/commonObjects/dataPath/graphFromModel.ts` на:
+
+```ts
+/**
+ * Регистрирует buildGraphFromModel для типа DataPath.
+ *
+ * PRD #118: dataPath-свойства элементов формы превращаются в reference-рёбра
+ * от узла элемента к узлу целевого реквизита/колонки.
+ *
+ * Kind ребра определяется по правилу yaml-name (PRD #114):
+ * propRule.graphEdgeKind ?? getKindByYaml(propRule.yaml).
+ *
+ * Резолвинг цели делегирован applyGraphOps через formLocalReferences —
+ * оркестратор вызовет resolveFormLocalPath при записи в граф.
+ */
+
+import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
+import { getKindByYaml, registerEdgeKind } from "~/metadata/relations/edgeKinds"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+} from "~/metadata/orchestration/property/fn"
+
+registerEdgeKind("DATA_PATH", { yaml: "ПутьКДанным", owning: false })
+registerEdgeKind("FOOTER_DATA_PATH", { yaml: "ПутьКДаннымПодвала", owning: false })
+registerEdgeKind("TITLE_DATA_PATH", { yaml: "ПутьКДаннымЗаголовка", owning: false })
+registerEdgeKind("ROW_PICTURE_DATA_PATH", { yaml: "ПутьКДаннымКартинкиСтроки", owning: false })
+
+const buildDataPathGraph: BuildGraphFromModelFunction = ({
+  model,
+  propRule,
+  extra,
+}): GraphOps | undefined => {
+  if (typeof model !== "string" || !model) return undefined
+  const formNodeId = extra?.formNodeId as string | undefined
+  if (!formNodeId) return undefined
+
+  const edgeYaml = propRule.yaml
+  if (!edgeYaml) return undefined
+  const edgeKind =
+    ((propRule as Record<string, unknown>).graphEdgeKind as string | undefined) ??
+    getKindByYaml(edgeYaml)
+  if (!edgeKind) return undefined
+
+  return {
+    formLocalReferences: [{ formLocalPath: model, formNodeId }],
+    edgeKind,
+    edgeYaml,
+  }
+}
+
+registerTypeRule("DataPath", "buildGraphFromModel", buildDataPathGraph)
+```
+
+Изменения:
+- Удалены импорты `resolveFormLocalPath` и `graph`-параметра.
+- Возвращается `GraphOps` с `formLocalReferences` — оркестратор резолвит при применении.
+
+- [ ] **Step 4: Прогнать тесты ядра**
+
+```bash
+pnpm --filter @nakidka/core test
+```
+
+Expected: PASS — `dataPath/graphFromModel.test.ts` остаётся зелёным. `applyGraphOps` теперь сам делегирует `resolveFormLocalPath`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  packages/core/metadata/orchestration/property/fn.ts \
+  packages/core/metadata/relations/applyGraphOps.ts \
+  packages/core/metadata/forms/commonObjects/dataPath/graphFromModel.ts
+git commit -m "$(cat <<'EOF'
+refactor: :recycle: перевести DataPath buildGraphFromModel на чистую форму
+
+GraphOps расширен декларацией formLocalReferences для целей, резолвимых
+через resolveFormLocalPath. applyGraphOps сам вызывает резолвинг и
+создаёт ребро (с заглушкой при отсутствии целевого узла). DataPath-обработчик
+становится чистой функцией: возвращает декларацию пути и edgeKind/edgeYaml,
+без обращения к graph.
+EOF
+)"
+```
+
+---
+
+## Task 6: Расширить `GraphOps` декларациями `item`/`parentOverride`/`recurse`, мигрировать `formAttribute` (FormAttributeColumns)
+
+**Files:**
+- Modify: `packages/core/metadata/orchestration/property/fn.ts`
+- Modify: `packages/core/metadata/relations/applyGraphOps.ts`
+- Modify: `packages/core/metadata/orchestration/buildGraphFromModel.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts`
+
+`FormAttributeColumns` создаёт многоуровневые узлы с собственным `item` и рекурсивно вызывает `buildGraphFromModel` оркестратора, чтобы пройтись по правилу `FormAttributeColumnRules`. В `additional`-ветке появляется прокси-узел, к которому прикрепляются и колонки-дети, и `formLocalReferences` ребра «Таблица», т.е. источник ребра ≠ `parentNodeId`.
+
+Расширения `GraphOps` (вводятся одним пакетом, прежде чем мигрировать сам файл):
+- `GraphOpsChild.item?: Record<string, unknown>` — записывается в `graph.promoteNode({ item })`.
+- `GraphOpsChild.parentOverride?: string` — если задано, ребро идёт от этого узла, и `childNodeId = parentOverride + "." + idSuffix`.
+- `GraphOpsFormLocalReference.parentOverride?: string` — аналогично для form-local рёбер.
+- `GraphOps.recurse?: GraphOpsRecurse[]` — список «рекурсивных задач»: оркестратор пройдёт по подмодели с указанным правилом после применения локальных ops.
+
+- [ ] **Step 1: Расширить типы в `fn.ts`**
+
+В `packages/core/metadata/orchestration/property/fn.ts` найти:
+
+```ts
+export interface GraphOpsChild {
+  idSuffix: string
+  name: string
+  positionFrom?: { offset: number; length?: number }
+}
+```
+
+Заменить на:
+
+```ts
+export interface GraphOpsChild {
+  idSuffix: string
+  name: string
+  positionFrom?: { offset: number; length?: number }
+  /** Запись в node.item при promoteNode. */
+  item?: Record<string, unknown>
+  /** Если задано — ребро идёт от этого узла, childNodeId = `${parentOverride}.${idSuffix}` вместо `${ctx.parentNodeId}.${idSuffix}`. */
+  parentOverride?: string
+}
+```
+
+Найти `GraphOpsFormLocalReference` (введён в Task 5):
+
+```ts
+export interface GraphOpsFormLocalReference {
+  formLocalPath: string
+  formNodeId: string
+  positionFrom?: { offset: number; length?: number }
+}
+```
+
+Заменить на:
+
+```ts
+export interface GraphOpsFormLocalReference {
+  formLocalPath: string
+  formNodeId: string
+  positionFrom?: { offset: number; length?: number }
+  /** Если задано — ребро идёт от этого узла к резолвимой цели вместо ctx.parentNodeId. */
+  parentOverride?: string
+}
+```
+
+После `GraphOpsFormLocalReference` добавить новый интерфейс:
+
+```ts
+export interface GraphOpsRecurse {
+  /** Подмодель, для которой нужно повторно вызвать обход правила. */
+  model: Record<string, unknown>
+  /** YAML-фрагмент подмодели для координат. Опционально. */
+  yamlMap?: YAMLMap
+  /** Правило обхода подмодели. */
+  rule: MetadataItemRule
+  /** Узел, относительно которого пойдёт обход — становится parentNodeId внутри. */
+  parentNodeId: string
+  /** Дополнительный контекст, пробрасываемый в обработчики. По умолчанию наследуется от вызывающего. */
+  extra?: Record<string, unknown>
+}
+```
+
+`YAMLMap` и `MetadataItemRule` уже импортированы в этом файле — дополнительные импорты не нужны.
+
+Найти `GraphOps`:
+
+```ts
+export interface GraphOps {
+  children?: GraphOpsChild[]
+  references?: GraphOpsReference[]
+  formLocalReferences?: GraphOpsFormLocalReference[]
+  edgeKind?: string
+  edgeYaml?: string
+}
+```
+
+Заменить на:
+
+```ts
+export interface GraphOps {
+  children?: GraphOpsChild[]
+  references?: GraphOpsReference[]
+  formLocalReferences?: GraphOpsFormLocalReference[]
+  /** Рекурсивные задачи: оркестратор пройдёт по правилу для каждой подмодели после применения локальных ops. */
+  recurse?: GraphOpsRecurse[]
+  edgeKind?: string
+  edgeYaml?: string
+}
+```
+
+- [ ] **Step 2: Адаптировать `applyGraphOps`**
+
+Целиком заменить содержимое `packages/core/metadata/relations/applyGraphOps.ts` на:
+
+```ts
+import { GraphOps } from "../orchestration/property/fn"
+import { resolveFormLocalPath } from "./resolveFormLocalPath"
+import { MetadataGraph } from "./MetadataGraph"
+
+export interface ApplyGraphOpsContext {
+  graph: MetadataGraph
+  parentNodeId: string
+  filePath: string
+  edgeKind: string
+  edgeYaml: string
+}
+
+export function applyGraphOps(ops: GraphOps, ctx: ApplyGraphOpsContext): void {
+  const { graph, parentNodeId, filePath, edgeKind, edgeYaml } = ctx
+
+  for (const child of ops.children ?? []) {
+    const effectiveParent = child.parentOverride ?? parentNodeId
+    const childNodeId = `${effectiveParent}.${child.idSuffix}`
+    graph.promoteNode(childNodeId, {
+      name: child.name,
+      filePaths: [filePath],
+      positionFrom: child.positionFrom,
+      item: child.item,
+    })
+    const edgeKey = `${effectiveParent}:${edgeKind}:${childNodeId}`
+    graph.ensureEdge(edgeKey, effectiveParent, childNodeId, {
+      yaml: edgeYaml,
+      kind: edgeKind,
+    })
+  }
+
+  for (const ref of ops.references ?? []) {
+    graph.ensureNode(ref.id, { name: ref.name })
+    const edgeKey = `${parentNodeId}:${edgeKind}:${ref.id}`
+    graph.ensureEdge(edgeKey, parentNodeId, ref.id, {
+      yaml: edgeYaml,
+      kind: edgeKind,
+      positionFrom: ref.positionFrom,
+    })
+  }
+
+  for (const local of ops.formLocalReferences ?? []) {
+    const effectiveParent = local.parentOverride ?? parentNodeId
+    const resolved = resolveFormLocalPath({
+      formNodeId: local.formNodeId,
+      path: local.formLocalPath,
+      graph,
+    })
+    if (!resolved) continue
+    const edgeKey = `${effectiveParent}:${edgeKind}:${resolved.targetId}`
+    graph.ensureEdge(edgeKey, effectiveParent, resolved.targetId, {
+      yaml: edgeYaml,
+      kind: edgeKind,
+      positionFrom: local.positionFrom,
+    })
+  }
+}
+```
+
+- [ ] **Step 3: Адаптировать оркестратор `buildGraphFromModel.ts` под `recurse`**
+
+В `packages/core/metadata/orchestration/buildGraphFromModel.ts` заменить весь блок ветки `if (buildGraphFn) { ... }` на:
+
+```ts
+if (buildGraphFn) {
+  const result = buildGraphFn({
+    model: model[key],
+    parentNodeId,
+    filePath,
+    yamlMap,
+    propRule,
+    graph,
+    extra,
+  })
+  const sections = Array.isArray(result) ? result : result ? [result] : []
+  for (const section of sections) {
+    const hasOps =
+      section.children?.length ||
+      section.references?.length ||
+      section.formLocalReferences?.length
+    if (hasOps) {
+      if (!section.edgeKind || !section.edgeYaml) {
+        throw new Error(
+          `buildGraphFromModel: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +
+            `Чистые функции должны указывать оба поля в результате.`,
+        )
+      }
+      applyGraphOps(section, {
+        graph,
+        parentNodeId,
+        filePath,
+        edgeKind: section.edgeKind,
+        edgeYaml: section.edgeYaml,
+      })
+    }
+    for (const recurse of section.recurse ?? []) {
+      buildGraphFromModel({
+        model: recurse.model,
+        yamlMap: recurse.yamlMap,
+        rule: recurse.rule,
+        graph,
+        parentNodeId: recurse.parentNodeId,
+        filePath,
+        extra: recurse.extra ?? extra,
+      })
+    }
+  }
+  continue
+}
+```
+
+Поведение: после применения каждой секции оркестратор разворачивает её `recurse`-задачи через рекурсивный вызов `buildGraphFromModel` с новой моделью, новым правилом и новым `parentNodeId`. `extra` пробрасывается без изменений, если в задаче не задан собственный.
+
+- [ ] **Step 4: Перевести `formAttribute/graphFromModel.ts` на чистую форму**
+
+Целиком заменить содержимое `packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts` на:
+
+```ts
+import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
+import { findSubmap } from "~/metadata/orchestration/property/position"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+  GraphOpsChild,
+  GraphOpsRecurse,
+} from "~/metadata/orchestration/property/fn"
+import { FormAttributeColumnRules, FormAttributeRules } from "./rules"
+import type { FormAttributeAdditionalColumns, FormAttributeColumn } from "./types"
+
+const COLUMN_EDGE_KIND = "FORM_COLUMN"
+const COLUMN_EDGE_YAML = "КолонкаФормы"
+const ADDITION_EDGE_KIND = "TABLE_EXTENSION"
+const ADDITION_EDGE_YAML = "ДополнениеТаблицы"
+const TABLE_EDGE_KIND = "TABLE"
+const TABLE_EDGE_YAML = "Таблица"
+const ADDITIONAL_COLUMN_EDGE_KIND = "ADDITIONAL_COLUMN"
+const ADDITIONAL_COLUMN_EDGE_YAML = "ДополнительнаяКолонка"
+
+/**
+ * graphChild для коллекции FormAttributes — оркестратор сам создаёт дочерние узлы.
+ */
+registerTypeRule("FormAttributes", "graphChild", {
+  idFrom: "name",
+  edgeKind: "FORM_ATTRIBUTE",
+  edgeYaml: "РеквизитФормы",
+  nodeSegment: "Реквизит",
+  itemRule: FormAttributeRules,
+})
+
+/**
+ * Обрабатывает коллекцию колонок реквизита формы.
+ *
+ * - inner: тип реквизита = ТаблицаЗначений / ДеревоЗначений / СписокВыбора.
+ *   Колонка → дочерний узел `<реквизит>.<колонка>` + ребро «КолонкаФормы»
+ *   + recurse по FormAttributeColumnRules для типов колонки.
+ * - additional: дополнительные колонки к реквизитам прикладного объекта.
+ *   Прокси-узел `<реквизит>.<lastSeg(table)>` + ребро «ДополнениеТаблицы»,
+ *   ребро «Таблица» от прокси к ТЧ через formLocalReferences,
+ *   per-column узлы под прокси + рёбра «ДополнительнаяКолонка»
+ *   + recurse по FormAttributeColumnRules.
+ */
+const buildFormAttributeColumnsGraph: BuildGraphFromModelFunction = ({
+  model,
+  parentNodeId,
+  yamlMap,
+  propRule,
+}): GraphOps[] | undefined => {
+  if (!Array.isArray(model) || model.length === 0) return undefined
+
+  const first = model[0] as Record<string, unknown>
+
+  // ---- Additional columns (PRD #116) ----
+  if (typeof first.table === "string") {
+    // parentNodeId = <formNodeId>.Реквизит.<attrName>; формируем formNodeId обратным путём
+    const formNodeId = parentNodeId.split(".").slice(0, -2).join(".")
+    const sections: GraphOps[] = []
+
+    for (const raw of model) {
+      const group = raw as FormAttributeAdditionalColumns
+      const tablePath = group.table
+      const lastSegment = tablePath.split(".").pop()
+      if (!lastSegment) continue
+
+      const proxyNodeId = `${parentNodeId}.${lastSegment}`
+
+      // (1) Прокси-узел: owning-ребро «ДополнениеТаблицы» от реквизита к прокси
+      sections.push({
+        children: [{
+          idSuffix: lastSegment,
+          name: lastSegment,
+          item: { itemType: "AdditionalColumnsProxy", table: tablePath },
+        }],
+        edgeKind: ADDITION_EDGE_KIND,
+        edgeYaml: ADDITION_EDGE_YAML,
+      })
+
+      // (2) Reference-ребро «Таблица» от прокси к ТЧ через resolveFormLocalPath
+      sections.push({
+        formLocalReferences: [{
+          formLocalPath: tablePath,
+          formNodeId,
+          parentOverride: proxyNodeId,
+        }],
+        edgeKind: TABLE_EDGE_KIND,
+        edgeYaml: TABLE_EDGE_YAML,
+      })
+
+      // (3) Дочерние колонки прокси + рекурсия по FormAttributeColumnRules
+      const columnChildren: GraphOpsChild[] = []
+      const columnRecurses: GraphOpsRecurse[] = []
+      for (const column of group.columns) {
+        const columnName = column.name
+        if (!columnName) continue
+        columnChildren.push({
+          idSuffix: columnName,
+          name: columnName,
+          item: column as unknown as Record<string, unknown>,
+          parentOverride: proxyNodeId,
+        })
+        columnRecurses.push({
+          model: column as unknown as Record<string, unknown>,
+          rule: FormAttributeColumnRules,
+          parentNodeId: `${proxyNodeId}.${columnName}`,
+        })
+      }
+      if (columnChildren.length > 0) {
+        sections.push({
+          children: columnChildren,
+          recurse: columnRecurses,
+          edgeKind: ADDITIONAL_COLUMN_EDGE_KIND,
+          edgeYaml: ADDITIONAL_COLUMN_EDGE_YAML,
+        })
+      }
+    }
+
+    return sections.length > 0 ? sections : undefined
+  }
+
+  // ---- Inner columns ----
+  const columnsKey = propRule.yaml // "Колонки"
+  const columnsYamlMap = columnsKey && yamlMap ? findSubmap(yamlMap, columnsKey) : undefined
+
+  const children: GraphOpsChild[] = []
+  const recurses: GraphOpsRecurse[] = []
+  for (const raw of model) {
+    const column = raw as FormAttributeColumn
+    const columnName = column.name
+    if (!columnName) continue
+
+    children.push({
+      idSuffix: columnName,
+      name: columnName,
+      item: column as unknown as Record<string, unknown>,
+    })
+    recurses.push({
+      model: column as unknown as Record<string, unknown>,
+      yamlMap: columnsYamlMap ? findSubmap(columnsYamlMap, columnName) : undefined,
+      rule: FormAttributeColumnRules,
+      parentNodeId: `${parentNodeId}.${columnName}`,
+    })
+  }
+
+  if (children.length === 0) return undefined
+
+  return [{
+    children,
+    recurse: recurses,
+    edgeKind: COLUMN_EDGE_KIND,
+    edgeYaml: COLUMN_EDGE_YAML,
+  }]
+}
+
+registerTypeRule("FormAttributeColumns", "buildGraphFromModel", buildFormAttributeColumnsGraph)
+```
+
+Изменения относительно прежнего файла:
+- Удалены импорты `buildGraphFromModel` (внешнего рекурсивного вызова) и `resolveFormLocalPath` — оба теперь делегированы оркестратору и `applyGraphOps`.
+- Из деструктуризации убран `graph`.
+- Все мутации заменены на возврат секций `GraphOps[]` с декларациями `children`/`formLocalReferences`/`recurse`.
+- В `additional`-ветке три отдельные секции: прокси, ребро TABLE, колонки. У каждой — собственный `parentOverride` где нужно.
+
+- [ ] **Step 5: Прогнать тесты ядра**
+
+```bash
+pnpm --filter @nakidka/core test
+```
+
+Expected: PASS — `formAttribute/graphFromModel.test.ts` остаётся зелёным. Все три кейса (inner / additional / mixed) проходят через новый поток.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  packages/core/metadata/orchestration/property/fn.ts \
+  packages/core/metadata/relations/applyGraphOps.ts \
+  packages/core/metadata/orchestration/buildGraphFromModel.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts
+git commit -m "$(cat <<'EOF'
+refactor: :recycle: перевести FormAttributeColumns buildGraphFromModel на чистую форму
+
+GraphOps расширен: GraphOpsChild.item для записи node.item при promoteNode,
+GraphOpsChild.parentOverride / GraphOpsFormLocalReference.parentOverride для
+рёбер от не-parentNodeId узла, GraphOps.recurse для рекурсивного обхода
+подмодели по правилу. Оркестратор сам разворачивает recurse-задачи через
+повторный вызов buildGraphFromModel.
+
+FormAttributeColumns обработчик стал чистой функцией: возвращает GraphOps[]
+с декларациями children/formLocalReferences/recurse — и для inner-, и для
+additional-ветки. Поведение в MetadataGraph идентично прежнему.
+EOF
+)"
+```
+
+---
+
+## Task 7: Самопроверка фазы 1b и подведение итога
+
+**Files:** —
+
+- [ ] **Step 1: Прогнать полный тестовый набор проекта**
+
+```bash
+cd /Users/nikita/git/nakidka-core/.claude/worktrees/graph-pure-functions
+pnpm test
+```
+
+Expected: PASS — все ~2531 тестов остаются зелёными во всех пакетах.
+
+- [ ] **Step 2: Убедиться, что 6 файлов мигрированы**
+
+```bash
+grep -l "applyGraphOps\b" \
+  packages/core/metadata/commonObjects/metadataValue/graphFromModel.ts \
+  packages/core/metadata/commonObjects/metadataRef/graphFromModel.ts \
+  packages/core/metadata/forms/commonObjects/commandName/graphFromModel.ts \
+  packages/core/metadata/forms/commonObjects/associatedTable/graphFromModel.ts \
+  packages/core/metadata/forms/commonObjects/dataPath/graphFromModel.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts \
+  2>/dev/null
+```
+
+Expected: пустой вывод — `applyGraphOps` ни в одном из шести файлов не вызывается.
+
+```bash
+grep -E "(\bgraph\b\s*[,:]\s*MetadataGraph|graph\.(promoteNode|ensureNode|ensureEdge))" \
+  packages/core/metadata/commonObjects/metadataValue/graphFromModel.ts \
+  packages/core/metadata/commonObjects/metadataRef/graphFromModel.ts \
+  packages/core/metadata/forms/commonObjects/commandName/graphFromModel.ts \
+  packages/core/metadata/forms/commonObjects/associatedTable/graphFromModel.ts \
+  packages/core/metadata/forms/commonObjects/dataPath/graphFromModel.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts \
+  2>/dev/null
+```
+
+Expected: пустой вывод — никаких прямых обращений к `graph.*`.
+
+- [ ] **Step 3: Подтвердить, что `forms/elements` остался единственным legacy-обработчиком**
+
+```bash
+grep -l "applyGraphOps\|graph\.\(promoteNode\|ensureNode\|ensureEdge\)" $(find packages/core/metadata -name "graphFromModel.ts")
+```
+
+Expected: только `packages/core/metadata/forms/elements/graphFromModel.ts`. Это подтверждает, что 1b закрыта, а `forms/elements` уезжает в 1c.
+
+- [ ] **Step 4: Финальный commit (если остались no-op изменения, иначе пропустить)**
+
+Если выше остались несостыковки в типах или импорты — поправить и закоммитить отдельным commit. Иначе шаг пропустить.
+
+---
+
+## Самопроверка
+
+После выполнения 7 задач:
+
+- 6 файлов `graphFromModel.ts` (все, кроме `forms/elements`) переведены на чистый возврат `GraphOps`/`GraphOps[]` без обращения к `graph` и `applyGraphOps`. В сумме с `metadataField` (фаза 1a) — 7 из 8 файлов с `BuildGraphFromModelFunction`-обработчиками чистые.
+- `GraphOps` обогащён декларативными полями: `children.item`, `children.parentOverride`, `formLocalReferences` (с `parentOverride`), `recurse`. `applyGraphOps` и оркестратор обрабатывают новые поля.
+- Возврат `BuildGraphFromModelFunction` расширен до `GraphOps | GraphOps[] | undefined | void` для поддержки многосекционного результата (`metadataValue.fixedArray` со смешанными kind'ами VALUE/OBJECT).
+- Поведение в `MetadataGraph` идентично прежнему — все integration-тесты `*/graphFromModel.test.ts` остаются зелёными.
+- Все ~2531 тестов проекта проходят.
+
+## Что НЕ входит в этот план
+
+- **Фаза 1c — `forms/elements/graphFromModel.ts`.** Самая сложная миграция: плоская раскладка узлов через `formNodeId.Элемент.<name>`, ребро от `formNodeId` (а не от непосредственного контейнера) для синглетов, дублированный обход свойств через `buildElementChildrenGraph`. Требует расширения `GraphOpsChild.absoluteId` (полный override childNodeId, а не только parentNodeId) и `edgeFrom` (источник ребра ≠ parentOverride). Дополнительно — выделить общий хелпер `applyBuildGraphResult(result, propType, ctx)` для нормализации `GraphOps | GraphOps[] → posекционное applyGraphOps`, переиспользуемый в `buildElementChildrenGraph` и основном `orchestration/buildGraphFromModel.ts` (сейчас дублируется; долг введён в Task 3 фазы 1b как минимально-необходимая мера, без которой чистый возврат в свойствах элементов формы молча игнорировался). После 1c: снимаем `graph: MetadataGraph` из сигнатуры `BuildGraphFromModelFunction`.
+- **Фаза 1d — чистый агрегатор `buildGraph(yamlFiles, context) → FileGraphData[]` + `flattenOps`.** Подсистема (Г) спеки.
+- **Фаза 1e — переезд CLI `nkdk update-graph` на `buildGraph + updateGraph(@nakidka/graph)` и удаление graphology, `MetadataGraph`, `applyGraphOps`, `GraphWalker`, `validateProject`, dead-кода в extension.** Подсистемы (В)+(Е) спеки.

--- a/packages/core/metadata/commonObjects/metadataRef/graphFromModel.ts
+++ b/packages/core/metadata/commonObjects/metadataRef/graphFromModel.ts
@@ -1,7 +1,10 @@
 import { isPair, isScalar, isSeq, YAMLSeq } from "yaml"
-import { applyGraphOps } from "~/metadata/relations/applyGraphOps"
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
-import { BuildGraphFromModelFunction, ExtractGraphFromModelFunction, GraphOps } from "~/metadata/orchestration/property/fn"
+import {
+  BuildGraphFromModelFunction,
+  ExtractGraphFromModelFunction,
+  GraphOps,
+} from "~/metadata/orchestration/property/fn"
 import { findSeqItemOffset } from "~/metadata/orchestration/property/position"
 import { extractReferenceFromPath } from "~/metadata/orchestration/property/extractReferenceFromPath"
 import { MetadataItemLink, MetadataItemLinks } from "./types"
@@ -11,7 +14,7 @@ const EDGE_YAML = "Объект"
 
 const extractMetadataItemLinkGraph: ExtractGraphFromModelFunction = (
   model,
-  position
+  position,
 ): GraphOps | undefined => {
   const link = model as MetadataItemLink
   if (!link) return undefined
@@ -22,18 +25,17 @@ const extractMetadataItemLinkGraph: ExtractGraphFromModelFunction = (
 
 const buildMetadataItemLinksGraph: BuildGraphFromModelFunction = ({
   model,
-  parentNodeId,
-  filePath,
   yamlMap,
   propRule,
-  graph,
-}) => {
+}): GraphOps | undefined => {
   const links = model as MetadataItemLinks | undefined
-  if (!Array.isArray(links) || links.length === 0) return
+  if (!Array.isArray(links) || links.length === 0) return undefined
 
   let yamlSeq: YAMLSeq | undefined
   if (yamlMap && propRule.yaml) {
-    const pair = yamlMap.items.find((i) => isPair(i) && isScalar(i.key) && i.key.value === propRule.yaml)
+    const pair = yamlMap.items.find(
+      (i) => isPair(i) && isScalar(i.key) && i.key.value === propRule.yaml,
+    )
     if (pair && isPair(pair) && isSeq(pair.value)) {
       yamlSeq = pair.value as YAMLSeq
     }
@@ -47,9 +49,9 @@ const buildMetadataItemLinksGraph: BuildGraphFromModelFunction = ({
     })
     .filter((ref): ref is NonNullable<typeof ref> => ref !== undefined)
 
-  if (references.length > 0) {
-    applyGraphOps({ references }, { graph, parentNodeId, filePath, edgeKind: EDGE_KIND, edgeYaml: EDGE_YAML })
-  }
+  if (references.length === 0) return undefined
+
+  return { references, edgeKind: EDGE_KIND, edgeYaml: EDGE_YAML }
 }
 
 registerTypeRule("MetadataItemLink", "extractGraph", extractMetadataItemLinkGraph)

--- a/packages/core/metadata/commonObjects/metadataValue/graphFromModel.test.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/graphFromModel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { parseDocument } from "yaml"
 import { MetadataGraph } from "~/metadata/relations/MetadataGraph"
 import { extractSingleValueRef, buildMetadataValueGraph } from "./graphFromModel"
+import { applyGraphOps } from "~/metadata/relations/applyGraphOps"
 import {
   MetadataFixedArrayValue,
   MetadataFormChoiceListValue,
@@ -20,6 +21,21 @@ function makeGraph() {
   const graph = new MetadataGraph()
   graph.ensureNode(PARENT_NODE, { name: "Товары", filePaths: [FILE_PATH] })
   return graph
+}
+
+function runBuild(params: Parameters<typeof buildMetadataValueGraph>[0]) {
+  const result = buildMetadataValueGraph(params)
+  const sections = Array.isArray(result) ? result : result ? [result] : []
+  for (const section of sections) {
+    if (!section.edgeKind || !section.edgeYaml) continue
+    applyGraphOps(section, {
+      graph: params.graph,
+      parentNodeId: params.parentNodeId,
+      filePath: params.filePath,
+      edgeKind: section.edgeKind,
+      edgeYaml: section.edgeYaml,
+    })
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -107,7 +123,7 @@ describe("buildMetadataValueGraph", () => {
   it("примитив → не создаёт рёбер", () => {
     const graph = makeGraph()
     const value: MetadataTypedValue = { type: "string", value: "привет" }
-    buildMetadataValueGraph({
+    runBuild({
       model: value,
       parentNodeId: PARENT_NODE,
       filePath: FILE_PATH,
@@ -121,7 +137,7 @@ describe("buildMetadataValueGraph", () => {
   it("ref → создаёт ребро kind Значение", () => {
     const graph = makeGraph()
     const value: MetadataRefValue = { type: "ref", value: "Catalog.Пользователи.EmptyRef" }
-    buildMetadataValueGraph({
+    runBuild({
       model: value,
       parentNodeId: PARENT_NODE,
       filePath: FILE_PATH,
@@ -140,7 +156,7 @@ describe("buildMetadataValueGraph", () => {
   it("objectRef → создаёт ребро kind Объект", () => {
     const graph = makeGraph()
     const value: MetadataObjectRefValue = { type: "objectRef", value: "Catalog.Контрагенты" }
-    buildMetadataValueGraph({
+    runBuild({
       model: value,
       parentNodeId: PARENT_NODE,
       filePath: FILE_PATH,
@@ -157,7 +173,7 @@ describe("buildMetadataValueGraph", () => {
 
   it("undefined model → не создаёт рёбер", () => {
     const graph = makeGraph()
-    buildMetadataValueGraph({
+    runBuild({
       model: undefined,
       parentNodeId: PARENT_NODE,
       filePath: FILE_PATH,
@@ -172,7 +188,7 @@ describe("buildMetadataValueGraph", () => {
     it("пустой fixedArray → не создаёт рёбер", () => {
       const graph = makeGraph()
       const value: MetadataFixedArrayValue = { type: "fixedArray", value: [] }
-      buildMetadataValueGraph({
+      runBuild({
         model: value,
         parentNodeId: PARENT_NODE,
         filePath: FILE_PATH,
@@ -201,7 +217,7 @@ describe("buildMetadataValueGraph", () => {
       ]
       const value: MetadataFixedArrayValue = { type: "fixedArray", value: items }
 
-      buildMetadataValueGraph({
+      runBuild({
         model: value,
         parentNodeId: PARENT_NODE,
         filePath: FILE_PATH,
@@ -237,7 +253,7 @@ describe("buildMetadataValueGraph", () => {
         presentation: { items: { ru: "Текст" } },
         value: undefined,
       }
-      buildMetadataValueGraph({
+      runBuild({
         model: value,
         parentNodeId: PARENT_NODE,
         filePath: FILE_PATH,
@@ -255,7 +271,7 @@ describe("buildMetadataValueGraph", () => {
         presentation: { items: { ru: "Физическое лицо" } },
         value: { type: "ref", value: "Enum.ВидыДоговоров.EnumValue.СПоставщиком" },
       }
-      buildMetadataValueGraph({
+      runBuild({
         model: value,
         parentNodeId: PARENT_NODE,
         filePath: FILE_PATH,
@@ -277,7 +293,7 @@ describe("buildMetadataValueGraph", () => {
         presentation: { items: { ru: "Метка" } },
         value: { type: "string", value: "строка" },
       }
-      buildMetadataValueGraph({
+      runBuild({
         model: value,
         parentNodeId: PARENT_NODE,
         filePath: FILE_PATH,

--- a/packages/core/metadata/commonObjects/metadataValue/graphFromModel.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/graphFromModel.ts
@@ -1,7 +1,10 @@
 import { isPair, isScalar, isSeq, YAMLSeq } from "yaml"
-import { applyGraphOps } from "~/metadata/relations/applyGraphOps"
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
-import { BuildGraphFromModelFunction, GraphOpsReference } from "~/metadata/orchestration/property/fn"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+  GraphOpsReference,
+} from "~/metadata/orchestration/property/fn"
 import { computeValuePosition, findSeqItemOffset, findSubmap } from "~/metadata/orchestration/property/position"
 import { extractReferenceFromPath } from "~/metadata/orchestration/property/extractReferenceFromPath"
 import { convertPath } from "~/metadata/commonObjects/metadataPath/helper"
@@ -20,38 +23,20 @@ const REF_EDGE_YAML = "Значение"
 const OBJECT_REF_EDGE_KIND = "OBJECT"
 const OBJECT_REF_EDGE_YAML = "Объект"
 
-/**
- * Конвертирует внутренний путь ref-значения (XML-формат) в node ID графа (YAML-формат).
- *
- * Примеры:
- *   "Catalog.X.EmptyRef"               → "Справочник.X.ПустаяСсылка"
- *   "Enum.ВидыДоговоров.EnumValue.Z"  → "Перечисление.ВидыДоговоров.Z"
- *   "" или неизвестный префикс        → undefined
- */
 function convertRefValueToNodeId(refValue: string): string | undefined {
   if (!refValue) return undefined
-
-  // Для Enum: убираем служебный сегмент "EnumValue"
   let processedPath = refValue
   if (refValue.startsWith("Enum.")) {
     processedPath = refValue.split(".").filter((p) => p !== "EnumValue").join(".")
   }
-
   const nodeId = convertPath(MetadataValuesRulesToYAML, processedPath)
-
-  // Если первый сегмент не был конвертирован — префикс неизвестен, возвращаем undefined
   const dotInInput = processedPath.indexOf(".")
   const dotInOutput = nodeId.indexOf(".")
   if (dotInInput === -1 || dotInOutput === -1) return undefined
   if (processedPath.substring(0, dotInInput) === nodeId.substring(0, dotInOutput)) return undefined
-
   return nodeId
 }
 
-/**
- * Извлекает GraphOpsReference из одного примитивного MetadataTypedValue.
- * Поддерживает только ref и objectRef; примитивы → undefined.
- */
 export function extractSingleValueRef(
   value: MetadataTypedValue,
   position?: { offset: number },
@@ -67,41 +52,26 @@ export function extractSingleValueRef(
       yaml: REF_EDGE_YAML,
     }
   }
-
   if (value.type === "objectRef") {
     const ref = extractReferenceFromPath((value as MetadataObjectRefValue).value, position)
     if (!ref) return undefined
     return { ref, kind: OBJECT_REF_EDGE_KIND, yaml: OBJECT_REF_EDGE_YAML }
   }
-
   return undefined
 }
 
-/**
- * Строит рёбра графа из MetadataValue-свойства.
- *
- * - Примитивы (string, decimal, dateTime, boolean, ApplicationUsePurpose) → no-op
- * - ref → ребро kind «Значение» к целевому узлу (YAML-формат)
- * - objectRef → ребро kind «Объект» к целевому узлу
- * - fixedArray → рекурсивно по элементам с per-element YAML-позициями
- * - formChoiceListDesTimeValue → рекурсивно в .value
- */
 export const buildMetadataValueGraph: BuildGraphFromModelFunction = ({
   model,
-  parentNodeId,
-  filePath,
   yamlMap,
   propRule,
-  graph,
-}) => {
+}): GraphOps[] | undefined => {
   const value = model as MetadataValue | undefined
-  if (!value) return
+  if (!value) return undefined
 
   if (value.type === "fixedArray") {
     const items = (value as MetadataFixedArrayValue).value
-    if (items.length === 0) return
+    if (items.length === 0) return undefined
 
-    // Находим YAML-последовательность для per-element позиций
     let yamlSeq: YAMLSeq | undefined
     if (yamlMap && propRule.yaml) {
       const pair = yamlMap.items.find(
@@ -112,7 +82,6 @@ export const buildMetadataValueGraph: BuildGraphFromModelFunction = ({
       }
     }
 
-    // Собираем ссылки, группируя по kind
     const refsByKind = new Map<string, { yaml: string; refs: GraphOpsReference[] }>()
     items.forEach((item, index) => {
       const offset = yamlSeq ? findSeqItemOffset(yamlSeq, index) : undefined
@@ -128,23 +97,17 @@ export const buildMetadataValueGraph: BuildGraphFromModelFunction = ({
       bucket.refs.push(ref)
     })
 
+    if (refsByKind.size === 0) return undefined
+    const sections: GraphOps[] = []
     for (const [kind, { yaml, refs }] of refsByKind) {
-      applyGraphOps({ references: refs }, {
-        graph,
-        parentNodeId,
-        filePath,
-        edgeKind: kind,
-        edgeYaml: yaml,
-      })
+      sections.push({ references: refs, edgeKind: kind, edgeYaml: yaml })
     }
-    return
+    return sections
   }
 
   if (value.type === "formChoiceListDesTimeValue") {
     const inner = (value as MetadataFormChoiceListValue).value
-    if (!inner) return
-
-    // Пытаемся найти позицию вложенного «Значение»
+    if (!inner) return undefined
     let innerPosition: { offset: number } | undefined
     if (yamlMap && propRule.yaml) {
       const innerMap = findSubmap(yamlMap, propRule.yaml)
@@ -154,31 +117,16 @@ export const buildMetadataValueGraph: BuildGraphFromModelFunction = ({
         innerPosition = computeValuePosition(yamlMap, propRule.yaml)
       }
     }
-
     const extracted = extractSingleValueRef(inner, innerPosition)
-    if (!extracted) return
-    applyGraphOps({ references: [extracted.ref] }, {
-      graph,
-      parentNodeId,
-      filePath,
-      edgeKind: extracted.kind,
-      edgeYaml: extracted.yaml,
-    })
-    return
+    if (!extracted) return undefined
+    return [{ references: [extracted.ref], edgeKind: extracted.kind, edgeYaml: extracted.yaml }]
   }
 
-  // Простой ref или objectRef
   const position =
     yamlMap && propRule.yaml ? computeValuePosition(yamlMap, propRule.yaml) : undefined
   const extracted = extractSingleValueRef(value, position ?? undefined)
-  if (!extracted) return
-  applyGraphOps({ references: [extracted.ref] }, {
-    graph,
-    parentNodeId,
-    filePath,
-    edgeKind: extracted.kind,
-    edgeYaml: extracted.yaml,
-  })
+  if (!extracted) return undefined
+  return [{ references: [extracted.ref], edgeKind: extracted.kind, edgeYaml: extracted.yaml }]
 }
 
 registerTypeRule("MetadataValue", "buildGraphFromModel", buildMetadataValueGraph)

--- a/packages/core/metadata/forms/commonObjects/associatedTable/graphFromModel.ts
+++ b/packages/core/metadata/forms/commonObjects/associatedTable/graphFromModel.ts
@@ -5,33 +5,36 @@
  * элемент-таблицу внутри той же формы (по имени элемента). Материализуется как
  * reference-ребро «СвязаннаяТаблица» от узла элемента к узлу таблицы.
  *
- * Если узел таблицы не существует в графе — создаётся заглушка (без filePaths).
- * formNodeId пробрасывается через extra от buildElementChildrenGraph.
+ * Если узел таблицы не существует — applyGraphOps создаст заглушку.
+ * formNodeId пробрасывается через extra от forms/elements.
  */
 
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { registerEdgeKind } from "~/metadata/relations/edgeKinds"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+} from "~/metadata/orchestration/property/fn"
 
 const EDGE_KIND = "ASSOCIATED_TABLE"
 const EDGE_YAML = "СвязаннаяТаблица"
 
 registerEdgeKind(EDGE_KIND, { yaml: EDGE_YAML, owning: false })
 
-registerTypeRule("AssociatedTable", "buildGraphFromModel", ({ model, parentNodeId, graph, extra }) => {
-  if (typeof model !== "string" || !model) return
-
-  // formNodeId пробрасывается через extra от buildElementChildrenGraph
+const buildAssociatedTableGraph: BuildGraphFromModelFunction = ({
+  model,
+  extra,
+}): GraphOps | undefined => {
+  if (typeof model !== "string" || !model) return undefined
   const formNodeId = extra?.formNodeId as string | undefined
-  if (!formNodeId) return
+  if (!formNodeId) return undefined
 
   const targetId = `${formNodeId}.Элемент.${model}`
+  return {
+    references: [{ id: targetId, name: model }],
+    edgeKind: EDGE_KIND,
+    edgeYaml: EDGE_YAML,
+  }
+}
 
-  // Создаём заглушку, если элемент-таблица ещё не зарегистрирован
-  graph.ensureNode(targetId, { name: model })
-
-  const edgeKey = `${parentNodeId}:${EDGE_KIND}:${targetId}`
-  graph.ensureEdge(edgeKey, parentNodeId, targetId, {
-    yaml: EDGE_YAML,
-    kind: EDGE_KIND,
-  })
-})
+registerTypeRule("AssociatedTable", "buildGraphFromModel", buildAssociatedTableGraph)

--- a/packages/core/metadata/forms/commonObjects/commandName/graphFromModel.ts
+++ b/packages/core/metadata/forms/commonObjects/commandName/graphFromModel.ts
@@ -4,33 +4,36 @@
  * PRD #121: свойство commandName на кнопках формы — имя команды в текущей форме.
  * Материализуется как reference-ребро «ИмяКоманды» от узла кнопки к узлу команды формы.
  *
- * Если команды с таким именем нет в форме — создаётся заглушка.
- * formNodeId пробрасывается через extra от buildElementChildrenGraph.
+ * Если команды с таким именем нет в форме — создаётся заглушка через ensureNode
+ * в applyGraphOps. formNodeId пробрасывается через extra от forms/elements.
  */
 
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { registerEdgeKind } from "~/metadata/relations/edgeKinds"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+} from "~/metadata/orchestration/property/fn"
 
 const EDGE_KIND = "COMMAND_NAME"
 const EDGE_YAML = "ИмяКоманды"
 
 registerEdgeKind(EDGE_KIND, { yaml: EDGE_YAML, owning: false })
 
-registerTypeRule("CommandName", "buildGraphFromModel", ({ model, parentNodeId, graph, extra }) => {
-  if (typeof model !== "string" || !model) return
-
-  // formNodeId пробрасывается через extra от buildElementChildrenGraph
+const buildCommandNameGraph: BuildGraphFromModelFunction = ({
+  model,
+  extra,
+}): GraphOps | undefined => {
+  if (typeof model !== "string" || !model) return undefined
   const formNodeId = extra?.formNodeId as string | undefined
-  if (!formNodeId) return
+  if (!formNodeId) return undefined
 
   const targetId = `${formNodeId}.Команда.${model}`
+  return {
+    references: [{ id: targetId, name: model }],
+    edgeKind: EDGE_KIND,
+    edgeYaml: EDGE_YAML,
+  }
+}
 
-  // Создаём заглушку, если команда ещё не зарегистрирована в форме
-  graph.ensureNode(targetId, { name: model })
-
-  const edgeKey = `${parentNodeId}:${EDGE_KIND}:${targetId}`
-  graph.ensureEdge(edgeKey, parentNodeId, targetId, {
-    yaml: EDGE_YAML,
-    kind: EDGE_KIND,
-  })
-})
+registerTypeRule("CommandName", "buildGraphFromModel", buildCommandNameGraph)

--- a/packages/core/metadata/forms/commonObjects/dataPath/graphFromModel.ts
+++ b/packages/core/metadata/forms/commonObjects/dataPath/graphFromModel.ts
@@ -5,51 +5,45 @@
  * от узла элемента к узлу целевого реквизита/колонки.
  *
  * Kind ребра определяется по правилу yaml-name (PRD #114):
- * propRule.graphEdgeKind ?? propRule.yaml:
- * - dataPath     → ПутьКДанным
- * - footerDataPath → ПутьКДаннымПодвала
- * - titleDataPath  → ПутьКДаннымЗаголовка
- * - rowPictureDataPath → ПутьКДаннымКартинкиСтроки
+ * propRule.graphEdgeKind ?? getKindByYaml(propRule.yaml).
  *
- * При отсутствии первого сегмента (невалидное имя реквизита формы) →
- * resolveFormLocalPath вернёт undefined → ребро не создаётся, стаб не создаётся.
- * При валидном первом сегменте, но отсутствующем конечном узле →
- * resolveFormLocalPath создаёт заглушку, ребро ведёт на заглушку.
+ * Резолвинг цели делегирован applyGraphOps через formLocalReferences —
+ * оркестратор вызовет resolveFormLocalPath при записи в граф.
  */
 
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { getKindByYaml, registerEdgeKind } from "~/metadata/relations/edgeKinds"
-import { resolveFormLocalPath } from "~/metadata/relations/resolveFormLocalPath"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+} from "~/metadata/orchestration/property/fn"
 
-// Reference-виды рёбер dataPath-свойств (PRD #118).
-// Зарегистрированы централизованно в edgeKinds.ts; повторные registerEdgeKind
-// здесь — идемпотентная страховка на случай, если порядок импортов отличается.
 registerEdgeKind("DATA_PATH", { yaml: "ПутьКДанным", owning: false })
 registerEdgeKind("FOOTER_DATA_PATH", { yaml: "ПутьКДаннымПодвала", owning: false })
 registerEdgeKind("TITLE_DATA_PATH", { yaml: "ПутьКДаннымЗаголовка", owning: false })
 registerEdgeKind("ROW_PICTURE_DATA_PATH", { yaml: "ПутьКДаннымКартинкиСтроки", owning: false })
 
-registerTypeRule("DataPath", "buildGraphFromModel", ({ model, parentNodeId, propRule, graph, extra }) => {
-  if (typeof model !== "string" || !model) return
-
-  // formNodeId пробрасывается через extra от buildElementChildrenGraph
+const buildDataPathGraph: BuildGraphFromModelFunction = ({
+  model,
+  propRule,
+  extra,
+}): GraphOps | undefined => {
+  if (typeof model !== "string" || !model) return undefined
   const formNodeId = extra?.formNodeId as string | undefined
-  if (!formNodeId) return
+  if (!formNodeId) return undefined
 
-  // edgeYaml — русский YAML-ключ свойства; edgeKind вычисляется через перевод
   const edgeYaml = propRule.yaml
-  if (!edgeYaml) return
+  if (!edgeYaml) return undefined
   const edgeKind =
     ((propRule as Record<string, unknown>).graphEdgeKind as string | undefined) ??
     getKindByYaml(edgeYaml)
-  if (!edgeKind) return
+  if (!edgeKind) return undefined
 
-  const resolved = resolveFormLocalPath({ formNodeId, path: model, graph })
-  if (!resolved) return
+  return {
+    formLocalReferences: [{ formLocalPath: model, formNodeId }],
+    edgeKind,
+    edgeYaml,
+  }
+}
 
-  const edgeKey = `${parentNodeId}:${edgeKind}:${resolved.targetId}`
-  graph.ensureEdge(edgeKey, parentNodeId, resolved.targetId, {
-    yaml: edgeYaml,
-    kind: edgeKind,
-  })
-})
+registerTypeRule("DataPath", "buildGraphFromModel", buildDataPathGraph)

--- a/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.test.ts
@@ -115,7 +115,7 @@ describe("FormAttributeColumns buildGraphFromModel", () => {
     expect(typeEdges[0].target).toBe("Справочник.Контрагенты")
   })
 
-  it("additional-колонки (с полем table) → no-op (срез #116)", () => {
+  it("additional-колонки (с полем table) → прокси-узел + ребро ДополнениеТаблицы", () => {
     const graph = makeGraph()
     graph.ensureNode(ATTR_NODE_ID, { name: "Объект" })
 
@@ -137,11 +137,25 @@ describe("FormAttributeColumns buildGraphFromModel", () => {
       filePath: FILE_PATH,
     })
 
-    // Additional-ветка не обрабатывается в этом срезе
-    const edges = [...graph.outEdgeEntries(ATTR_NODE_ID)].filter(
-      (e) => e.attributes.kind === "FORM_COLUMN",
+    // Прокси-узел существует
+    const proxyNodeId = `${ATTR_NODE_ID}.КакаяТоТаблица`
+    expect(graph.hasNode(proxyNodeId)).toBe(true)
+
+    // Owning-ребро «ДополнениеТаблицы» от реквизита к прокси
+    const additionEdges = [...graph.outEdgeEntries(ATTR_NODE_ID)].filter(
+      (e) => e.attributes.kind === "TABLE_EXTENSION",
     )
-    expect(edges).toHaveLength(0)
+    expect(additionEdges).toHaveLength(1)
+    expect(additionEdges[0].target).toBe(proxyNodeId)
+
+    // Дочерняя колонка под прокси
+    const columnNodeId = `${proxyNodeId}.КолонкаТаблицы`
+    expect(graph.hasNode(columnNodeId)).toBe(true)
+    const additionalColumnEdges = [...graph.outEdgeEntries(proxyNodeId)].filter(
+      (e) => e.attributes.kind === "ADDITIONAL_COLUMN",
+    )
+    expect(additionalColumnEdges).toHaveLength(1)
+    expect(additionalColumnEdges[0].target).toBe(columnNodeId)
   })
 
   it("узел колонки несёт item и filePaths", () => {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts
@@ -1,7 +1,11 @@
-import { buildGraphFromModel } from "~/metadata/orchestration/buildGraphFromModel"
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { findSubmap } from "~/metadata/orchestration/property/position"
-import { resolveFormLocalPath } from "~/metadata/relations/resolveFormLocalPath"
+import {
+  BuildGraphFromModelFunction,
+  GraphOps,
+  GraphOpsChild,
+  GraphOpsRecurse,
+} from "~/metadata/orchestration/property/fn"
 import { FormAttributeColumnRules, FormAttributeRules } from "./rules"
 import type { FormAttributeAdditionalColumns, FormAttributeColumn } from "./types"
 
@@ -15,12 +19,7 @@ const ADDITIONAL_COLUMN_EDGE_KIND = "ADDITIONAL_COLUMN"
 const ADDITIONAL_COLUMN_EDGE_YAML = "ДополнительнаяКолонка"
 
 /**
- * Регистрирует graphChild для коллекции FormAttributes:
- * при построении графа формы каждый реквизит становится дочерним узлом
- * с owning-ребром «РеквизитФормы».
- *
- * Kind ребер TypeDescription (Тип, ТипЗначения) определяется автоматически
- * из yaml-имени свойства по правилу PRD #114.
+ * graphChild для коллекции FormAttributes — оркестратор сам создаёт дочерние узлы.
  */
 registerTypeRule("FormAttributes", "graphChild", {
   idFrom: "name",
@@ -31,125 +30,126 @@ registerTypeRule("FormAttributes", "graphChild", {
 })
 
 /**
- * Обрабатывает коллекцию колонок реквизита формы (FormAttributeColumns).
+ * Обрабатывает коллекцию колонок реквизита формы.
  *
- * PRD #115: различает два вида колонок по форме первого элемента:
- * - inner (тип реквизита = ТаблицаЗначений / ДеревоЗначений / СписокВыбора):
- *   каждая колонка → узел <реквизит>.<имяКолонки> + owning-ребро «КолонкаФормы»
- *   + рекурсивный buildGraphFromModel для TypeDescription (ребро «Тип»).
- * - additional (дополнительные колонки к реквизитам прикладного объекта):
- *   обработка отложена до среза #116 (no-op здесь).
+ * - inner: тип реквизита = ТаблицаЗначений / ДеревоЗначений / СписокВыбора.
+ *   Колонка → дочерний узел `<реквизит>.<колонка>` + ребро «КолонкаФормы»
+ *   + recurse по FormAttributeColumnRules для типов колонки.
+ * - additional: дополнительные колонки к реквизитам прикладного объекта.
+ *   Прокси-узел `<реквизит>.<lastSeg(table)>` + ребро «ДополнениеТаблицы»,
+ *   ребро «Таблица» от прокси к ТЧ через formLocalReferences,
+ *   per-column узлы под прокси + рёбра «ДополнительнаяКолонка»
+ *   + recurse по FormAttributeColumnRules.
  */
-registerTypeRule("FormAttributeColumns", "buildGraphFromModel", ({
+const buildFormAttributeColumnsGraph: BuildGraphFromModelFunction = ({
   model,
   parentNodeId,
-  filePath,
   yamlMap,
   propRule,
-  graph,
-}) => {
-  if (!Array.isArray(model) || model.length === 0) return
+}): GraphOps[] | undefined => {
+  if (!Array.isArray(model) || model.length === 0) return undefined
 
-  // Discriminate: если первый элемент имеет строковое поле table — это additional-ветка
   const first = model[0] as Record<string, unknown>
+
+  // ---- Additional columns (PRD #116) ----
   if (typeof first.table === "string") {
-    // Additional columns (PRD #116)
     // parentNodeId = <formNodeId>.Реквизит.<attrName>; формируем formNodeId обратным путём
     const formNodeId = parentNodeId.split(".").slice(0, -2).join(".")
+    const sections: GraphOps[] = []
 
     for (const raw of model) {
       const group = raw as FormAttributeAdditionalColumns
-      const tablePath = group.table // e.g. "Объект.Состав"
+      const tablePath = group.table
       const lastSegment = tablePath.split(".").pop()
       if (!lastSegment) continue
 
-      // Прокси-узел: <реквизит>.<lastSegment>
       const proxyNodeId = `${parentNodeId}.${lastSegment}`
-      graph.promoteNode(proxyNodeId, {
-        name: lastSegment,
-        filePaths: [filePath],
-        item: { itemType: "AdditionalColumnsProxy", table: tablePath },
+
+      // (1) Прокси-узел: owning-ребро «ДополнениеТаблицы» от реквизита к прокси
+      sections.push({
+        children: [{
+          idSuffix: lastSegment,
+          name: lastSegment,
+          item: { itemType: "AdditionalColumnsProxy", table: tablePath },
+        }],
+        edgeKind: ADDITION_EDGE_KIND,
+        edgeYaml: ADDITION_EDGE_YAML,
       })
 
-      // Owning-ребро «ДополнениеТаблицы» от реквизита к прокси
-      const proxyEdgeKey = `${parentNodeId}:${ADDITION_EDGE_KIND}:${proxyNodeId}`
-      graph.ensureEdge(proxyEdgeKey, parentNodeId, proxyNodeId, {
-        yaml: ADDITION_EDGE_YAML,
-        kind: ADDITION_EDGE_KIND,
+      // (2) Reference-ребро «Таблица» от прокси к ТЧ через resolveFormLocalPath
+      sections.push({
+        formLocalReferences: [{
+          formLocalPath: tablePath,
+          formNodeId,
+          parentOverride: proxyNodeId,
+        }],
+        edgeKind: TABLE_EDGE_KIND,
+        edgeYaml: TABLE_EDGE_YAML,
       })
 
-      // Резолвим tablePath → NodeId реальной ТЧ; reference-ребро «Таблица»
-      const resolved = resolveFormLocalPath({ formNodeId, path: tablePath, graph })
-      if (resolved) {
-        const tableEdgeKey = `${proxyNodeId}:${TABLE_EDGE_KIND}:${resolved.targetId}`
-        graph.ensureEdge(tableEdgeKey, proxyNodeId, resolved.targetId, {
-          yaml: TABLE_EDGE_YAML,
-          kind: TABLE_EDGE_KIND,
-        })
-      }
-
-      // Узлы-колонки под прокси
+      // (3) Дочерние колонки прокси + рекурсия по FormAttributeColumnRules
+      const columnChildren: GraphOpsChild[] = []
+      const columnRecurses: GraphOpsRecurse[] = []
       for (const column of group.columns) {
         const columnName = column.name
         if (!columnName) continue
-
-        const columnNodeId = `${proxyNodeId}.${columnName}`
-        graph.promoteNode(columnNodeId, {
+        columnChildren.push({
+          idSuffix: columnName,
           name: columnName,
-          filePaths: [filePath],
-          item: column,
+          item: column as unknown as Record<string, unknown>,
+          parentOverride: proxyNodeId,
         })
-
-        const colEdgeKey = `${proxyNodeId}:${ADDITIONAL_COLUMN_EDGE_KIND}:${columnNodeId}`
-        graph.ensureEdge(colEdgeKey, proxyNodeId, columnNodeId, {
-          yaml: ADDITIONAL_COLUMN_EDGE_YAML,
-          kind: ADDITIONAL_COLUMN_EDGE_KIND,
-        })
-
-        buildGraphFromModel({
-          model: column as Record<string, unknown>,
-          yamlMap: undefined,
+        columnRecurses.push({
+          model: column as unknown as Record<string, unknown>,
           rule: FormAttributeColumnRules,
-          graph,
-          parentNodeId: columnNodeId,
-          filePath,
+          parentNodeId: `${proxyNodeId}.${columnName}`,
+        })
+      }
+      if (columnChildren.length > 0) {
+        sections.push({
+          children: columnChildren,
+          recurse: columnRecurses,
+          edgeKind: ADDITIONAL_COLUMN_EDGE_KIND,
+          edgeYaml: ADDITIONAL_COLUMN_EDGE_YAML,
         })
       }
     }
-    return
+
+    return sections.length > 0 ? sections : undefined
   }
 
-  // Inner columns
+  // ---- Inner columns ----
   const columnsKey = propRule.yaml // "Колонки"
   const columnsYamlMap = columnsKey && yamlMap ? findSubmap(yamlMap, columnsKey) : undefined
 
+  const children: GraphOpsChild[] = []
+  const recurses: GraphOpsRecurse[] = []
   for (const raw of model) {
     const column = raw as FormAttributeColumn
     const columnName = column.name
     if (!columnName) continue
 
-    const columnNodeId = `${parentNodeId}.${columnName}`
-    const columnYamlMap = columnsYamlMap ? findSubmap(columnsYamlMap, columnName) : undefined
-
-    graph.promoteNode(columnNodeId, {
+    children.push({
+      idSuffix: columnName,
       name: columnName,
-      filePaths: [filePath],
-      item: column,
+      item: column as unknown as Record<string, unknown>,
     })
-
-    const edgeKey = `${parentNodeId}:${COLUMN_EDGE_KIND}:${columnNodeId}`
-    graph.ensureEdge(edgeKey, parentNodeId, columnNodeId, {
-      yaml: COLUMN_EDGE_YAML,
-      kind: COLUMN_EDGE_KIND,
-    })
-
-    buildGraphFromModel({
-      model: column as Record<string, unknown>,
-      yamlMap: columnYamlMap,
+    recurses.push({
+      model: column as unknown as Record<string, unknown>,
+      yamlMap: columnsYamlMap ? findSubmap(columnsYamlMap, columnName) : undefined,
       rule: FormAttributeColumnRules,
-      graph,
-      parentNodeId: columnNodeId,
-      filePath,
+      parentNodeId: `${parentNodeId}.${columnName}`,
     })
   }
-})
+
+  if (children.length === 0) return undefined
+
+  return [{
+    children,
+    recurse: recurses,
+    edgeKind: COLUMN_EDGE_KIND,
+    edgeYaml: COLUMN_EDGE_YAML,
+  }]
+}
+
+registerTypeRule("FormAttributeColumns", "buildGraphFromModel", buildFormAttributeColumnsGraph)

--- a/packages/core/metadata/forms/elements/graphFromModel.ts
+++ b/packages/core/metadata/forms/elements/graphFromModel.ts
@@ -15,6 +15,7 @@ import { getElementRule } from "~/metadata/orchestration/formElement/ruleFactory
 import { MetadataGraph } from "~/metadata/relations/MetadataGraph"
 import { PropertyRuleType } from "~/metadata/orchestration/property/registry"
 import { MetadataItemRule } from "~/metadata/orchestration/property/types"
+import { buildGraphFromModel } from "~/metadata/orchestration/buildGraphFromModel"
 import { applyGraphOps } from "~/metadata/relations/applyGraphOps"
 import { getKindByYaml } from "~/metadata/relations/edgeKinds"
 import { AutoCommandBarRules } from "./autoCommandBar/rules"
@@ -97,20 +98,36 @@ function buildElementChildrenGraph(params: {
     })
     const sections = Array.isArray(result) ? result : result ? [result] : []
     for (const section of sections) {
-      if (!section.children?.length && !section.references?.length && !section.formLocalReferences?.length) continue
-      if (!section.edgeKind || !section.edgeYaml) {
-        throw new Error(
-          `buildElementChildrenGraph: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +
-            `Чистые функции должны указывать оба поля в результате.`,
-        )
+      const hasOps =
+        section.children?.length ||
+        section.references?.length ||
+        section.formLocalReferences?.length
+      if (hasOps) {
+        if (!section.edgeKind || !section.edgeYaml) {
+          throw new Error(
+            `buildElementChildrenGraph: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +
+              `Чистые функции должны указывать оба поля в результате.`,
+          )
+        }
+        applyGraphOps(section, {
+          graph,
+          parentNodeId,
+          filePath,
+          edgeKind: section.edgeKind,
+          edgeYaml: section.edgeYaml,
+        })
       }
-      applyGraphOps(section, {
-        graph,
-        parentNodeId,
-        filePath,
-        edgeKind: section.edgeKind,
-        edgeYaml: section.edgeYaml,
-      })
+      for (const recurse of section.recurse ?? []) {
+        buildGraphFromModel({
+          model: recurse.model,
+          yamlMap: recurse.yamlMap,
+          rule: recurse.rule,
+          graph,
+          parentNodeId: recurse.parentNodeId,
+          filePath,
+          extra: recurse.extra ?? { formNodeId },
+        })
+      }
     }
   }
 }

--- a/packages/core/metadata/forms/elements/graphFromModel.ts
+++ b/packages/core/metadata/forms/elements/graphFromModel.ts
@@ -87,6 +87,8 @@ function buildElementChildrenGraph(params: {
     const value = element[key]
     if (value === undefined || value === null) continue
 
+    // TODO 1c: вынести в общий хелпер applyBuildGraphResult(result, propType, ctx) —
+    // дубликат с orchestration/buildGraphFromModel.ts (тот же five-step normalize-блок).
     const result = buildGraphFn({
       model: value,
       parentNodeId,

--- a/packages/core/metadata/forms/elements/graphFromModel.ts
+++ b/packages/core/metadata/forms/elements/graphFromModel.ts
@@ -86,7 +86,7 @@ function buildElementChildrenGraph(params: {
     const value = element[key]
     if (value === undefined || value === null) continue
 
-    buildGraphFn({
+    const result = buildGraphFn({
       model: value,
       parentNodeId,
       filePath,
@@ -95,6 +95,23 @@ function buildElementChildrenGraph(params: {
       graph,
       extra: { formNodeId },
     })
+    const sections = Array.isArray(result) ? result : result ? [result] : []
+    for (const section of sections) {
+      if (!section.children?.length && !section.references?.length) continue
+      if (!section.edgeKind || !section.edgeYaml) {
+        throw new Error(
+          `buildElementChildrenGraph: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +
+            `Чистые функции должны указывать оба поля в результате.`,
+        )
+      }
+      applyGraphOps(section, {
+        graph,
+        parentNodeId,
+        filePath,
+        edgeKind: section.edgeKind,
+        edgeYaml: section.edgeYaml,
+      })
+    }
   }
 }
 

--- a/packages/core/metadata/forms/elements/graphFromModel.ts
+++ b/packages/core/metadata/forms/elements/graphFromModel.ts
@@ -97,7 +97,7 @@ function buildElementChildrenGraph(params: {
     })
     const sections = Array.isArray(result) ? result : result ? [result] : []
     for (const section of sections) {
-      if (!section.children?.length && !section.references?.length) continue
+      if (!section.children?.length && !section.references?.length && !section.formLocalReferences?.length) continue
       if (!section.edgeKind || !section.edgeYaml) {
         throw new Error(
           `buildElementChildrenGraph: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +

--- a/packages/core/metadata/orchestration/buildGraphFromModel.ts
+++ b/packages/core/metadata/orchestration/buildGraphFromModel.ts
@@ -69,20 +69,36 @@ export function buildGraphFromModel(params: {
       })
       const sections = Array.isArray(result) ? result : result ? [result] : []
       for (const section of sections) {
-        if (!section.children?.length && !section.references?.length && !section.formLocalReferences?.length) continue
-        if (!section.edgeKind || !section.edgeYaml) {
-          throw new Error(
-            `buildGraphFromModel: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +
-              `Чистые функции должны указывать оба поля в результате.`,
-          )
+        const hasOps =
+          section.children?.length ||
+          section.references?.length ||
+          section.formLocalReferences?.length
+        if (hasOps) {
+          if (!section.edgeKind || !section.edgeYaml) {
+            throw new Error(
+              `buildGraphFromModel: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +
+                `Чистые функции должны указывать оба поля в результате.`,
+            )
+          }
+          applyGraphOps(section, {
+            graph,
+            parentNodeId,
+            filePath,
+            edgeKind: section.edgeKind,
+            edgeYaml: section.edgeYaml,
+          })
         }
-        applyGraphOps(section, {
-          graph,
-          parentNodeId,
-          filePath,
-          edgeKind: section.edgeKind,
-          edgeYaml: section.edgeYaml,
-        })
+        for (const recurse of section.recurse ?? []) {
+          buildGraphFromModel({
+            model: recurse.model,
+            yamlMap: recurse.yamlMap,
+            rule: recurse.rule,
+            graph,
+            parentNodeId: recurse.parentNodeId,
+            filePath,
+            extra: recurse.extra ?? extra,
+          })
+        }
       }
       continue
     }

--- a/packages/core/metadata/orchestration/buildGraphFromModel.ts
+++ b/packages/core/metadata/orchestration/buildGraphFromModel.ts
@@ -67,19 +67,21 @@ export function buildGraphFromModel(params: {
         graph,
         extra,
       })
-      if (result && (result.children?.length || result.references?.length)) {
-        if (!result.edgeKind || !result.edgeYaml) {
+      const sections = Array.isArray(result) ? result : result ? [result] : []
+      for (const section of sections) {
+        if (!section.children?.length && !section.references?.length) continue
+        if (!section.edgeKind || !section.edgeYaml) {
           throw new Error(
             `buildGraphFromModel: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +
               `Чистые функции должны указывать оба поля в результате.`,
           )
         }
-        applyGraphOps(result, {
+        applyGraphOps(section, {
           graph,
           parentNodeId,
           filePath,
-          edgeKind: result.edgeKind,
-          edgeYaml: result.edgeYaml,
+          edgeKind: section.edgeKind,
+          edgeYaml: section.edgeYaml,
         })
       }
       continue

--- a/packages/core/metadata/orchestration/buildGraphFromModel.ts
+++ b/packages/core/metadata/orchestration/buildGraphFromModel.ts
@@ -69,7 +69,7 @@ export function buildGraphFromModel(params: {
       })
       const sections = Array.isArray(result) ? result : result ? [result] : []
       for (const section of sections) {
-        if (!section.children?.length && !section.references?.length) continue
+        if (!section.children?.length && !section.references?.length && !section.formLocalReferences?.length) continue
         if (!section.edgeKind || !section.edgeYaml) {
           throw new Error(
             `buildGraphFromModel: обработчик типа "${propType}" вернул GraphOps без edgeKind/edgeYaml. ` +

--- a/packages/core/metadata/orchestration/property/fn.ts
+++ b/packages/core/metadata/orchestration/property/fn.ts
@@ -94,9 +94,19 @@ export interface GraphOpsReference {
   positionFrom?: { offset: number; length?: number }
 }
 
+export interface GraphOpsFormLocalReference {
+  /** Form-local путь, например "Объект.Договор.Владелец". */
+  formLocalPath: string
+  /** Корневой узел формы — стартовая точка резолвинга. */
+  formNodeId: string
+  positionFrom?: { offset: number; length?: number }
+}
+
 export interface GraphOps {
   children?: GraphOpsChild[]
   references?: GraphOpsReference[]
+  /** Reference-рёбра, цель которых нужно резолвить через resolveFormLocalPath. */
+  formLocalReferences?: GraphOpsFormLocalReference[]
   /** ASCII-метка ребра. Передаётся в applyGraphOps оркестратором, когда BuildGraphFromModelFunction возвращает GraphOps вместо мутации graph. */
   edgeKind?: string
   /** Русский YAML-ключ ребра. Передаётся в applyGraphOps. */

--- a/packages/core/metadata/orchestration/property/fn.ts
+++ b/packages/core/metadata/orchestration/property/fn.ts
@@ -80,7 +80,7 @@ export type BuildGraphFromModelFunction = (params: {
   graph: MetadataGraph
   /** Дополнительный контекст, пробрасываемый в кастомные обработчики (например, formNodeId). */
   extra?: Record<string, unknown>
-}) => GraphOps | undefined | void
+}) => GraphOps | GraphOps[] | undefined | void
 
 export interface GraphOpsChild {
   idSuffix: string

--- a/packages/core/metadata/orchestration/property/fn.ts
+++ b/packages/core/metadata/orchestration/property/fn.ts
@@ -96,6 +96,9 @@ export interface GraphOpsReference {
   id: string
   name: string
   positionFrom?: { offset: number; length?: number }
+  // parentOverride намеренно не поддерживается: reference создаёт глобальный stub-узел
+  // и ребро всегда от ctx.parentNodeId. Если нужен override-источник ребра — используй
+  // formLocalReferences (с собственной семантикой резолвинга цели).
 }
 
 export interface GraphOpsFormLocalReference {

--- a/packages/core/metadata/orchestration/property/fn.ts
+++ b/packages/core/metadata/orchestration/property/fn.ts
@@ -86,6 +86,10 @@ export interface GraphOpsChild {
   idSuffix: string
   name: string
   positionFrom?: { offset: number; length?: number }
+  /** Запись в node.item при promoteNode. */
+  item?: Record<string, unknown>
+  /** Если задано — ребро идёт от этого узла, childNodeId = `${parentOverride}.${idSuffix}` вместо `${ctx.parentNodeId}.${idSuffix}`. */
+  parentOverride?: string
 }
 
 export interface GraphOpsReference {
@@ -100,6 +104,21 @@ export interface GraphOpsFormLocalReference {
   /** Корневой узел формы — стартовая точка резолвинга. */
   formNodeId: string
   positionFrom?: { offset: number; length?: number }
+  /** Если задано — ребро идёт от этого узла к резолвимой цели вместо ctx.parentNodeId. */
+  parentOverride?: string
+}
+
+export interface GraphOpsRecurse {
+  /** Подмодель, для которой нужно повторно вызвать обход правила. */
+  model: Record<string, unknown>
+  /** YAML-фрагмент подмодели для координат. Опционально. */
+  yamlMap?: YAMLMap
+  /** Правило обхода подмодели. */
+  rule: MetadataItemRule
+  /** Узел, относительно которого пойдёт обход — становится parentNodeId внутри. */
+  parentNodeId: string
+  /** Дополнительный контекст, пробрасываемый в обработчики. По умолчанию наследуется от вызывающего. */
+  extra?: Record<string, unknown>
 }
 
 export interface GraphOps {
@@ -107,6 +126,8 @@ export interface GraphOps {
   references?: GraphOpsReference[]
   /** Reference-рёбра, цель которых нужно резолвить через resolveFormLocalPath. */
   formLocalReferences?: GraphOpsFormLocalReference[]
+  /** Рекурсивные задачи: оркестратор пройдёт по правилу для каждой подмодели после применения локальных ops. */
+  recurse?: GraphOpsRecurse[]
   /** ASCII-метка ребра. Передаётся в applyGraphOps оркестратором, когда BuildGraphFromModelFunction возвращает GraphOps вместо мутации graph. */
   edgeKind?: string
   /** Русский YAML-ключ ребра. Передаётся в applyGraphOps. */

--- a/packages/core/metadata/relations/applyGraphOps.test.ts
+++ b/packages/core/metadata/relations/applyGraphOps.test.ts
@@ -249,7 +249,7 @@ describe("applyGraphOps", () => {
     })
 
     it("пробрасывает positionFrom на ребро", () => {
-      const { graph, formNodeId, attrId } = makeFormGraph()
+      const { graph, formNodeId } = makeFormGraph()
       const elementId = `${formNodeId}.Элемент.Кнопка`
       graph.ensureNode(elementId, { name: "Кнопка", filePaths: ["test/Форма.yaml"] })
 

--- a/packages/core/metadata/relations/applyGraphOps.test.ts
+++ b/packages/core/metadata/relations/applyGraphOps.test.ts
@@ -287,4 +287,97 @@ describe("applyGraphOps", () => {
       expect(graph.outEdges(elementId)).toHaveLength(0)
     })
   })
+
+  describe("parentOverride и item", () => {
+    it("child.parentOverride меняет childNodeId и источник ребра", () => {
+      const ctx = makeCtx()
+      // Создаём прокси-узел, от которого будет идти ребро
+      const proxyNodeId = `${PARENT_NODE_ID}.Прокси`
+      ctx.graph.ensureNode(proxyNodeId, { name: "Прокси", filePaths: [FILE_PATH] })
+
+      const ops: GraphOps = {
+        children: [{
+          idSuffix: "ДочерняяКолонка",
+          name: "ДочерняяКолонка",
+          parentOverride: proxyNodeId,
+        }],
+        edgeKind: "FORM_COLUMN",
+        edgeYaml: "КолонкаФормы",
+      }
+      applyGraphOps(ops, { ...ctx, edgeKind: "FORM_COLUMN", edgeYaml: "КолонкаФормы" })
+
+      // Узел сформирован относительно proxy, а не PARENT_NODE_ID
+      const childNodeId = `${proxyNodeId}.ДочерняяКолонка`
+      expect(ctx.graph.hasNode(childNodeId)).toBe(true)
+
+      // Ребро идёт от proxy, а не от PARENT_NODE_ID
+      const edgesFromProxy = [...ctx.graph.outEdgeEntries(proxyNodeId)]
+      expect(edgesFromProxy).toHaveLength(1)
+      expect(edgesFromProxy[0].target).toBe(childNodeId)
+      expect(edgesFromProxy[0].attributes.kind).toBe("FORM_COLUMN")
+
+      // Никаких рёбер от PARENT_NODE_ID
+      expect(ctx.graph.outEdges(PARENT_NODE_ID)).toHaveLength(0)
+    })
+
+    it("child.item записывается в node.item при promoteNode", () => {
+      const ctx = makeCtx()
+      const item = { itemType: "FormAttributeColumn", customField: 42 }
+
+      const ops: GraphOps = {
+        children: [{
+          idSuffix: "Колонка",
+          name: "Колонка",
+          item,
+        }],
+        edgeKind: "FORM_COLUMN",
+        edgeYaml: "КолонкаФормы",
+      }
+      applyGraphOps(ops, { ...ctx, edgeKind: "FORM_COLUMN", edgeYaml: "КолонкаФормы" })
+
+      const childNodeId = `${PARENT_NODE_ID}.Колонка`
+      expect(ctx.graph.hasNode(childNodeId)).toBe(true)
+      expect(ctx.graph.getNodeAttribute(childNodeId, "item")).toEqual(item)
+    })
+
+    it("formLocalReferences.parentOverride меняет источник ребра", () => {
+      const ctx = makeCtx()
+      // Граф формы: формNode + один реквизит "Объект", к которому будет резолвиться путь
+      const formNodeId = "Форма.ТестоваяФорма"
+      const attrId = `${formNodeId}.Реквизит.Объект`
+      ctx.graph.ensureNode(formNodeId, { name: "ТестоваяФорма", filePaths: [FILE_PATH] })
+      ctx.graph.ensureNode(attrId, { name: "Объект", filePaths: [FILE_PATH] })
+      ctx.graph.ensureEdge(`${formNodeId}:FORM_ATTRIBUTE:${attrId}`, formNodeId, attrId, {
+        yaml: "РеквизитФормы",
+        kind: "FORM_ATTRIBUTE",
+      })
+
+      // Прокси-узел, от которого по факту должно идти ребро TABLE
+      const proxyNodeId = `${PARENT_NODE_ID}.Прокси`
+      ctx.graph.ensureNode(proxyNodeId, { name: "Прокси", filePaths: [FILE_PATH] })
+
+      const ops: GraphOps = {
+        formLocalReferences: [{
+          formLocalPath: "Объект",
+          formNodeId,
+          parentOverride: proxyNodeId,
+        }],
+        edgeKind: "TABLE",
+        edgeYaml: "Таблица",
+      }
+      applyGraphOps(ops, { ...ctx, edgeKind: "TABLE", edgeYaml: "Таблица" })
+
+      // Ребро идёт от proxy, а не от PARENT_NODE_ID
+      const edgesFromProxy = [...ctx.graph.outEdgeEntries(proxyNodeId)]
+      expect(edgesFromProxy).toHaveLength(1)
+      expect(edgesFromProxy[0].target).toBe(attrId)
+      expect(edgesFromProxy[0].attributes.kind).toBe("TABLE")
+
+      // Никаких рёбер с TABLE от PARENT_NODE_ID
+      const tableEdges = [...ctx.graph.outEdgeEntries(PARENT_NODE_ID)].filter(
+        (e) => e.attributes.kind === "TABLE",
+      )
+      expect(tableEdges).toHaveLength(0)
+    })
+  })
 })

--- a/packages/core/metadata/relations/applyGraphOps.test.ts
+++ b/packages/core/metadata/relations/applyGraphOps.test.ts
@@ -188,4 +188,103 @@ describe("applyGraphOps", () => {
       expect(edges.every((e) => e.attributes.kind === "TYPE")).toBe(true)
     })
   })
+
+  describe("formLocalReferences", () => {
+    // Готовит граф формы с минимальным набором узлов/рёбер,
+    // достаточным для resolveFormLocalPath: форма + один реквизит формы
+    // ("Объект"), от которого можно резолвить простые form-local пути.
+    function makeFormGraph() {
+      const graph = new MetadataGraph()
+      const formNodeId = "Форма.ТестоваяФорма"
+      const attrId = `${formNodeId}.Реквизит.Объект`
+      graph.ensureNode(formNodeId, { name: "ТестоваяФорма", filePaths: ["test/Форма.yaml"] })
+      graph.ensureNode(attrId, { name: "Объект", filePaths: ["test/Форма.yaml"] })
+      const edgeKey = `${formNodeId}:FORM_ATTRIBUTE:${attrId}`
+      graph.ensureEdge(edgeKey, formNodeId, attrId, { yaml: "РеквизитФормы", kind: "FORM_ATTRIBUTE" })
+      return { graph, formNodeId, attrId }
+    }
+
+    it("создаёт ребро на резолвимую цель (happy path)", () => {
+      const { graph, formNodeId, attrId } = makeFormGraph()
+      const elementId = `${formNodeId}.Элемент.Кнопка`
+      graph.ensureNode(elementId, { name: "Кнопка", filePaths: ["test/Форма.yaml"] })
+
+      const ctx: ApplyGraphOpsContext = {
+        graph,
+        parentNodeId: elementId,
+        filePath: "test/Форма.yaml",
+        edgeKind: "DATA_PATH",
+        edgeYaml: "ПутьКДанным",
+      }
+      const ops: GraphOps = {
+        formLocalReferences: [{ formLocalPath: "Объект", formNodeId }],
+      }
+      applyGraphOps(ops, ctx)
+
+      const edges = [...graph.outEdgeEntries(elementId)]
+      expect(edges).toHaveLength(1)
+      expect(edges[0].target).toBe(attrId)
+      expect(edges[0].attributes.kind).toBe("DATA_PATH")
+      expect(edges[0].attributes.yaml).toBe("ПутьКДанным")
+    })
+
+    it("не создаёт ребро, если resolveFormLocalPath вернул undefined (нет первого сегмента)", () => {
+      const { graph, formNodeId } = makeFormGraph()
+      const elementId = `${formNodeId}.Элемент.Кнопка`
+      graph.ensureNode(elementId, { name: "Кнопка", filePaths: ["test/Форма.yaml"] })
+
+      const ctx: ApplyGraphOpsContext = {
+        graph,
+        parentNodeId: elementId,
+        filePath: "test/Форма.yaml",
+        edgeKind: "DATA_PATH",
+        edgeYaml: "ПутьКДанным",
+      }
+      const ops: GraphOps = {
+        formLocalReferences: [{ formLocalPath: "НесуществующийРеквизит", formNodeId }],
+      }
+      applyGraphOps(ops, ctx)
+
+      expect(graph.outEdges(elementId)).toHaveLength(0)
+    })
+
+    it("пробрасывает positionFrom на ребро", () => {
+      const { graph, formNodeId, attrId } = makeFormGraph()
+      const elementId = `${formNodeId}.Элемент.Кнопка`
+      graph.ensureNode(elementId, { name: "Кнопка", filePaths: ["test/Форма.yaml"] })
+
+      const ctx: ApplyGraphOpsContext = {
+        graph,
+        parentNodeId: elementId,
+        filePath: "test/Форма.yaml",
+        edgeKind: "DATA_PATH",
+        edgeYaml: "ПутьКДанным",
+      }
+      const ops: GraphOps = {
+        formLocalReferences: [{ formLocalPath: "Объект", formNodeId, positionFrom: { offset: 42 } }],
+      }
+      applyGraphOps(ops, ctx)
+
+      const edges = [...graph.outEdgeEntries(elementId)]
+      expect(edges).toHaveLength(1)
+      expect(edges[0].attributes.positionFrom).toEqual({ offset: 42 })
+    })
+
+    it("пустой formLocalReferences не создаёт рёбер", () => {
+      const { graph, formNodeId } = makeFormGraph()
+      const elementId = `${formNodeId}.Элемент.Кнопка`
+      graph.ensureNode(elementId, { name: "Кнопка", filePaths: ["test/Форма.yaml"] })
+
+      const ctx: ApplyGraphOpsContext = {
+        graph,
+        parentNodeId: elementId,
+        filePath: "test/Форма.yaml",
+        edgeKind: "DATA_PATH",
+        edgeYaml: "ПутьКДанным",
+      }
+      applyGraphOps({ formLocalReferences: [] }, ctx)
+
+      expect(graph.outEdges(elementId)).toHaveLength(0)
+    })
+  })
 })

--- a/packages/core/metadata/relations/applyGraphOps.ts
+++ b/packages/core/metadata/relations/applyGraphOps.ts
@@ -1,26 +1,15 @@
 import { GraphOps } from "../orchestration/property/fn"
+import { resolveFormLocalPath } from "./resolveFormLocalPath"
 import { MetadataGraph } from "./MetadataGraph"
 
 export interface ApplyGraphOpsContext {
   graph: MetadataGraph
   parentNodeId: string
   filePath: string
-  /** ASCII-метка ребра (тип отношения в Cypher и идентификатор в логике). */
   edgeKind: string
-  /** Русский YAML-ключ ребра (для round-trip и человекочитаемости). */
   edgeYaml: string
 }
 
-/**
- * Применяет декларативный GraphOps к графу.
- *
- * - children → owned-узлы с filePath, owning-рёбра kind=edgeKind от parentNodeId
- * - references → stub-узлы (если ещё нет), reference-рёбра kind=edgeKind с positionFrom
- *
- * edgeKind должен быть зарегистрирован в edgeKinds:
- * - для children — owning kind
- * - для references — reference kind
- */
 export function applyGraphOps(ops: GraphOps, ctx: ApplyGraphOpsContext): void {
   const { graph, parentNodeId, filePath, edgeKind, edgeYaml } = ctx
 
@@ -45,6 +34,21 @@ export function applyGraphOps(ops: GraphOps, ctx: ApplyGraphOpsContext): void {
       yaml: edgeYaml,
       kind: edgeKind,
       positionFrom: ref.positionFrom,
+    })
+  }
+
+  for (const local of ops.formLocalReferences ?? []) {
+    const resolved = resolveFormLocalPath({
+      formNodeId: local.formNodeId,
+      path: local.formLocalPath,
+      graph,
+    })
+    if (!resolved) continue
+    const edgeKey = `${parentNodeId}:${edgeKind}:${resolved.targetId}`
+    graph.ensureEdge(edgeKey, parentNodeId, resolved.targetId, {
+      yaml: edgeYaml,
+      kind: edgeKind,
+      positionFrom: local.positionFrom,
     })
   }
 }

--- a/packages/core/metadata/relations/applyGraphOps.ts
+++ b/packages/core/metadata/relations/applyGraphOps.ts
@@ -14,10 +14,12 @@ export interface ApplyGraphOpsContext {
  * Применяет декларативный GraphOps к графу.
  *
  * - children → owned-узлы с filePath, owning-рёбра kind=edgeKind от parentNodeId
+ *   (или от child.parentOverride, если задано — childNodeId формируется относительно него)
  * - references → stub-узлы (если ещё нет), reference-рёбра kind=edgeKind с positionFrom
  * - formLocalReferences → reference-рёбра, цель которых резолвится через resolveFormLocalPath
  *   (form-local путь типа "Объект.Договор.Владелец" → NodeId через обход рёбер формы);
  *   при `resolveFormLocalPath → undefined` ребро не создаётся
+ *   (или от local.parentOverride, если задано — ребро идёт оттуда)
  *
  * edgeKind должен быть зарегистрирован в edgeKinds: для children — owning, для references/formLocalReferences — reference.
  */
@@ -25,14 +27,16 @@ export function applyGraphOps(ops: GraphOps, ctx: ApplyGraphOpsContext): void {
   const { graph, parentNodeId, filePath, edgeKind, edgeYaml } = ctx
 
   for (const child of ops.children ?? []) {
-    const childNodeId = `${parentNodeId}.${child.idSuffix}`
+    const effectiveParent = child.parentOverride ?? parentNodeId
+    const childNodeId = `${effectiveParent}.${child.idSuffix}`
     graph.promoteNode(childNodeId, {
       name: child.name,
       filePaths: [filePath],
       positionFrom: child.positionFrom,
+      item: child.item,
     })
-    const edgeKey = `${parentNodeId}:${edgeKind}:${childNodeId}`
-    graph.ensureEdge(edgeKey, parentNodeId, childNodeId, {
+    const edgeKey = `${effectiveParent}:${edgeKind}:${childNodeId}`
+    graph.ensureEdge(edgeKey, effectiveParent, childNodeId, {
       yaml: edgeYaml,
       kind: edgeKind,
     })
@@ -49,14 +53,15 @@ export function applyGraphOps(ops: GraphOps, ctx: ApplyGraphOpsContext): void {
   }
 
   for (const local of ops.formLocalReferences ?? []) {
+    const effectiveParent = local.parentOverride ?? parentNodeId
     const resolved = resolveFormLocalPath({
       formNodeId: local.formNodeId,
       path: local.formLocalPath,
       graph,
     })
     if (!resolved) continue
-    const edgeKey = `${parentNodeId}:${edgeKind}:${resolved.targetId}`
-    graph.ensureEdge(edgeKey, parentNodeId, resolved.targetId, {
+    const edgeKey = `${effectiveParent}:${edgeKind}:${resolved.targetId}`
+    graph.ensureEdge(edgeKey, effectiveParent, resolved.targetId, {
       yaml: edgeYaml,
       kind: edgeKind,
       positionFrom: local.positionFrom,

--- a/packages/core/metadata/relations/applyGraphOps.ts
+++ b/packages/core/metadata/relations/applyGraphOps.ts
@@ -10,6 +10,17 @@ export interface ApplyGraphOpsContext {
   edgeYaml: string
 }
 
+/**
+ * Применяет декларативный GraphOps к графу.
+ *
+ * - children → owned-узлы с filePath, owning-рёбра kind=edgeKind от parentNodeId
+ * - references → stub-узлы (если ещё нет), reference-рёбра kind=edgeKind с positionFrom
+ * - formLocalReferences → reference-рёбра, цель которых резолвится через resolveFormLocalPath
+ *   (form-local путь типа "Объект.Договор.Владелец" → NodeId через обход рёбер формы);
+ *   при `resolveFormLocalPath → undefined` ребро не создаётся
+ *
+ * edgeKind должен быть зарегистрирован в edgeKinds: для children — owning, для references/formLocalReferences — reference.
+ */
 export function applyGraphOps(ops: GraphOps, ctx: ApplyGraphOpsContext): void {
   const { graph, parentNodeId, filePath, edgeKind, edgeYaml } = ctx
 


### PR DESCRIPTION
## Summary

Завершение перевода `graphFromModel.ts`-обработчиков на чистый контракт `BuildGraphFromModelFunction → GraphOps[]`, начатого в PR #144 (фаза 1a).

- 6 файлов мигрированы: `metadataRef`, `metadataValue`, `commandName`, `associatedTable`, `dataPath`, `formAttribute` — больше не зависят от `MetadataGraph` и `applyGraphOps`.
- `GraphOps` расширен полями `formLocalReferences` (резолвинг form-local пути в `applyGraphOps`), `recurse` (рекурсивный обход подмодели по правилу), `GraphOpsChild.item`/`parentOverride`, `GraphOpsFormLocalReference.parentOverride`.
- `forms/elements/graphFromModel.ts` остался единственным legacy-обходчиком — переедет в фазу 1c вместе с выносом общего хелпера `applyBuildGraphResult` (TODO-маркер на месте).
- Поведение в `MetadataGraph` идентично прежнему: единственный шлюз мутации — тот же `applyGraphOps`. Все integration-тесты остались зелёными без правок логики.

План фазы — `docs/superpowers/plans/2026-04-28-graph-pure-functions-1b.md`.

## Test Plan

- [x] `pnpm test` — 2538 passed, 13 skipped, 0 failed
- [x] type-check `@nakidka/core` чистый
- [x] прицельные тесты `applyGraphOps` (20/20), `formAttribute/graphFromModel` (5/5), `forms/elements` (534/534)
- [x] integration-сценарий additional-колонок в `importMetadataFileWithGraph.test.ts` — зелёный