### PR TITLE
Сохранять DataPath командных кнопок

### DIFF
--- a/docs/superpowers/plans/2026-05-07-command-button-datapath.md
+++ b/docs/superpowers/plans/2026-05-07-command-button-datapath.md
@@ -46,17 +46,12 @@ export const commandBarButtonWithDataPath = {
   type: "CommandBarButton",
   commandName: "CommonCommand.КомандаСПараметром",
   dataPath: "Items.ДинамическийСписок.CurrentData.Ref",
-  extendedTooltip: {
-    itemType: "ExtendedTooltip",
-    name: "ОбщаяКомандаКомандаСПараметромРасширеннаяПодсказка",
-  },
 } satisfies CommandBarButton
 
 export const commandBarButtonWithDataPathPartialYAML = {
   Вид: "КнопкаКоманднойПанели",
   ИмяКоманды: "CommonCommand.КомандаСПараметром",
   Данные: "Items.ДинамическийСписок.CurrentData.Ref",
-  РасширеннаяПодсказка: {},
 } satisfies CommandBarButtonPartialYAML
 
 export const commandBarButtonWithDataPathTypedYAML: CommandBarButtonTypedYAML = {
@@ -136,7 +131,7 @@ In `packages/core/metadata/forms/elements/button/rules.ts`, change the area arou
 ```ts
   check: { yaml: "Пометка", type: "boolean" },
   commandName: { yaml: "ИмяКоманды", type: "CommandName" },
-  dataPath: { yaml: "Данные", xml: "DataPath", type: "DataPath" },
+  dataPath: { yaml: "Данные", xml: "DataPath", type: "DataPath", defaultType: "string" },
   textColor: { yaml: "ЦветТекста", type: "Color" },
 ```
 
@@ -207,7 +202,7 @@ No output means the implementation and test commits captured all intended change
 
 ## Self-Review
 
-- Spec coverage: Task 1 covers the provided XML fixture and shared test registration. Task 2 covers the `dataPath` rule with YAML `Данные`, XML `DataPath`, and type `DataPath`. Task 3 covers package verification.
+- Spec coverage: Task 1 covers the provided XML fixture and shared test registration. Task 2 covers the `dataPath` rule with YAML `Данные`, XML `DataPath`, type `DataPath`, and Enterprise fallback type `string`. Task 3 covers package verification.
 - Scope check: The plan does not include `MobileDeviceCommandBarContent`, `CommandInterface` ordering, DCS `xsi:type`, chart settings, or form attribute columns.
 - Placeholder scan: No placeholders remain; each code-editing step includes concrete code and exact commands.
 - Type consistency: The property is consistently named `dataPath` in TS, `DataPath` in XML, and `Данные` in YAML.

--- a/docs/superpowers/plans/2026-05-07-command-button-datapath.md
+++ b/docs/superpowers/plans/2026-05-07-command-button-datapath.md
@@ -1,0 +1,213 @@
+# Command Button DataPath Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve the `DataPath` XML node for command bar buttons during form element XML and YAML round-trips.
+
+**Architecture:** Button form elements are rule-driven. Add `dataPath` to shared button rules so `Button` and `CommandBarButton` use the same import/export pipeline, then register the provided `withDataPath.xml` fixture in the existing centralized element fixture table.
+
+**Tech Stack:** TypeScript, Vitest, rule-driven metadata orchestration, `DataPath` common object type, pnpm workspace.
+
+---
+
+## File Structure
+
+- Modify `packages/core/metadata/forms/elements/button/rules.ts`
+  - Owns button element rule definitions.
+  - Add `dataPath` to `commonButtonProperties` near `commandName`.
+- Modify `packages/core/metadata/forms/elements/button/__fixtures__/data.ts`
+  - Owns expected model/YAML/enterprise fixtures for button tests.
+  - Add model and YAML constants for the existing `withDataPath.xml`.
+- Modify `packages/core/metadata/forms/elements/__tests__/fixtures.ts`
+  - Owns the shared fixture registry used by form element XML/YAML tests.
+  - Import and register the new `with data path` fixture.
+- Use existing `packages/core/metadata/forms/elements/button/__fixtures__/withDataPath.xml`
+  - User-provided XML source fixture.
+  - Do not rewrite it unless formatting fails in `toXML`.
+
+## Task 1: Register Failing DataPath Fixture
+
+**Files:**
+- Modify: `packages/core/metadata/forms/elements/button/__fixtures__/data.ts`
+- Modify: `packages/core/metadata/forms/elements/__tests__/fixtures.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/fromXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/fromYAML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toYAML.test.ts`
+
+- [ ] **Step 1: Add expected model and YAML fixtures**
+
+In `packages/core/metadata/forms/elements/button/__fixtures__/data.ts`, insert this block after `fullCommandBarButtonEnterprise` and before `//#endregion` for `CommandBarButton / CommandBarButton`:
+
+```ts
+export const commandBarButtonWithDataPath = {
+  itemType: "CommandBarButton",
+  name: "ОбщаяКомандаКомандаСПараметром",
+  type: "CommandBarButton",
+  commandName: "CommonCommand.КомандаСПараметром",
+  dataPath: "Items.ДинамическийСписок.CurrentData.Ref",
+  extendedTooltip: {
+    itemType: "ExtendedTooltip",
+    name: "ОбщаяКомандаКомандаСПараметромРасширеннаяПодсказка",
+  },
+} satisfies CommandBarButton
+
+export const commandBarButtonWithDataPathPartialYAML = {
+  Вид: "КнопкаКоманднойПанели",
+  ИмяКоманды: "CommonCommand.КомандаСПараметром",
+  Данные: "Items.ДинамическийСписок.CurrentData.Ref",
+  РасширеннаяПодсказка: {},
+} satisfies CommandBarButtonPartialYAML
+
+export const commandBarButtonWithDataPathTypedYAML: CommandBarButtonTypedYAML = {
+  ...commandBarButtonWithDataPathPartialYAML,
+  Тип: "КнопкаКоманднойПанели",
+}
+```
+
+- [ ] **Step 2: Import new fixtures in the shared element registry**
+
+In `packages/core/metadata/forms/elements/__tests__/fixtures.ts`, extend the import from `../button/__fixtures__/data`:
+
+```ts
+  commandBarButtonWithDataPath,
+  commandBarButtonWithDataPathPartialYAML,
+  commandBarButtonWithDataPathTypedYAML,
+```
+
+Keep the imported names sorted with the nearby button fixture imports if the file already follows that style.
+
+- [ ] **Step 3: Register the XML fixture**
+
+In `packages/core/metadata/forms/elements/__tests__/fixtures.ts`, add this entry in the `CommandBarButton` region after the existing `"command bar button"` fixture:
+
+```ts
+  {
+    group: "CommandBarButton",
+    name: "with data path",
+    element: CommandBarButton,
+    xml: "withDataPath.xml",
+    xmlFolder: "button",
+    model: commandBarButtonWithDataPath,
+    yaml: commandBarButtonWithDataPathPartialYAML,
+    typedYAML: commandBarButtonWithDataPathTypedYAML,
+    enterprise: undefined,
+  },
+```
+
+- [ ] **Step 4: Run the focused tests and verify the expected failure**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t "with data path"
+```
+
+Expected before the implementation:
+
+- `fromXML` fails because imported model does not include `dataPath`.
+- `toXML` fails because exported XML does not include `<DataPath>Items.ДинамическийСписок.CurrentData.Ref</DataPath>`.
+- `fromYAML` / `toYAML` may fail on unknown or missing YAML field `Данные`.
+
+The exact assertion format may differ, but at least one failure must show `dataPath` / `DataPath` / `Данные` is not round-tripping.
+
+- [ ] **Step 5: Commit the failing fixture**
+
+Run:
+
+```bash
+git add packages/core/metadata/forms/elements/button/__fixtures__/withDataPath.xml packages/core/metadata/forms/elements/button/__fixtures__/data.ts packages/core/metadata/forms/elements/__tests__/fixtures.ts
+git commit -m "test: :white_check_mark: покрыть DataPath командной кнопки"
+```
+
+## Task 2: Implement DataPath Rule
+
+**Files:**
+- Modify: `packages/core/metadata/forms/elements/button/rules.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/fromXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/fromYAML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toYAML.test.ts`
+
+- [ ] **Step 1: Add the `dataPath` property rule**
+
+In `packages/core/metadata/forms/elements/button/rules.ts`, change the area around `commandName` to:
+
+```ts
+  check: { yaml: "Пометка", type: "boolean" },
+  commandName: { yaml: "ИмяКоманды", type: "CommandName" },
+  dataPath: { yaml: "Данные", xml: "DataPath", type: "DataPath" },
+  textColor: { yaml: "ЦветТекста", type: "Color" },
+```
+
+Do not add custom `fromXML`, `toXML`, `fromYAML`, or `toYAML` handlers. The existing rule pipeline should handle `DataPath`.
+
+- [ ] **Step 2: Run the focused tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t "with data path"
+```
+
+Expected:
+
+```text
+Test Files  4 passed
+```
+
+Vitest may report skipped unrelated cases, but the `with data path` cases must pass.
+
+- [ ] **Step 3: Commit the implementation**
+
+Run:
+
+```bash
+git add packages/core/metadata/forms/elements/button/rules.ts
+git commit -m "fix: :bug: сохранять DataPath командных кнопок"
+```
+
+## Task 3: Verify Package Baseline
+
+**Files:**
+- No source edits expected.
+- Test: all `@nakidka/core` tests.
+
+- [ ] **Step 1: Run the core package test suite**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' test
+```
+
+Expected:
+
+```text
+Test Files  391 passed | 9 skipped (400)
+Tests       2640 passed | 13 skipped (2653)
+```
+
+The exact duration can differ. If new tests increase the count, accept the increased passing total if there are no failures.
+
+- [ ] **Step 2: Check worktree status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+
+```text
+```
+
+No output means the implementation and test commits captured all intended changes. If generated files changed unexpectedly, inspect them before committing.
+
+## Self-Review
+
+- Spec coverage: Task 1 covers the provided XML fixture and shared test registration. Task 2 covers the `dataPath` rule with YAML `Данные`, XML `DataPath`, and type `DataPath`. Task 3 covers package verification.
+- Scope check: The plan does not include `MobileDeviceCommandBarContent`, `CommandInterface` ordering, DCS `xsi:type`, chart settings, or form attribute columns.
+- Placeholder scan: No placeholders remain; each code-editing step includes concrete code and exact commands.
+- Type consistency: The property is consistently named `dataPath` in TS, `DataPath` in XML, and `Данные` in YAML.

--- a/docs/superpowers/specs/2026-05-07-command-button-datapath-design.md
+++ b/docs/superpowers/specs/2026-05-07-command-button-datapath-design.md
@@ -1,0 +1,57 @@
+# DataPath у командных кнопок
+
+## Цель
+
+Сохранить XML-узел `DataPath` у кнопок командной панели при импорте и экспорте формы.
+Первичный пример покрывает фикстура `packages/core/metadata/forms/elements/button/__fixtures__/withDataPath.xml`.
+
+## Границы
+
+В работу входит только свойство `DataPath` для элементов `Button` / `CommandBarButton`.
+Не входят другие текущие round-trip расхождения: `MobileDeviceCommandBarContent`, порядок `CommandInterface`, DCS `xsi:type`, настройки диаграмм и колонки реквизитов.
+
+## Решение
+
+Добавить свойство `dataPath` в `commonButtonProperties`:
+
+- YAML: `Данные`
+- XML: `DataPath`
+- тип: `DataPath`
+
+Свойство размещается рядом с `commandName`, потому что `DataPath` задает данные для команды кнопки. Добавление в общие свойства делает его доступным как для обычной `Button`, так и для `CommandBarButton`, что согласуется с текущей моделью общих свойств кнопок.
+
+## Тестовые данные
+
+В `packages/core/metadata/forms/elements/button/__fixtures__/data.ts` добавляется модель для `withDataPath.xml`:
+
+- `itemType: "CommandBarButton"`
+- `name: "ОбщаяКомандаКомандаСПараметром"`
+- `type: "CommandBarButton"`
+- `commandName: "CommonCommand.КомандаСПараметром"`
+- `dataPath: "Items.ДинамическийСписок.CurrentData.Ref"`
+- `extendedTooltip` по XML-фикстуре
+
+Для YAML-ожидания используется поле `Данные` с тем же путем.
+
+## Подключение к тестам
+
+В `packages/core/metadata/forms/elements/__tests__/fixtures.ts` добавляется запись группы `CommandBarButton` для `withDataPath.xml`. Это включает фикстуру в общие проверки:
+
+- `fromXML`
+- `toXML`
+- `fromYAML`
+- `toYAML`
+
+## Проверка
+
+Сначала запускается узкая проверка по новой фикстуре:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t "with data path"
+```
+
+После этого запускается пакетная проверка:
+
+```bash
+pnpm --filter '@nakidka/core' test
+```

--- a/docs/superpowers/specs/2026-05-07-command-button-datapath-design.md
+++ b/docs/superpowers/specs/2026-05-07-command-button-datapath-design.md
@@ -17,6 +17,7 @@
 - YAML: `Данные`
 - XML: `DataPath`
 - тип: `DataPath`
+- fallback-тип для Enterprise: `string`
 
 Свойство размещается рядом с `commandName`, потому что `DataPath` задает данные для команды кнопки. Добавление в общие свойства делает его доступным как для обычной `Button`, так и для `CommandBarButton`, что согласуется с текущей моделью общих свойств кнопок.
 
@@ -29,7 +30,6 @@
 - `type: "CommandBarButton"`
 - `commandName: "CommonCommand.КомандаСПараметром"`
 - `dataPath: "Items.ДинамическийСписок.CurrentData.Ref"`
-- `extendedTooltip` по XML-фикстуре
 
 Для YAML-ожидания используется поле `Данные` с тем же путем.
 

--- a/packages/core/metadata/forms/elements/__tests__/fixtures.ts
+++ b/packages/core/metadata/forms/elements/__tests__/fixtures.ts
@@ -22,6 +22,9 @@ import {
   TablePictureField,
 } from "nkdk-language"
 import {
+  commandBarButtonWithDataPath,
+  commandBarButtonWithDataPathPartialYAML,
+  commandBarButtonWithDataPathTypedYAML,
   fullCommandBarButton,
   fullCommandBarButtonEnterprise,
   fullCommandBarButtonPartialYAML,
@@ -369,6 +372,17 @@ export const ElementFixtures: ElementFixture[] = [
     yaml: fullCommandBarButtonPartialYAML,
     typedYAML: fullCommandBarButtonTypedYAML,
     enterprise: fullCommandBarButtonEnterprise,
+  },
+  {
+    group: "CommandBarButton",
+    name: "with data path",
+    element: CommandBarButton,
+    xml: "withDataPath.xml",
+    xmlFolder: "button",
+    model: commandBarButtonWithDataPath,
+    yaml: commandBarButtonWithDataPathPartialYAML,
+    typedYAML: commandBarButtonWithDataPathTypedYAML,
+    enterprise: undefined,
   },
   {
     group: "CommandBarButton",

--- a/packages/core/metadata/forms/elements/button/__fixtures__/data.ts
+++ b/packages/core/metadata/forms/elements/button/__fixtures__/data.ts
@@ -218,6 +218,25 @@ export const fullCommandBarButtonEnterprise = {
   Type: { Type: "SystemEnumeration" as const, Value: "FormButtonType.CommandBarButton" },
 } satisfies CommandBarButtonEnterprise
 
+export const commandBarButtonWithDataPath = {
+  itemType: "CommandBarButton",
+  name: "ОбщаяКомандаКомандаСПараметром",
+  type: "CommandBarButton",
+  commandName: "CommonCommand.КомандаСПараметром",
+  dataPath: "Items.ДинамическийСписок.CurrentData.Ref",
+} satisfies CommandBarButton
+
+export const commandBarButtonWithDataPathPartialYAML = {
+  Вид: "КнопкаКоманднойПанели",
+  ИмяКоманды: "CommonCommand.КомандаСПараметром",
+  Данные: "Items.ДинамическийСписок.CurrentData.Ref",
+} satisfies CommandBarButtonPartialYAML
+
+export const commandBarButtonWithDataPathTypedYAML: CommandBarButtonTypedYAML = {
+  ...commandBarButtonWithDataPathPartialYAML,
+  Тип: "КнопкаКоманднойПанели",
+}
+
 //#endregion
 
 //#region CommandBarButton / CommandBarHyperlink

--- a/packages/core/metadata/forms/elements/button/__fixtures__/withDataPath.xml
+++ b/packages/core/metadata/forms/elements/button/__fixtures__/withDataPath.xml
@@ -1,0 +1,6 @@
+<Button name="ОбщаяКомандаКомандаСПараметром" id="9">
+	<Type>CommandBarButton</Type>
+	<CommandName>CommonCommand.КомандаСПараметром</CommandName>
+	<DataPath>Items.ДинамическийСписок.CurrentData.Ref</DataPath>
+	<ExtendedTooltip name="ОбщаяКомандаКомандаСПараметромРасширеннаяПодсказка" id="10"/>
+</Button>

--- a/packages/core/metadata/forms/elements/button/rules.ts
+++ b/packages/core/metadata/forms/elements/button/rules.ts
@@ -52,7 +52,7 @@ export const commonButtonProperties = {
   },
   check: { yaml: "Пометка", type: "boolean" },
   commandName: { yaml: "ИмяКоманды", type: "CommandName" },
-  dataPath: { yaml: "Данные", xml: "DataPath", type: "DataPath" },
+  dataPath: { yaml: "Данные", xml: "DataPath", type: "DataPath", defaultType: "string" },
   textColor: { yaml: "ЦветТекста", type: "Color" },
   backColor: { yaml: "ЦветФона", type: "Color" },
   borderColor: { yaml: "ЦветРамки", type: "Color" },

--- a/packages/core/metadata/forms/elements/button/rules.ts
+++ b/packages/core/metadata/forms/elements/button/rules.ts
@@ -52,6 +52,7 @@ export const commonButtonProperties = {
   },
   check: { yaml: "Пометка", type: "boolean" },
   commandName: { yaml: "ИмяКоманды", type: "CommandName" },
+  dataPath: { yaml: "Данные", xml: "DataPath", type: "DataPath" },
   textColor: { yaml: "ЦветТекста", type: "Color" },
   backColor: { yaml: "ЦветФона", type: "Color" },
   borderColor: { yaml: "ЦветРамки", type: "Color" },


### PR DESCRIPTION
## Summary
- добавить правило DataPath для Button/CommandBarButton с YAML-полем `Данные`
- покрыть XML/YAML round-trip фикстурой командной кнопки с `DataPath`
- добавить спецификацию и план реализации

## Test Plan
- [x] `pnpm --filter '@nakidka/core' exec tsc --noEmit`
- [x] `pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t "with data path"`
- [x] `pnpm --filter '@nakidka/core' test`