### PR TITLE
[codex] сохранить поля таблиц DCS

### DIFF
--- a/docs/superpowers/plans/2026-05-07-table-dcs-composer-fields.md
+++ b/docs/superpowers/plans/2026-05-07-table-dcs-composer-fields.md
@@ -1,0 +1,399 @@
+# Table DCS Composer Fields Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add focused Table element fixtures for DCS composer tables and preserve their DCS-specific XML/YAML fields through the shared form-element test mechanism.
+
+**Architecture:** The behavior belongs in `TableRules`, because form elements derive XML, YAML, and TS shapes from metadata rules. The two DCS composer tables become normal element fixtures registered in `ElementFixtures`; no local `fromXML.test.ts` or `toXML.test.ts` files are added for `table`.
+
+**Tech Stack:** TypeScript, Vitest, `pnpm`, Nakidka metadata rules, shared form-element test harness.
+
+---
+
+## File Structure
+
+- Modify `packages/core/metadata/forms/elements/table/rules.ts`: add three optional Table properties.
+- Modify `packages/core/metadata/forms/elements/table/__fixtures__/data.ts`: keep `fullTable` from becoming responsible for the new DCS-specific fields by excluding them from the required-field assertion only.
+- Create `packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.ts`: TS and YAML expectations for `dcsComposerFilter.xml`.
+- Create `packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.ts`: TS and YAML expectations for `dcsComposerSettings.xml`.
+- Modify `packages/core/metadata/forms/elements/__tests__/fixtures.ts`: import and register both new fixtures in the `Table` region.
+
+## Task 1: Register Focused DCS Composer Fixtures
+
+**Files:**
+- Create: `packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.ts`
+- Create: `packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.ts`
+- Modify: `packages/core/metadata/forms/elements/__tests__/fixtures.ts`
+
+- [ ] **Step 1: Create `dcsComposerFilter.ts` with expected model and YAML**
+
+Create `packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.ts`:
+
+```typescript
+import type { Table, TablePartialYAML } from "../types"
+
+export const dcsComposerFilter: Table = {
+  itemType: "Table",
+  name: "КомпоновщикНастроекКомпоновкиДанныхНастройкиОтбор",
+  representation: "Tree",
+  autofill: true,
+  width: 60,
+  initialTreeView: "ExpandAllLevels",
+  enableStartDrag: true,
+  enableDrag: true,
+  dataPath: "КомпоновщикНастроекКомпоновкиДанных.Settings.Filter",
+  viewMode: "QuickAccess",
+  settingsNamedItemDetailedRepresentation: false,
+  contextMenu: {
+    itemType: "ContextMenu",
+    childItems: [],
+  },
+  autoCommandBar: {
+    itemType: "AutoCommandBar",
+    autofill: true,
+    childItems: [],
+  },
+  extendedTooltip: {
+    itemType: "ExtendedTooltip",
+  },
+  searchStringRepresentation: {
+    itemType: "SingleSearchStringAddition",
+    contextMenu: {
+      itemType: "ContextMenu",
+      childItems: [],
+    },
+    extendedTooltip: {
+      itemType: "ExtendedTooltip",
+    },
+  },
+  viewStatusRepresentation: {
+    itemType: "ViewStatusAddition",
+    contextMenu: {
+      itemType: "ContextMenu",
+      childItems: [],
+    },
+    extendedTooltip: {
+      itemType: "ExtendedTooltip",
+    },
+  },
+  searchControl: {
+    itemType: "SingleSearchControlAddition",
+    childItems: [],
+    contextMenu: {
+      itemType: "ContextMenu",
+      childItems: [],
+    },
+    extendedTooltip: {
+      itemType: "ExtendedTooltip",
+    },
+  },
+  childItems: [
+    {
+      itemType: "TableCheckBoxField",
+      name: "КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборИспользование",
+      dataPath: "КомпоновщикНастроекКомпоновкиДанных.Settings.Filter.Use",
+      editMode: "EnterOnInput",
+      checkBoxType: "Auto",
+      contextMenu: {
+        itemType: "ContextMenu",
+        childItems: [],
+      },
+      extendedTooltip: {
+        itemType: "ExtendedTooltip",
+      },
+    },
+  ],
+}
+
+export const dcsComposerFilterYAML: TablePartialYAML = {
+  АвтозаполнениеКолонок: "Истина",
+  НачальноеОтображениеДерева: "РаскрыватьВсеУровни",
+  Отображение: "Дерево",
+  ПодробноеОтображениеИменованныхЭлементовНастройки: "Ложь",
+  РазрешитьНачалоПеретаскивания: "Истина",
+  РазрешитьПеретаскивание: "Истина",
+  РежимОтображения: "БыстрыйДоступ",
+  Ширина: 60,
+}
+```
+
+- [ ] **Step 2: Create `dcsComposerSettings.ts` with expected model and YAML**
+
+Create `packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.ts`:
+
+```typescript
+import type { Table, TablePartialYAML } from "../types"
+
+export const dcsComposerSettings: Table = {
+  itemType: "Table",
+  name: "КомпоновщикНастроекКомпоновкиДанныхНастройки",
+  representation: "Tree",
+  horizontalLines: false,
+  useAlternationRowColor: true,
+  initialTreeView: "ExpandAllLevels",
+  enableStartDrag: true,
+  enableDrag: true,
+  dataPath: "КомпоновщикНастроекКомпоновкиДанных.Settings",
+  contextMenu: {
+    itemType: "ContextMenu",
+    childItems: [],
+  },
+  autoCommandBar: {
+    itemType: "AutoCommandBar",
+    autofill: true,
+    childItems: [],
+  },
+  extendedTooltip: {
+    itemType: "ExtendedTooltip",
+  },
+  searchStringRepresentation: {
+    itemType: "SingleSearchStringAddition",
+    contextMenu: {
+      itemType: "ContextMenu",
+      childItems: [],
+    },
+    extendedTooltip: {
+      itemType: "ExtendedTooltip",
+    },
+  },
+  viewStatusRepresentation: {
+    itemType: "ViewStatusAddition",
+    contextMenu: {
+      itemType: "ContextMenu",
+      childItems: [],
+    },
+    extendedTooltip: {
+      itemType: "ExtendedTooltip",
+    },
+  },
+  searchControl: {
+    itemType: "SingleSearchControlAddition",
+    childItems: [],
+    contextMenu: {
+      itemType: "ContextMenu",
+      childItems: [],
+    },
+    extendedTooltip: {
+      itemType: "ExtendedTooltip",
+    },
+  },
+  childItems: [
+    {
+      itemType: "TableCheckBoxField",
+      name: "КомпоновщикНастроекКомпоновкиДанныхНастройкиИспользование",
+      dataPath: "КомпоновщикНастроекКомпоновкиДанных.Settings.Use",
+      editMode: "EnterOnInput",
+      checkBoxType: "Auto",
+      contextMenu: {
+        itemType: "ContextMenu",
+        childItems: [],
+      },
+      extendedTooltip: {
+        itemType: "ExtendedTooltip",
+      },
+    },
+  ],
+}
+
+export const dcsComposerSettingsYAML: TablePartialYAML = {
+  ГоризонтальныеЛинии: "Ложь",
+  НачальноеОтображениеДерева: "РаскрыватьВсеУровни",
+  Отображение: "Дерево",
+  РазрешитьНачалоПеретаскивания: "Истина",
+  РазрешитьПеретаскивание: "Истина",
+  ЧередованиеЦветовСтрок: "Истина",
+}
+```
+
+- [ ] **Step 3: Register the fixtures in `ElementFixtures`**
+
+Modify the table imports in `packages/core/metadata/forms/elements/__tests__/fixtures.ts` from:
+
+```typescript
+import { dynamicList } from "../table/__fixtures__/dynamicList"
+import { fullTable, fullTableEnterprise, fullTableYAML, minimalTable } from "../table/__fixtures__/data"
+```
+
+to:
+
+```typescript
+import { dynamicList } from "../table/__fixtures__/dynamicList"
+import { dcsComposerFilter, dcsComposerFilterYAML } from "../table/__fixtures__/dcsComposerFilter"
+import { dcsComposerSettings, dcsComposerSettingsYAML } from "../table/__fixtures__/dcsComposerSettings"
+import { fullTable, fullTableEnterprise, fullTableYAML, minimalTable } from "../table/__fixtures__/data"
+```
+
+Add these entries in the `//#region Table` block after `dynamicList`:
+
+```typescript
+  {
+    group: "Table",
+    name: "dcsComposerFilter",
+    element: Table,
+    xml: "dcsComposerFilter.xml",
+    xmlFolder: undefined,
+    model: dcsComposerFilter,
+    yaml: dcsComposerFilterYAML,
+    enterprise: undefined,
+  },
+  {
+    group: "Table",
+    name: "dcsComposerSettings",
+    element: Table,
+    xml: "dcsComposerSettings.xml",
+    xmlFolder: undefined,
+    model: dcsComposerSettings,
+    yaml: dcsComposerSettingsYAML,
+    enterprise: undefined,
+  },
+```
+
+- [ ] **Step 4: Run the focused tests and verify they fail for the missing rules**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t "dcsComposer"
+```
+
+Expected: FAIL before `TableRules` is updated. The failures should mention missing or unexpected `autofill`, `viewMode`, and `settingsNamedItemDetailedRepresentation` model/YAML properties for `dcsComposerFilter`; `dcsComposerSettings` may also fail if YAML expectations for empty nested elements need calibration.
+
+## Task 2: Add Table Rules for DCS Composer Fields
+
+**Files:**
+- Modify: `packages/core/metadata/forms/elements/table/rules.ts`
+- Modify: `packages/core/metadata/forms/elements/table/__fixtures__/data.ts`
+
+- [ ] **Step 1: Add the three properties to `TableRules`**
+
+In `packages/core/metadata/forms/elements/table/rules.ts`, add these properties after `autoCommandBar` and before `autoInsertNewRow`:
+
+```typescript
+    autofill: { yaml: "АвтозаполнениеКолонок", type: "boolean" },
+    viewMode: {
+      yaml: "РежимОтображения",
+      type: "SystemEnumeration",
+      typeSE: "DataCompositionSettingsViewMode",
+    },
+    settingsNamedItemDetailedRepresentation: {
+      yaml: "ПодробноеОтображениеИменованныхЭлементовНастройки",
+      xml: "SettingsNamedItemDetailedRepresentation",
+      type: "boolean",
+    },
+```
+
+The `autofill` property does not need `xml: "Autofill"` because the rule engine maps camelCase `autofill` to `Autofill` by default. `viewMode` similarly maps to `ViewMode`.
+
+- [ ] **Step 2: Keep `fullTable` out of the DCS-specific coverage**
+
+In `packages/core/metadata/forms/elements/table/__fixtures__/data.ts`, change the `fullTable` assertion from:
+
+```typescript
+} satisfies Omit<RequiredFieldsElement<Table>, "period" | "topLevelParent">
+```
+
+to:
+
+```typescript
+} satisfies Omit<
+  RequiredFieldsElement<Table>,
+  "autofill" | "period" | "settingsNamedItemDetailedRepresentation" | "topLevelParent" | "viewMode"
+>
+```
+
+Do not add the new fields to `fullTable` or `fullTableYAML`; the focused DCS composer fixtures cover them.
+
+- [ ] **Step 3: Run the focused XML/YAML tests again**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t "dcsComposer"
+```
+
+Expected: PASS. If only YAML assertions fail because the shared exporter includes empty nested elements, update the YAML objects in `dcsComposerFilter.ts` and `dcsComposerSettings.ts` to exactly match the received `TablePartialYAML`, then rerun the same command until it passes.
+
+## Task 3: Verify Table Regression Surface
+
+**Files:**
+- Test: `packages/core/metadata/forms/elements/__tests__/fromXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/fromYAML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toYAML.test.ts`
+
+- [ ] **Step 1: Run all shared element tests for `Table`**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t "Table"
+```
+
+Expected: PASS. This confirms existing `all fields`, `minimal fields`, and `dynamicList` fixtures still work with the new optional rules.
+
+- [ ] **Step 2: Run the full core test package**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run
+```
+
+Expected: PASS with the normal skipped tests unchanged.
+
+- [ ] **Step 3: Check worktree status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: changed files include only:
+
+```text
+M  packages/core/metadata/forms/elements/__tests__/fixtures.ts
+M  packages/core/metadata/forms/elements/table/__fixtures__/data.ts
+A  packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.ts
+?? packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.xml
+A  packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.ts
+?? packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.xml
+M  packages/core/metadata/forms/elements/table/rules.ts
+```
+
+The two XML files may show as `??` if the user-created fixture files have not been staged yet.
+
+## Task 4: Commit the Implementation
+
+**Files:**
+- Commit all implementation files from Tasks 1-3, including both XML fixtures.
+
+- [ ] **Step 1: Stage the implementation files**
+
+Run:
+
+```bash
+git add packages/core/metadata/forms/elements/table/rules.ts \
+  packages/core/metadata/forms/elements/table/__fixtures__/data.ts \
+  packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.ts \
+  packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.xml \
+  packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.ts \
+  packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.xml \
+  packages/core/metadata/forms/elements/__tests__/fixtures.ts
+```
+
+- [ ] **Step 2: Commit**
+
+Run:
+
+```bash
+git commit -m "fix: :bug: сохранить поля таблиц DCS"
+```
+
+Expected: commit succeeds. Do not amend the prior docs commit unless the user explicitly asks.
+
+## Self-Review Notes
+
+- Spec coverage: rules for all three fields are in Task 2; both fixture pairs and `ElementFixtures` registration are in Task 1; shared XML/YAML tests are in Tasks 1 and 3; existing `fullTable` behavior is handled in Task 2.
+- Placeholder scan: no `TBD`, `TODO`, or undefined implementation steps remain.
+- Type consistency: field names are `autofill`, `viewMode`, and `settingsNamedItemDetailedRepresentation` throughout; YAML names match the approved spec.

