### PR TITLE
fix: сохранить порядок CommandInterface

### DIFF
--- a/docs/superpowers/plans/2026-05-07-command-interface-index-order.md
+++ b/docs/superpowers/plans/2026-05-07-command-interface-index-order.md
@@ -13,7 +13,7 @@
 ## File Structure
 
 - Create: `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/indexedItemOrderSwap.xml`
-  - Minimal `CommandInterface` XML with two `NavigationPanel.Item` nodes in source order: first without `Index`, second with `Index`.
+  - Minimal `CommandInterface` XML with two `NavigationPanel.Item` nodes in source order: first with `Index`, second without `Index`.
 - Create: `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/indexedItemOrderSwap.ts`
   - Expected `CommandInterface` model in XML order.
 - Modify: `packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts`
@@ -49,8 +49,9 @@ Create `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__
 <CommandInterface>
 	<NavigationPanel>
 		<Item>
-			<Command>InformationRegister.ОтносительныеКурсыВалют.Command.ЗагрузитьКурсыИзТаблицы</Command>
+			<Command>DataProcessor.ЗагрузкаКурсовВалютЕЦБ.Command.ЗагрузитьКурсыВалютЕЦБ</Command>
 			<Type>Added</Type>
+			<Index>1</Index>
 			<DefaultVisible>false</DefaultVisible>
 			<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
 			<Visible>
@@ -58,9 +59,8 @@ Create `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__
 			</Visible>
 		</Item>
 		<Item>
-			<Command>DataProcessor.ЗагрузкаКурсовВалютЕЦБ.Command.ЗагрузитьКурсыВалютЕЦБ</Command>
+			<Command>InformationRegister.ОтносительныеКурсыВалют.Command.ЗагрузитьКурсыИзТаблицы</Command>
 			<Type>Added</Type>
-			<Index>1</Index>
 			<DefaultVisible>false</DefaultVisible>
 			<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
 			<Visible>
