### PR TITLE
fix: не дублировать buildGraph props

### DIFF
--- a/packages/core/metadata/orchestration/buildGraphFromModel.test.ts
+++ b/packages/core/metadata/orchestration/buildGraphFromModel.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { buildGraphFromModel } from "./buildGraphFromModel"
+import { GraphBuilder } from "./buildGraph/internal/GraphBuilder"
+import { walkGraphToFileData } from "./buildGraph/walkGraphToFileData"
+import type { MetadataItemRule } from "./property/types"
+
+import "~/metadata/forms/commonObjects/dataPath/graphFromModel"
+
+describe("buildGraphFromModel", () => {
+  it("не дублирует свойство с buildGraphFromModel в props родительского узла", () => {
+    const graph = new GraphBuilder()
+    const formNodeId = "Форма"
+    const parentNodeId = "Форма.Элемент.Поле"
+    const filePath = "form.yaml"
+    const item = {
+      itemType: "FormElement",
+      name: "Поле",
+      dataPath: "Объект.Имя",
+    }
+    const rule = {
+      properties: {
+        dataPath: { type: "DataPath", yaml: "ПутьКДанным", defaultType: "string" },
+      },
+    } satisfies MetadataItemRule
+
+    graph.ensureNode(formNodeId, { name: "Форма" })
+    graph.ensureNode("Форма.Реквизит.Объект", { name: "Объект" })
+    graph.ensureNode("Справочник.Товары", { name: "Товары" })
+    graph.ensureNode("Справочник.Товары.Имя", { name: "Имя" })
+    graph.ensureEdge(formNodeId, "Форма.Реквизит.Объект", "FORM_ATTRIBUTE", { yaml: "РеквизитФормы" })
+    graph.ensureEdge("Форма.Реквизит.Объект", "Справочник.Товары", "TYPE", { yaml: "Тип" })
+    graph.ensureNode(parentNodeId, { name: "Поле" })
+    graph.addFilePath(parentNodeId, filePath)
+    graph.setItem(parentNodeId, item)
+
+    buildGraphFromModel({
+      model: item,
+      yamlMap: undefined,
+      rule,
+      graph,
+      parentNodeId,
+      filePath,
+      extra: { formNodeId },
+    })
+
+    const result = walkGraphToFileData(graph)
+    const file = result.find((f) => f.filePath === filePath)
+    const parent = file?.nodes.find((node) => node.id === parentNodeId)
+
+    expect(parent?.props).not.toHaveProperty("p_dataPath")
+  })
+})

--- a/packages/core/metadata/orchestration/buildGraphFromModel.ts
+++ b/packages/core/metadata/orchestration/buildGraphFromModel.ts
@@ -61,6 +61,17 @@ export function applyBuildGraphResult(
   }
 }
 
+function hasBuildGraphResult(result: GraphOps | GraphOps[] | undefined | void): boolean {
+  const sections = Array.isArray(result) ? result : result ? [result] : []
+  return sections.some(
+    (section) =>
+      Boolean(section.children?.length) ||
+      Boolean(section.references?.length) ||
+      Boolean(section.formLocalReferences?.length) ||
+      Boolean(section.recurse?.length),
+  )
+}
+
 /**
  * Обходит модель параллельно с YAML AST, вызывает зарегистрированную extractGraph
  * для свойств с зарегистрированным экстрактором и применяет результат через applyGraphOps.
@@ -126,6 +137,9 @@ export function buildGraphFromModel(params: {
         propRule,
         extra,
       })
+      if (hasBuildGraphResult(result)) {
+        graph.addFlattenSkipKeys(parentNodeId, [key])
+      }
       applyBuildGraphResult(result, { graph, parentNodeId, filePath, propType, extra })
       continue
     }


### PR DESCRIPTION
## Summary
- Добавлен регрессионный тест для buildGraphFromModel-свойств в props.
- Исключение из flatten props теперь применяется к buildGraphFromModel только когда обработчик реально вернул графовые операции.
- Сохранён смешанный сценарий MetadataValue, где примитив остаётся в props без графовых рёбер.

## Test Plan
- pnpm --filter @nakidka/core exec vitest run metadata/orchestration/buildGraph/flattenItem.test.ts metadata/orchestration/buildGraph/walkGraphToFileData.test.ts metadata/orchestration/buildGraph/internal/applyGraphOps.test.ts metadata/orchestration/buildGraphFromModel.test.ts metadata/orchestration/importMetadataFileWithGraph.test.ts
- pnpm --filter @nakidka/graph test
- pnpm test