--- a/docs/superpowers/specs/2026-05-07-table-dcs-composer-fields-design.md
+++ b/docs/superpowers/specs/2026-05-07-table-dcs-composer-fields-design.md
@@ -1,0 +1,47 @@
+# Table DCS Composer Fields Reproducer
+
+## Context
+
+Short round-trip diff 3 shows that form table XML nodes can lose DCS composer table fields during XML -> model -> XML conversion. The immediate examples are two table fixtures:
+
+- `packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.xml`
+- `packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.xml`
+
+Both fixtures should become first-class form element fixtures and run through the shared element test mechanism.
+
+## Design
+
+Add three optional properties to `TableRules`:
+
+- `autofill`: XML `Autofill`, YAML `АвтозаполнениеКолонок`, type `boolean`.
+- `viewMode`: XML `ViewMode`, YAML `РежимОтображения`, type `SystemEnumeration`, `typeSE: "DataCompositionSettingsViewMode"`.
+- `settingsNamedItemDetailedRepresentation`: XML `SettingsNamedItemDetailedRepresentation`, YAML `ПодробноеОтображениеИменованныхЭлементовНастройки`, type `boolean`.
+
+Use simple model names for the first two fields because they match XML and the user explicitly chose that shape. Use a longer model name for `SettingsNamedItemDetailedRepresentation` to preserve the XML meaning without abbreviation.
+
+## Fixtures
+
+Create `dcsComposerFilter.ts` and `dcsComposerSettings.ts` next to the XML files. Each file exports a `Table` model and a `TablePartialYAML` value.
+
+`dcsComposerFilter` covers the three new fields with `Autofill=true`, `ViewMode=QuickAccess`, and `SettingsNamedItemDetailedRepresentation=false`.
+
+`dcsComposerSettings` is a separate table fixture for the nearby DCS composer settings table. It should include supported table properties and YAML expectations, but it does not need to force the three new fields if they are absent from its XML.
+
+## Tests
+
+Register both fixtures in `packages/core/metadata/forms/elements/__tests__/fixtures.ts` under the `Table` region. Use the existing shared element tests for XML and YAML:
+
+- `fromXML.test.ts`
+- `toXML.test.ts`
+- `fromYAML.test.ts`
+- `toYAML.test.ts`
+
+Do not add local `fromXML.test.ts` or `toXML.test.ts` files for `table`, because form elements are tested centrally.
+
+## Existing Full Fixture
+
+Do not add these DCS-specific fields to the existing `fullTable` fixture. If TypeScript requires the `fullTable` required-field assertion to mention the new properties, exclude them from that assertion only. The new fields are covered by the two focused DCS composer fixtures instead.
+
+## Out Of Scope
+
+This design does not change fromXML/toXML/fromYAML/toYAML implementation files directly. Behavior changes should come through `TableRules`.