@@ -82,8 +82,9 @@ export const indexedItemOrderSwap = {
   itemType: "CommandInterface",
   NavigationPanel: [
     {
-      command: "InformationRegister.ОтносительныеКурсыВалют.Command.ЗагрузитьКурсыИзТаблицы",
+      command: "DataProcessor.ЗагрузкаКурсовВалютЕЦБ.Command.ЗагрузитьКурсыВалютЕЦБ",
       type: "Added",
+      index: 1,
       defaultVisible: false,
       commandGroup: "FormNavigationPanelGoTo",
       visible: {
@@ -93,9 +94,8 @@ export const indexedItemOrderSwap = {
       itemType: "CommandInterfaceItem",
     },
     {
-      command: "DataProcessor.ЗагрузкаКурсовВалютЕЦБ.Command.ЗагрузитьКурсыВалютЕЦБ",
+      command: "InformationRegister.ОтносительныеКурсыВалют.Command.ЗагрузитьКурсыИзТаблицы",
       type: "Added",
-      index: 1,
       defaultVisible: false,
       commandGroup: "FormNavigationPanelGoTo",
       visible: {
@@ -158,17 +158,17 @@ Inside `describe("exportCommandInterfaceToXML", () => { ... })`, after `it("expo
 Run:
 
 ```bash
-pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts -t "import indexedItemOrderSwap"
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/commandInterface/fromXML.test.ts -t "import indexedItemOrderSwap"
 ```
 
-Expected: FAIL. The diff must show `NavigationPanel` items in the wrong order: the item with command `DataProcessor.ЗагрузкаКурсовВалютЕЦБ.Command.ЗагрузитьКурсыВалютЕЦБ` appears before `InformationRegister.ОтносительныеКурсыВалют.Command.ЗагрузитьКурсыИзТаблицы`.
+Expected: FAIL. The diff must show `NavigationPanel` items in the wrong order: current sorting moves the unindexed item with command `InformationRegister.ОтносительныеКурсыВалют.Command.ЗагрузитьКурсыИзТаблицы` before the indexed item with command `DataProcessor.ЗагрузкаКурсовВалютЕЦБ.Command.ЗагрузитьКурсыВалютЕЦБ`.
 
 - [ ] **Step 6: Run the focused export test and verify it passes**
 
 Run:
 
 ```bash
-pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/commandInterface/toXML.test.ts -t "export indexedItemOrderSwap"
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/commandInterface/toXML.test.ts -t "export indexedItemOrderSwap"
 ```
 
 Expected: PASS. If it fails only because of whitespace or final newline, adjust only `indexedItemOrderSwap.xml` formatting to match existing `commandInterface` fixtures and rerun this step.
@@ -217,7 +217,7 @@ with:
 Run:
 
 ```bash
-pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts -t "import indexedItemOrderSwap"
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/commandInterface/fromXML.test.ts -t "import indexedItemOrderSwap"
 ```
 
 Expected: PASS.
@@ -227,7 +227,7 @@ Expected: PASS.
 Run:
 
 ```bash
-pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/commandInterface
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/commandInterface
 ```
 
 Expected: PASS for `fromXML.test.ts`, `toXML.test.ts`, `fromYAML.test.ts`, and `toYAML.test.ts`.

--- a/packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/indexedItemOrderSwap.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/indexedItemOrderSwap.ts
@@ -1,0 +1,31 @@
+import type { CommandInterface } from "../types"
+
+export const indexedItemOrderSwap = {
+  itemType: "CommandInterface",
+  NavigationPanel: [
+    {
+      command: "DataProcessor.ЗагрузкаКурсовВалютЕЦБ.Command.ЗагрузитьКурсыВалютЕЦБ",
+      type: "Added",
+      index: 1,
+      defaultVisible: false,
+      commandGroup: "FormNavigationPanelGoTo",
+      visible: {
+        common: false,
+        values: [],
+      },
+      itemType: "CommandInterfaceItem",
+    },
+    {
+      command: "InformationRegister.ОтносительныеКурсыВалют.Command.ЗагрузитьКурсыИзТаблицы",
+      type: "Added",
+      defaultVisible: false,
+      commandGroup: "FormNavigationPanelGoTo",
+      visible: {
+        common: false,
+        values: [],
+      },
+      itemType: "CommandInterfaceItem",
+    },
+  ],
+  CommandBar: [],
+} as const satisfies CommandInterface

--- a/packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/indexedItemOrderSwap.xml
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/indexedItemOrderSwap.xml
@@ -1,0 +1,23 @@
+<CommandInterface>
+	<NavigationPanel>
+		<Item>
+			<Command>DataProcessor.ЗагрузкаКурсовВалютЕЦБ.Command.ЗагрузитьКурсыВалютЕЦБ</Command>
+			<Type>Added</Type>
+			<Index>1</Index>
+			<DefaultVisible>false</DefaultVisible>
+			<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
+			<Visible>
+				<xr:Common>false</xr:Common>
+			</Visible>
+		</Item>
+		<Item>
+			<Command>InformationRegister.ОтносительныеКурсыВалют.Command.ЗагрузитьКурсыИзТаблицы</Command>
+			<Type>Added</Type>
+			<DefaultVisible>false</DefaultVisible>
+			<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
+			<Visible>
+				<xr:Common>false</xr:Common>
+			</Visible>
+		</Item>
+	</NavigationPanel>
+</CommandInterface>

--- a/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest"
 import { mockContextFromXML, mockRule } from "~/tests/mockContext"
 import { readAndParseXMLFile } from "~/tests/readAndParseXMLFile"
 import { commandBarIndexInsertion } from "./__fixtures__/commandBarIndexInsertion"
+import { indexedItemOrderSwap } from "./__fixtures__/indexedItemOrderSwap"
 import { fullCommandInterface } from "./__fixtures__/full"
 import { importCommandInterfaceFromXML } from "./fromXML"
 import { CommandInterfaceXML } from "./types"
@@ -34,5 +35,16 @@ describe("importCommandInterfaceFromXML", () => {
     const result = importCommandInterfaceFromXML(mockContextFromXML(), mockRule, xmlData.CommandInterface)
 
     expect(result).toEqual(commandBarIndexInsertion)
+  })
+
+  it("import indexedItemOrderSwap", () => {
+    const xmlData = readAndParseXMLFile<{ CommandInterface: CommandInterfaceXML }>(
+      "indexedItemOrderSwap.xml",
+      fixturesDir
+    )
+
+    const result = importCommandInterfaceFromXML(mockContextFromXML(), mockRule, xmlData.CommandInterface)
+
+    expect(result).toEqual(indexedItemOrderSwap)
   })
 })

--- a/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts
@@ -19,16 +19,12 @@ export const importCommandInterfaceFromXML = (
 
   if (xml.NavigationPanel?.Item) {
     const items = Array.isArray(xml.NavigationPanel.Item) ? xml.NavigationPanel.Item : [xml.NavigationPanel.Item]
-    result.NavigationPanel = items
-      .sort((a, b) => (a.Index ?? 0) - (b.Index ?? 0))
-      .map((item) => importCommandInterfaceItemFromXML(context, item))
+    result.NavigationPanel = items.map((item) => importCommandInterfaceItemFromXML(context, item))
   }
 
   if (xml.CommandBar?.Item) {
     const items = Array.isArray(xml.CommandBar.Item) ? xml.CommandBar.Item : [xml.CommandBar.Item]
-    result.CommandBar = items
-      .sort((a, b) => (a.Index ?? 0) - (b.Index ?? 0))
-      .map((item) => importCommandInterfaceItemFromXML(context, item))
+    result.CommandBar = items.map((item) => importCommandInterfaceItemFromXML(context, item))
   }
 
   return result

--- a/packages/core/metadata/forms/commonObjects/commandInterface/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/toXML.test.ts
@@ -5,6 +5,7 @@ import { mockContext, mockRule } from "~/tests/mockContext"
 import { readXMLFileAsString } from "~/tests/readAndParseXMLFile"
 import { xmlExport } from "~/xml/export/exporter"
 import { commandBarIndexInsertion } from "./__fixtures__/commandBarIndexInsertion"
+import { indexedItemOrderSwap } from "./__fixtures__/indexedItemOrderSwap"
 import { fullCommandInterface } from "./__fixtures__/full"
 import { exportCommandInterfaceToXML } from "./toXML"
 
@@ -39,6 +40,15 @@ describe("exportCommandInterfaceToXML", () => {
   it("export commandBarIndexInsertion", () => {
     const expectedResult = readXMLFileAsString("commandBarIndexInsertion.xml", fixturesDir).trimEnd()
     const xmlData = exportCommandInterfaceToXML(mockContext, mockRule, commandBarIndexInsertion)
+
+    const result = xmlExport({ CommandInterface: xmlData }, false)
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("export indexedItemOrderSwap", () => {
+    const expectedResult = readXMLFileAsString("indexedItemOrderSwap.xml", fixturesDir).trimEnd()
+    const xmlData = exportCommandInterfaceToXML(mockContext, mockRule, indexedItemOrderSwap)
 
     const result = xmlExport({ CommandInterface: xmlData }, false)
 


### PR DESCRIPTION
## Summary
- Добавлен reproducer на порядок CommandInterface.Item при смешанном Index/без Index.
- fromXML больше не сортирует NavigationPanel и CommandBar по Index.
- Ветка сохраняет XML-порядок как временную норму до отдельной доменной проработки Index.

## Test Plan
- [x] pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/commandInterface
- [x] pnpm test