### PR TITLE
Сохранить условное оформление реквизитов формы

### DIFF
--- a/packages/core/metadata/forms/clientApplicationForm/__fixtures__/conditionalAppearanceWithoutAttributes.xml
+++ b/packages/core/metadata/forms/clientApplicationForm/__fixtures__/conditionalAppearanceWithoutAttributes.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Form xmlns="http://v8.1c.ru/8.3/xcf/logform" xmlns:app="http://v8.1c.ru/8.2/managed-application/core" xmlns:cfg="http://v8.1c.ru/8.1/data/enterprise/current-config" xmlns:dcscor="http://v8.1c.ru/8.1/data-composition-system/core" xmlns:dcssch="http://v8.1c.ru/8.1/data-composition-system/schema" xmlns:dcsset="http://v8.1c.ru/8.1/data-composition-system/settings" xmlns:ent="http://v8.1c.ru/8.1/data/enterprise" xmlns:lf="http://v8.1c.ru/8.2/managed-application/logform" xmlns:style="http://v8.1c.ru/8.1/data/ui/style" xmlns:sys="http://v8.1c.ru/8.1/data/ui/fonts/system" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:v8ui="http://v8.1c.ru/8.1/data/ui" xmlns:web="http://v8.1c.ru/8.1/data/ui/colors/web" xmlns:win="http://v8.1c.ru/8.1/data/ui/colors/windows" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<AutoCommandBar name="ФормаКоманднаяПанель" id="-1"/>
+	<Attributes>
+		<ConditionalAppearance>
+			<dcsset:viewMode>Normal</dcsset:viewMode>
+		</ConditionalAppearance>
+	</Attributes>
+</Form>

--- a/packages/core/metadata/forms/clientApplicationForm/__fixtures__/data.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/__fixtures__/data.ts
@@ -15,7 +15,10 @@ const fullCommandInterface: CommandInterface = {
   itemType: "CommandInterface",
 }
 