--- a/packages/core/metadata/forms/elements/__tests__/fixtures.ts
+++ b/packages/core/metadata/forms/elements/__tests__/fixtures.ts
@@ -240,6 +240,8 @@ import {
   minimalSpreadSheetDocumentField,
 } from "../spreadSheetDocumentField/__fixtures__/data"
 import { dynamicList } from "../table/__fixtures__/dynamicList"
+import { dcsComposerFilter, dcsComposerFilterYAML } from "../table/__fixtures__/dcsComposerFilter"
+import { dcsComposerSettings, dcsComposerSettingsYAML } from "../table/__fixtures__/dcsComposerSettings"
 import { fullTable, fullTableEnterprise, fullTableYAML, minimalTable } from "../table/__fixtures__/data"
 import {
   fullTextDocumentField,
@@ -1092,6 +1094,26 @@ export const ElementFixtures: ElementFixture[] = [
     contextAttributes: [
       { itemType: "FormAttribute", name: "Список", type: { type: ["DynamicList"] }, columns: [] },
     ],
+  },
+  {
+    group: "Table",
+    name: "dcsComposerFilter",
+    element: Table,
+    xml: "dcsComposerFilter.xml",
+    xmlFolder: undefined,
+    model: dcsComposerFilter,
+    yaml: dcsComposerFilterYAML,
+    enterprise: undefined,
+  },
+  {
+    group: "Table",
+    name: "dcsComposerSettings",
+    element: Table,
+    xml: "dcsComposerSettings.xml",
+    xmlFolder: undefined,
+    model: dcsComposerSettings,
+    yaml: dcsComposerSettingsYAML,
+    enterprise: undefined,
   },
   //#endregion
   //#region TextDocumentField

--- a/packages/core/metadata/forms/elements/table/__fixtures__/data.ts
+++ b/packages/core/metadata/forms/elements/table/__fixtures__/data.ts
@@ -273,7 +273,10 @@ export const fullTable = {
   viewStatusLocation: "Top",
   visible: false,
   width: 1,
-} satisfies Omit<RequiredFieldsElement<Table>, "period" | "topLevelParent">
+} satisfies Omit<
+  RequiredFieldsElement<Table>,
+  "autofill" | "period" | "settingsNamedItemDetailedRepresentation" | "topLevelParent" | "viewMode"
+>
 
 export const fullTableYAML: TablePartialYAML = {
   АвтоВводНезаполненного: "Истина",

--- a/packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.ts
+++ b/packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.ts
@@ -1,0 +1,35 @@
+import type { Table, TablePartialYAML } from "../types"
+
+export const dcsComposerFilter: Table = {
+  itemType: "Table",
+  name: "КомпоновщикНастроекКомпоновкиДанныхНастройкиОтбор",
+  representation: "Tree",
+  autofill: true,
+  width: 60,
+  initialTreeView: "ExpandAllLevels",
+  enableStartDrag: true,
+  enableDrag: true,
+  dataPath: "КомпоновщикНастроекКомпоновкиДанных.Settings.Filter",
+  viewMode: "QuickAccess",
+  settingsNamedItemDetailedRepresentation: false,
+  childItems: [
+    {
+      itemType: "TableCheckBoxField",
+      name: "КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборИспользование",
+      dataPath: "КомпоновщикНастроекКомпоновкиДанных.Settings.Filter.Use",
+      editMode: "EnterOnInput",
+      checkBoxType: "Auto",
+    },
+  ],
+}
+
+export const dcsComposerFilterYAML: TablePartialYAML = {
+  АвтозаполнениеКолонок: "Истина",
+  НачальноеОтображениеДерева: "РаскрыватьВсеУровни",
+  Отображение: "Дерево",
+  ПодробноеОтображениеИменованныхЭлементовНастройки: "Ложь",
+  РазрешитьНачалоПеретаскивания: "Истина",
+  РазрешитьПеретаскивание: "Истина",
+  РежимОтображения: "БыстрыйДоступ",
+  Ширина: 60,
+}

--- a/packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.xml
+++ b/packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerFilter.xml
@@ -1,0 +1,47 @@
+<Table name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтбор" id="115">
+	<Representation>Tree</Representation>
+	<Autofill>true</Autofill>
+	<Width>60</Width>
+	<InitialTreeView>ExpandAllLevels</InitialTreeView>
+	<EnableStartDrag>true</EnableStartDrag>
+	<EnableDrag>true</EnableDrag>
+	<DataPath>КомпоновщикНастроекКомпоновкиДанных.Settings.Filter</DataPath>
+	<ViewMode>QuickAccess</ViewMode>
+	<SettingsNamedItemDetailedRepresentation>false</SettingsNamedItemDetailedRepresentation>
+	<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборКонтекстноеМеню" id="116"/>
+	<AutoCommandBar name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборКоманднаяПанель" id="117"/>
+	<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборРасширеннаяПодсказка" id="118"/>
+	<SearchStringAddition name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборСтрокаПоиска" id="119">
+		<AdditionSource>
+			<Item>КомпоновщикНастроекКомпоновкиДанныхНастройкиОтбор</Item>
+			<Type>SearchStringRepresentation</Type>
+		</AdditionSource>
+		<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборСтрокаПоискаКонтекстноеМеню" id="120"/>
+		<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборСтрокаПоискаРасширеннаяПодсказка" id="121"/>
+	</SearchStringAddition>
+	<ViewStatusAddition name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборСостояниеПросмотра" id="122">
+		<AdditionSource>
+			<Item>КомпоновщикНастроекКомпоновкиДанныхНастройкиОтбор</Item>
+			<Type>ViewStatusRepresentation</Type>
+		</AdditionSource>
+		<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборСостояниеПросмотраКонтекстноеМеню" id="123"/>
+		<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборСостояниеПросмотраРасширеннаяПодсказка" id="124"/>
+	</ViewStatusAddition>
+	<SearchControlAddition name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборУправлениеПоиском" id="125">
+		<AdditionSource>
+			<Item>КомпоновщикНастроекКомпоновкиДанныхНастройкиОтбор</Item>
+			<Type>SearchControl</Type>
+		</AdditionSource>
+		<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборУправлениеПоискомКонтекстноеМеню" id="126"/>
+		<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборУправлениеПоискомРасширеннаяПодсказка" id="127"/>
+	</SearchControlAddition>
+	<ChildItems>
+		<CheckBoxField name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборИспользование" id="128">
+			<DataPath>КомпоновщикНастроекКомпоновкиДанных.Settings.Filter.Use</DataPath>
+			<EditMode>EnterOnInput</EditMode>
+			<CheckBoxType>Auto</CheckBoxType>
+			<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборИспользованиеКонтекстноеМеню" id="129"/>
+			<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиОтборИспользованиеРасширеннаяПодсказка" id="130"/>
+		</CheckBoxField>
+	</ChildItems>
+</Table>

--- a/packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.ts
+++ b/packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.ts
@@ -1,0 +1,31 @@
+import type { Table, TablePartialYAML } from "../types"
+
+export const dcsComposerSettings: Table = {
+  itemType: "Table",
+  name: "КомпоновщикНастроекКомпоновкиДанныхНастройки",
+  representation: "Tree",
+  horizontalLines: false,
+  useAlternationRowColor: true,
+  initialTreeView: "ExpandAllLevels",
+  enableStartDrag: true,
+  enableDrag: true,
+  dataPath: "КомпоновщикНастроекКомпоновкиДанных.Settings",
+  childItems: [
+    {
+      itemType: "TableCheckBoxField",
+      name: "КомпоновщикНастроекКомпоновкиДанныхНастройкиИспользование",
+      dataPath: "КомпоновщикНастроекКомпоновкиДанных.Settings.Use",
+      editMode: "EnterOnInput",
+      checkBoxType: "Auto",
+    },
+  ],
+}
+
+export const dcsComposerSettingsYAML: TablePartialYAML = {
+  ГоризонтальныеЛинии: "Ложь",
+  НачальноеОтображениеДерева: "РаскрыватьВсеУровни",
+  Отображение: "Дерево",
+  РазрешитьНачалоПеретаскивания: "Истина",
+  РазрешитьПеретаскивание: "Истина",
+  ЧередованиеЦветовСтрок: "Истина",
+}

--- a/packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.xml
+++ b/packages/core/metadata/forms/elements/table/__fixtures__/dcsComposerSettings.xml
@@ -1,0 +1,45 @@
+<Table name="КомпоновщикНастроекКомпоновкиДанныхНастройки" id="102">
+	<Representation>Tree</Representation>
+	<HorizontalLines>false</HorizontalLines>
+	<UseAlternationRowColor>true</UseAlternationRowColor>
+	<InitialTreeView>ExpandAllLevels</InitialTreeView>
+	<EnableStartDrag>true</EnableStartDrag>
+	<EnableDrag>true</EnableDrag>
+	<DataPath>КомпоновщикНастроекКомпоновкиДанных.Settings</DataPath>
+	<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиКонтекстноеМеню" id="103"/>
+	<AutoCommandBar name="КомпоновщикНастроекКомпоновкиДанныхНастройкиКоманднаяПанель" id="104"/>
+	<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиРасширеннаяПодсказка" id="105"/>
+	<SearchStringAddition name="КомпоновщикНастроекКомпоновкиДанныхНастройкиСтрокаПоиска" id="106">
+		<AdditionSource>
+			<Item>КомпоновщикНастроекКомпоновкиДанныхНастройки</Item>
+			<Type>SearchStringRepresentation</Type>
+		</AdditionSource>
+		<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиСтрокаПоискаКонтекстноеМеню" id="107"/>
+		<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиСтрокаПоискаРасширеннаяПодсказка" id="108"/>
+	</SearchStringAddition>
+	<ViewStatusAddition name="КомпоновщикНастроекКомпоновкиДанныхНастройкиСостояниеПросмотра" id="109">
+		<AdditionSource>
+			<Item>КомпоновщикНастроекКомпоновкиДанныхНастройки</Item>
+			<Type>ViewStatusRepresentation</Type>
+		</AdditionSource>
+		<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиСостояниеПросмотраКонтекстноеМеню" id="110"/>
+		<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиСостояниеПросмотраРасширеннаяПодсказка" id="111"/>
+	</ViewStatusAddition>
+	<SearchControlAddition name="КомпоновщикНастроекКомпоновкиДанныхНастройкиУправлениеПоиском" id="112">
+		<AdditionSource>
+			<Item>КомпоновщикНастроекКомпоновкиДанныхНастройки</Item>
+			<Type>SearchControl</Type>
+		</AdditionSource>
+		<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиУправлениеПоискомКонтекстноеМеню" id="113"/>
+		<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиУправлениеПоискомРасширеннаяПодсказка" id="114"/>
+	</SearchControlAddition>
+	<ChildItems>
+		<CheckBoxField name="КомпоновщикНастроекКомпоновкиДанныхНастройкиИспользование" id="131">
+			<DataPath>КомпоновщикНастроекКомпоновкиДанных.Settings.Use</DataPath>
+			<EditMode>EnterOnInput</EditMode>
+			<CheckBoxType>Auto</CheckBoxType>
+			<ContextMenu name="КомпоновщикНастроекКомпоновкиДанныхНастройкиИспользованиеКонтекстноеМеню" id="132"/>
+			<ExtendedTooltip name="КомпоновщикНастроекКомпоновкиДанныхНастройкиИспользованиеРасширеннаяПодсказка" id="133"/>
+		</CheckBoxField>
+	</ChildItems>
+</Table>

--- a/packages/core/metadata/forms/elements/table/rules.ts
+++ b/packages/core/metadata/forms/elements/table/rules.ts
@@ -19,6 +19,17 @@ export const TableRules = {
     },
     autoAddIncomplete: { yaml: "АвтоВводНезаполненного", type: "boolean" },
     autoCommandBar: { yaml: "КоманднаяПанель", type: "TableAutoCommandBar", toEnterprise: false },
+    autofill: { yaml: "АвтозаполнениеКолонок", type: "boolean" },
+    viewMode: {
+      yaml: "РежимОтображения",
+      type: "SystemEnumeration",
+      typeSE: "DataCompositionSettingsViewMode",
+    },
+    settingsNamedItemDetailedRepresentation: {
+      yaml: "ПодробноеОтображениеИменованныхЭлементовНастройки",
+      xml: "SettingsNamedItemDetailedRepresentation",
+      type: "boolean",
+    },
     autoInsertNewRow: { yaml: "АвтоВводНовойСтроки", type: "boolean" },
     autoMarkIncomplete: { yaml: "АвтоОтметкаНезаполненного", type: "boolean" },
     autoMaxHeight: { yaml: "АвтоМаксимальнаяВысота", type: "boolean" },


### PR DESCRIPTION
## Что изменилось
- Добавлены правила Table для Autofill, ViewMode и SettingsNamedItemDetailedRepresentation.
- Добавлены две отдельные фикстуры dcsComposerFilter и dcsComposerSettings с XML/TS/YAML покрытием.
- Фикстуры подключены к общему механизму тестирования элементов.

## Проверка
- pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t dcsComposer
- pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t Table
- pnpm --filter '@nakidka/core' exec vitest run
- round-trip-xml --triage --batch-size 5 --start-index 11: DIFF_COUNT 514 -> 508, НастройкаОтборов с Autofill/ViewMode исчез из пачки