### PR TITLE
fix: сохранить xsi:type числовых границ

### DIFF
--- a/packages/core/metadata/commonObjects/metadataAttribute/rules.ts
+++ b/packages/core/metadata/commonObjects/metadataAttribute/rules.ts
@@ -112,6 +112,7 @@ const commonAttributeProperties = {
     type: "number",
     xmlParents: ["Properties"],
     order: 13,
+    typedXML: "xs:string",
     defaultValueXMLRaw: { "_xsi:nil": true },
   },
   maxValue: {
@@ -120,6 +121,7 @@ const commonAttributeProperties = {
     type: "number",
     xmlParents: ["Properties"],
     order: 14,
+    typedXML: "xs:string",
     defaultValueXMLRaw: { "_xsi:nil": true },
   },
   fillChecking: {

--- a/packages/core/metadata/commonObjects/metadataAttribute/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataAttribute/toXML.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { minimalFromXML, multipleFromXML } from "./__fixtures__/data"
+import { fullFromXML, minimalFromXML, multipleFromXML } from "./__fixtures__/data"
 import { testExportPropertyToXML } from "~/tests/property/exportPropertyToXML"
 
 const rule = { type: "MetadataAttributes", xml: "Attribute" } as const
@@ -22,6 +22,17 @@ describe("export MetadataAttributes to XML", () => {
       value: multipleFromXML,
       xmlRootTag: "Attribute",
       path: "multiple.xml",
+      importMetaUrl: import.meta.url,
+    })
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("should export full (round-trip)", () => {
+    const { expectedResult, result } = testExportPropertyToXML({
+      rule,
+      value: fullFromXML,
+      xmlRootTag: "Attribute",
+      path: "full.xml",
       importMetaUrl: import.meta.url,
     })
     expect(result).toEqual(expectedResult)

--- a/packages/core/metadata/commonObjects/number/toXML.ts
+++ b/packages/core/metadata/commonObjects/number/toXML.ts
@@ -7,11 +7,12 @@ export const exportNumberToXML = (
   _context: ConfigurationContextWithExportToXML,
   rule: PropertyRule | undefined,
   value: number | undefined
-): number | { "_xsi:type": "xs:decimal"; "#text": string } | undefined => {
+): number | { "_xsi:type": "xs:decimal" | "xs:string"; "#text": string } | undefined => {
   if (value === undefined) return undefined
   const numberRule = rule as NumberPropertyRule | undefined
   if (numberRule?.typedXML) {
-    return { "_xsi:type": "xs:decimal", "#text": String(value) }
+    const xsiType = numberRule.typedXML === true ? "xs:decimal" : numberRule.typedXML
+    return { "_xsi:type": xsiType, "#text": String(value) }
   }
   return value
 }

--- a/packages/core/metadata/commonObjects/number/types.ts
+++ b/packages/core/metadata/commonObjects/number/types.ts
@@ -7,6 +7,6 @@ export type NumberYAML = Static<typeof NumberJSONSchema>
 
 export interface NumberPropertyRule extends BasePropertyRule {
   type: "number"
-  /** Выгружать число с указанием типа: `xsi:type="xs:decimal"` */
-  typedXML?: true
+  /** Выгружать число с указанием `xsi:type`. `true` сохраняет старое поведение: `xs:decimal`. */
+  typedXML?: true | "xs:decimal" | "xs:string"
 }

--- a/packages/core/metadata/forms/elements/table/__fixtures__/data.ts
+++ b/packages/core/metadata/forms/elements/table/__fixtures__/data.ts
@@ -595,7 +595,10 @@ export const fullTableEnterprise = {
   AllowGettingCurrentRowURL: true,
   UserSettingsGroup: "ГруппаПользовательскихНастроек",
   RowsPicture: { Type: "Picture", Value: "PictureLib.Print" },
-} satisfies Omit<Required<TableEnterprise>, "Period" | "TopLevelParent">
+} satisfies Omit<
+  Required<TableEnterprise>,
+  "Autofill" | "Period" | "SettingsNamedItemDetailedRepresentation" | "TopLevelParent" | "ViewMode"
+>
 
 export const fullTableChildItems = {
   ТаблицаГруппа1: {


### PR DESCRIPTION
## Summary
- расширяет typedXML у number для строкового xsi:type
- сохраняет xs:string у MinValue/MaxValue metadataAttribute
- добавляет export round-trip full.xml и синхронизирует table enterprise fixture

## Test Plan
- [x] pnpm --filter '@nakidka/core' run type-check
- [x] pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/metadataAttribute metadata/commonObjects/number metadata/forms/elements/table
- [x] pnpm test