-export const fullClientApplicationForm: Omit<Required<ClientApplicationForm>, "uuid" | "formType" | "name"> = {
+export const fullClientApplicationForm: Omit<
+  Required<ClientApplicationForm>,
+  "uuid" | "formType" | "name" | "attributesConditionalAppearance"
+> = {
   parameters: [
     {
       name: "Параметр1",
@@ -155,7 +158,10 @@ export const clientApplicationFormReference: ClientApplicationForm = {
   uuid: "11111111-1111-4111-8111-111111111111",
 }
 
-export const fullClientApplicationFormYAML: Required<ClientApplicationFormYAML> = {
+export const fullClientApplicationFormYAML: Omit<
+  Required<ClientApplicationFormYAML>,
+  "УсловноеОформлениеРеквизитов"
+> = {
   Синоним: "Синоним формы",
   Комментарий: "Комментарий к форме",
   ВключатьСправкуВСодержание: "Истина",
@@ -279,7 +285,7 @@ export const fullClientApplicationFormYAML: Required<ClientApplicationFormYAML> 
   },
   РежимВыбора: "БыстрыйВыбор",
   // #endregion
-} satisfies Required<ClientApplicationFormYAML>
+} satisfies Omit<Required<ClientApplicationFormYAML>, "УсловноеОформлениеРеквизитов">
 
 export const minimalClientApplicationForm: ClientApplicationForm = {
   childItems: [],
@@ -290,6 +296,19 @@ export const minimalClientApplicationForm: ClientApplicationForm = {
   comment: "",
   includeHelpInContents: false,
   usePurposes: ["PlatformApplication", "MobilePlatformApplication"],
+}
+
+export const conditionalAppearanceWithoutAttributesClientApplicationForm: ClientApplicationForm & {
+  attributesConditionalAppearance: {
+    itemType: "ConditionalAppearance"
+    viewMode: "Normal"
+  }
+} = {
+  ...minimalClientApplicationForm,
+  attributesConditionalAppearance: {
+    itemType: "ConditionalAppearance",
+    viewMode: "Normal",
+  },
 }
 
 export const minimalClientApplicationFormReference: ClientApplicationForm = {

--- a/packages/core/metadata/forms/clientApplicationForm/fromXML.test.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/fromXML.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 import { readAndParseXMLFixture } from "~/tests/readFixtureXML"
-import { fullClientApplicationForm, minimalClientApplicationForm } from "./__fixtures__/data"
+import {
+  conditionalAppearanceWithoutAttributesClientApplicationForm,
+  fullClientApplicationForm,
+  minimalClientApplicationForm,
+} from "./__fixtures__/data"
 import { importClientApplicationFormFromXML } from "./fromXML"
 import { ClientApplicationFormXML, FormMetadataXML } from "./types"
 import { mockContextFromXML } from "~/tests/mockContext"
@@ -34,5 +38,23 @@ describe("importClientApplicationFormFromXML", () => {
     })
 
     expect(result).toEqual(minimalClientApplicationForm)
+  })
+
+  it("imports conditional appearance without attributes", () => {
+    const xmlData = readAndParseXMLFixture<{ Form: ClientApplicationFormXML }>(
+      import.meta.url,
+      "conditionalAppearanceWithoutAttributes.xml"
+    )
+    const xmlMetadata = readAndParseXMLFixture<{ MetaDataObject: FormMetadataXML }>(
+      import.meta.url,
+      "minimalMetadata.xml"
+    )
+    const result = importClientApplicationFormFromXML({
+      context: mockContextFromXML(),
+      xml: xmlData.Form,
+      xmlMetadata: xmlMetadata.MetaDataObject,
+    })
+
+    expect(result).toEqual(conditionalAppearanceWithoutAttributesClientApplicationForm)
   })
 })

--- a/packages/core/metadata/forms/clientApplicationForm/rules.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/rules.ts
@@ -14,6 +14,13 @@ export const ClientApplicationFormRules = {
       tag: FormRulesTags.Form,
       defaultValueXMLEmpty: [],
     },
+    attributesConditionalAppearance: {
+      yaml: "УсловноеОформлениеРеквизитов",
+      type: "ConditionalAppearance",
+      xml: "ConditionalAppearance",
+      xmlParents: ["Attributes"],
+      tag: FormRulesTags.Form,
+    },
     autoCommandBar: {
       yaml: "КоманднаяПанель",
       type: "AutoCommandBar",

--- a/packages/core/metadata/forms/clientApplicationForm/toXML.test.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/toXML.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest"
 import { mockContextFromXML, mockContextToXML } from "~/tests/mockContext"
 import { readAndParseXMLFixture, readXMLFixtureAsString } from "~/tests/readFixtureXML"
 import { xmlExport } from "~/xml/export/exporter"
-import { fullClientApplicationForm, minimalClientApplicationForm } from "./__fixtures__/data"
+import {
+  conditionalAppearanceWithoutAttributesClientApplicationForm,
+  fullClientApplicationForm,
+  minimalClientApplicationForm,
+} from "./__fixtures__/data"
 import { importClientApplicationFormFromXML } from "./fromXML"
 import { exportClientApplicationFormToXML, exportFormMetadataToXML } from "./toXML"
 import { ClientApplicationFormXML, FormMetadataXML } from "./types"
@@ -54,6 +58,32 @@ describe("exportToXML", () => {
       const xmlData = exportClientApplicationFormToXML({
         context: mockContextToXML(),
         form: minimalClientApplicationForm,
+        referenceForm,
+      })
+
+      const result = xmlExport({ Form: xmlData })
+
+      expect(result).toEqual(expectedResult)
+    })
+
+    it("exports conditional appearance without attributes", () => {
+      const expectedResult = readXMLFixtureAsString(import.meta.url, "conditionalAppearanceWithoutAttributes.xml")
+      const referenceFormXML = readAndParseXMLFixture<{ Form: ClientApplicationFormXML }>(
+        import.meta.url,
+        "conditionalAppearanceWithoutAttributes.xml"
+      )
+      const referenceMetadataXML = readAndParseXMLFixture<{ MetaDataObject: FormMetadataXML }>(
+        import.meta.url,
+        "minimalMetadata.xml"
+      )
+      const referenceForm = importClientApplicationFormFromXML({
+        context: mockContextFromXML({ forReference: true }),
+        xml: referenceFormXML.Form,
+        xmlMetadata: referenceMetadataXML.MetaDataObject,
+      })
+      const xmlData = exportClientApplicationFormToXML({
+        context: mockContextToXML(),
+        form: conditionalAppearanceWithoutAttributesClientApplicationForm,
         referenceForm,
       })
 

--- a/packages/core/metadata/forms/clientApplicationForm/types.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/types.ts
@@ -30,7 +30,8 @@ export interface ClientApplicationFormXML {
   _version?: string
 
   Attributes?: {
-    Attribute: FormAttributesXML
+    Attribute?: FormAttributesXML
+    ConditionalAppearance?: Record<string, unknown>
   }
   Parameters?: {
     Parameter: FormParametersXML

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
@@ -15,12 +15,21 @@ import {
   FormAttributeXML,
 } from "./types"
 
+const isAttributesContainerWithoutAttributes = (xml: unknown): boolean => {
+  if (xml === null || xml === undefined || Array.isArray(xml) || typeof xml !== "object") return false
+
+  const xmlObject = xml as Record<string, unknown>
+  return !("Attribute" in xmlObject) && !("_name" in xmlObject) && "ConditionalAppearance" in xmlObject
+}
+
 export const importFormAttributesFromXML = (
   context: ConfigurationContextFromXML,
   _rule: PropertyRule | undefined,
   xml: { Attribute: FormAttributesXML } | FormAttributeXML | FormAttributesXML | undefined
 ): FormAttributes | undefined => {
   if (!xml) return undefined
+
+  if (isAttributesContainerWithoutAttributes(xml)) return []
 
   const xmlAttributes = "Attribute" in xml ? xml.Attribute : xml
   const items = Array.isArray(xmlAttributes) ? xmlAttributes : [xmlAttributes]

--- a/packages/core/metadata/orchestration/property/helpers.test.ts
+++ b/packages/core/metadata/orchestration/property/helpers.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest"
 import { applyRequiredXMLParents, getOrderedKeysFromXML } from "./helpers"
 import { setXMLValue } from "./toXML"
 
-const createRule = (properties: Record<string, { xml?: string; tag?: string; runtimeOnly?: true }>): any => {
+const createRule = (
+  properties: Record<string, { xml?: string; xmlParents?: string[]; tag?: string; runtimeOnly?: true }>
+): any => {
   return {
     // Остальное для этих тестов не важно, используются только свойства
     properties: Object.fromEntries(
@@ -100,6 +102,31 @@ describe("getOrderedKeysFromXML", () => {
     })
 
     expect(result).toEqual(["visible"])
+  })
+
+  it("ставит свойство-контейнер перед вложенными свойствами того же XML-узла", () => {
+    const rule = createRule({
+      attributes: { xml: "Attributes" },
+      attributesConditionalAppearance: {
+        xml: "ConditionalAppearance",
+        xmlParents: ["Attributes"],
+      },
+    })
+
+    const xml = {
+      Attributes: {
+        ConditionalAppearance: {
+          "dcsset:viewMode": "Normal",
+        },
+      },
+    }
+
+    const result = getOrderedKeysFromXML({
+      rule,
+      xml,
+    })
+
+    expect(result).toEqual(["attributes", "attributesConditionalAppearance"])
   })
 })
 

--- a/packages/core/metadata/orchestration/property/helpers.ts
+++ b/packages/core/metadata/orchestration/property/helpers.ts
@@ -269,6 +269,12 @@ export const getOrderedKeysFromXML = <Rule extends MetadataItemRule>(params: {
     const result: string[] = []
 
     for (const k of Object.keys(obj)) {
+      const directKey = propsAtPath[k]
+      if (directKey !== undefined && !added.has(directKey)) {
+        added.add(directKey)
+        result.push(directKey)
+      }
+
       if (childContainers.has(k)) {
         const nested = walkXml(obj[k], pathPrefix.concat([k]))
         for (const key of nested) {
@@ -276,12 +282,6 @@ export const getOrderedKeysFromXML = <Rule extends MetadataItemRule>(params: {
             added.add(key)
             result.push(key)
           }
-        }
-      } else if (propsAtPath[k] !== undefined) {
-        const key = propsAtPath[k]!
-        if (!added.has(key)) {
-          added.add(key)
-          result.push(key)
         }
       }
     }


### PR DESCRIPTION
## Summary
- Добавлен rules-property для условного оформления реквизитов формы внутри `Attributes`.
- Покрыт случай `ConditionalAppearance` без `Attribute` и сохранён сценарий `Attributes/`.
- Исправлен порядок обхода XML-свойств для контейнера с вложенными `xmlParents`.

## Test Plan
- [x] `pnpm test`