### PR TITLE
Разделить обычные и дополнительные колонки формы

### DIFF
--- a/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/mixedColumns.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/mixedColumns.ts
@@ -1,0 +1,34 @@
+import type { FormAttributes } from "../types"
+
+export const mixedColumns = [
+  {
+    name: "График",
+    title: { items: { ru: "" } },
+    type: { type: ["ValueTable"] },
+    columns: [
+      {
+        name: "Отступ",
+        title: { items: { ru: "Отступ" } },
+        type: { type: ["string"] },
+        itemType: "FormAttributeColumn",
+      },
+    ],
+    additionalColumns: [
+      {
+        table: "ГрафикНачислений",
+        columns: [
+          {
+            name: "Сумма",
+            title: { items: { ru: "Сумма" } },
+            type: {
+              type: ["decimal"],
+              numberQualifiers: { digits: 10, fractionDigits: 2, allowedSign: "Any" },
+            },
+            itemType: "FormAttributeColumn",
+          },
+        ],
+      },
+    ],
+    itemType: "FormAttribute",
+  },
+] as const satisfies FormAttributes

--- a/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/mixedColumns.xml
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/mixedColumns.xml
@@ -1,0 +1,40 @@
+<Attribute name="График" id="1">
+	<Columns>
+		<Column name="Отступ" id="1">
+			<Title>
+				<v8:item>
+					<v8:lang>ru</v8:lang>
+					<v8:content>Отступ</v8:content>
+				</v8:item>
+			</Title>
+			<Type>
+				<v8:Type>xs:string</v8:Type>
+				<v8:StringQualifiers>
+					<v8:Length>0</v8:Length>
+					<v8:AllowedLength>Variable</v8:AllowedLength>
+				</v8:StringQualifiers>
+			</Type>
+		</Column>
+		<AdditionalColumns table="ГрафикНачислений">
+			<Column name="Сумма" id="2">
+				<Title>
+					<v8:item>
+						<v8:lang>ru</v8:lang>
+						<v8:content>Сумма</v8:content>
+					</v8:item>
+				</Title>
+				<Type>
+					<v8:Type>xs:decimal</v8:Type>
+					<v8:NumberQualifiers>
+						<v8:Digits>10</v8:Digits>
+						<v8:FractionDigits>2</v8:FractionDigits>
+						<v8:AllowedSign>Any</v8:AllowedSign>
+					</v8:NumberQualifiers>
+				</Type>
+			</Column>
+		</AdditionalColumns>
+	</Columns>
+	<Type>
+		<v8:Type>v8:ValueTable</v8:Type>
+	</Type>
+</Attribute>

--- a/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/titleColumnsType.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/titleColumnsType.ts
@@ -1,0 +1,17 @@
+import type { FormAttributes } from "../types"
+
+export const titleColumnsType = [
+  {
+    name: "Таблица",
+    title: { items: { ru: "Таблица" } },
+    type: { type: ["ValueTable"] },
+    columns: [
+      {
+        name: "Колонка",
+        type: { type: ["boolean"] },
+        itemType: "FormAttributeColumn",
+      },
+    ],
+    itemType: "FormAttribute",
+  },
+] as const satisfies FormAttributes

--- a/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/titleColumnsType.xml
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/titleColumnsType.xml
@@ -1,0 +1,18 @@
+<Attribute name="Таблица" id="1">
+	<Title>
+		<v8:item>
+			<v8:lang>ru</v8:lang>
+			<v8:content>Таблица</v8:content>
+		</v8:item>
+	</Title>
+	<Columns>
+		<Column name="Колонка" id="1">
+			<Type>
+				<v8:Type>xs:boolean</v8:Type>
+			</Type>
+		</Column>
+	</Columns>
+	<Type>
+		<v8:Type>v8:ValueTable</v8:Type>
+	</Type>
+</Attribute>

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts
@@ -15,6 +15,7 @@ import { testImportPropertyFromXML } from "~/tests/property/importPropertyFromXM
 import { readAndParseXMLFile } from "~/tests/readAndParseXMLFile"
 import { attributeAnyType } from "./__fixtures__/attributeAnyType"
 import { columnAnyType } from "./__fixtures__/columnAnyType"
+import { mixedColumns } from "./__fixtures__/mixedColumns"
 import { tableWithColumns } from "./__fixtures__/tableWithColumns"
 import { treeWithColumn } from "./__fixtures__/treeWithColumn"
 import { twoTables } from "./__fixtures__/twoTables"
@@ -137,6 +138,16 @@ describe("importFormAttributesFromXML", () => {
     })
 
     expect(result).toEqual(twoTables)
+  })
+
+  it("import mixedColumns", () => {
+    const result = testImportPropertyFromXML({
+      rule: formAttributesRule,
+      path: "mixedColumns.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(mixedColumns)
   })
 
   it("import attributeAnyType", () => {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
@@ -7,6 +7,7 @@ import {
   FormAttributeAdditionalColumns,
   FormAttributeAdditionalColumnXML,
   FormAttributeColumn,
+  FormAttributeColumnsXML,
   FormAttributeColumnXML,
   FormAttributes,
   FormAttributesXML,
@@ -109,9 +110,23 @@ const importFormAttributeFromXML = (context: ConfigurationContextFromXML, xml: F
 const importFormAttributeColumnsFromXML = (
   context: ConfigurationContextFromXML,
   _rule: PropertyRule | undefined,
-  xml: FormAttributeColumnXML | FormAttributeColumnXML[] | undefined
+  xml: FormAttributeColumnsXML | FormAttributeColumnXML | FormAttributeColumnXML[] | undefined
 ): FormAttributeColumn[] | undefined => {
+  if (isFormAttributeColumnsXML(xml)) {
+    return importColumnsFromXML(context, xml.Column)
+  }
+
   return importColumnsFromXML(context, xml)
+}
+
+const isFormAttributeColumnsXML = (xml: unknown): xml is FormAttributeColumnsXML => {
+  return (
+    xml !== undefined &&
+    xml !== null &&
+    !Array.isArray(xml) &&
+    typeof xml === "object" &&
+    ("Column" in xml || "AdditionalColumns" in xml)
+  )
 }
 
 const importColumnsFromXML = (

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
@@ -61,7 +61,7 @@ const importFormAttributeFromXML = (context: ConfigurationContextFromXML, xml: F
     columns: _importedColumns,
     additionalColumns: _importedAdditionalColumns,
     ...properties
-  } = importedProperties ?? {}
+  } = (importedProperties ?? {}) as FormAttributeWithAdditionalColumns
 
   if (context.fromXML.forReference) {
     const result = { itemType: FormAttributeRules.itemType } as FormAttributeWithAdditionalColumns
@@ -91,27 +91,19 @@ const importFormAttributeFromXML = (context: ConfigurationContextFromXML, xml: F
     return result as FormAttribute
   }
 
-  const useLegacyAdditionalColumns =
-    columns.length === 0 && additionalColumns.length > 0 && !isFormObject(properties.type)
-
   const result: FormAttributeWithAdditionalColumns = {
+    ...properties,
     itemType: FormAttributeRules.itemType,
     name: xml._name,
     title: properties.title!,
-    columns: useLegacyAdditionalColumns ? (additionalColumns as unknown as FormAttributeColumn[]) : columns,
-    ...properties,
+    columns,
   }
 
-  if (!useLegacyAdditionalColumns && additionalColumns.length > 0) {
+  if (additionalColumns.length > 0) {
     result.additionalColumns = additionalColumns
   }
 
   return result
-}
-
-const isFormObject = (type: FormAttribute["type"] | undefined): boolean => {
-  const formObjectTypes = ["ValueTable", "ValueTree", "ChoiceList"]
-  return type?.type.some((t) => formObjectTypes.includes(t)) ?? false
 }
 
 const importFormAttributeColumnsFromXML = (

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
@@ -7,11 +7,10 @@ import {
   FormAttributeAdditionalColumns,
   FormAttributeAdditionalColumnXML,
   FormAttributeColumn,
-  FormAttributeColumns,
-  FormAttributeColumnsXML,
   FormAttributeColumnXML,
   FormAttributes,
   FormAttributesXML,
+  FormAttributeWithAdditionalColumns,
   FormAttributeXML,
 } from "./types"
 
@@ -50,43 +49,77 @@ export const importFormAttributeColumnFromXML = (
 }
 
 const importFormAttributeFromXML = (context: ConfigurationContextFromXML, xml: FormAttributeXML): FormAttribute => {
-  const properties = importMetadataItemFromXML({
+  const importedProperties = importMetadataItemFromXML({
     context: context,
     xml,
     rule: FormAttributeRules,
   })
 
+  const columns = importColumnsFromXML(context, xml.Columns?.Column)
+  const additionalColumns = importAdditionalColumnsFromXML(context, xml.Columns?.AdditionalColumns)
+  const {
+    columns: _importedColumns,
+    additionalColumns: _importedAdditionalColumns,
+    ...properties
+  } = importedProperties ?? {}
+
   if (context.fromXML.forReference) {
-    return {
-      itemType: FormAttributeRules.itemType,
-      ...properties,
-      name: xml._name,
-    } as FormAttribute
+    const result = { itemType: FormAttributeRules.itemType } as FormAttributeWithAdditionalColumns
+    for (const key of Object.keys(importedProperties ?? {})) {
+      if (key === "columns") {
+        result.columns = columns
+        if (additionalColumns.length > 0) {
+          result.additionalColumns = additionalColumns
+        }
+        continue
+      }
+
+      if (key === "additionalColumns") {
+        if (additionalColumns.length > 0) {
+          result.additionalColumns = additionalColumns
+        }
+        continue
+      }
+
+      ;(result as Record<string, unknown>)[key] = (properties as Record<string, unknown>)[key]
+    }
+    result.name = xml._name
+    if (result.columns === undefined) result.columns = columns
+    if (result.additionalColumns === undefined && additionalColumns.length > 0)
+      result.additionalColumns = additionalColumns
+
+    return result as FormAttribute
   }
 
-  const result: FormAttribute = {
+  const useLegacyAdditionalColumns =
+    columns.length === 0 && additionalColumns.length > 0 && !isFormObject(properties.type)
+
+  const result: FormAttributeWithAdditionalColumns = {
     itemType: FormAttributeRules.itemType,
     name: xml._name,
-    title: properties!.title!,
-    columns: [],
+    title: properties.title!,
+    columns: useLegacyAdditionalColumns ? (additionalColumns as unknown as FormAttributeColumn[]) : columns,
     ...properties,
+  }
+
+  if (!useLegacyAdditionalColumns && additionalColumns.length > 0) {
+    result.additionalColumns = additionalColumns
   }
 
   return result
 }
 
+const isFormObject = (type: FormAttribute["type"] | undefined): boolean => {
+  const formObjectTypes = ["ValueTable", "ValueTree", "ChoiceList"]
+  return type?.type.some((t) => formObjectTypes.includes(t)) ?? false
+}
+
 const importFormAttributeColumnsFromXML = (
   context: ConfigurationContextFromXML,
   _rule: PropertyRule | undefined,
-  xml: FormAttributeColumnsXML | undefined
-): FormAttributeColumns | undefined => {
-  if (!xml) return undefined
-
-  const isAdditional = xml.AdditionalColumns !== undefined
-
-  if (isAdditional) return importAdditionalColumnsFromXML(context, xml.AdditionalColumns)
-
-  return importColumnsFromXML(context, xml.Column)
+  xml: FormAttributeColumnXML | FormAttributeColumnXML[] | undefined
+): FormAttributeColumn[] | undefined => {
+  return importColumnsFromXML(context, xml)
 }
 
 const importColumnsFromXML = (
@@ -134,5 +167,14 @@ const importAdditionalColumnsFromXML = (
   }))
 }
 
+const importFormAttributeAdditionalColumnsFromXML = (
+  context: ConfigurationContextFromXML,
+  _rule: PropertyRule | undefined,
+  xml: FormAttributeAdditionalColumnXML | FormAttributeAdditionalColumnXML[] | undefined
+): FormAttributeAdditionalColumns[] | undefined => {
+  return importAdditionalColumnsFromXML(context, xml)
+}
+
 registerTypeRule("FormAttributes", "importFromXML", importFormAttributesFromXML)
 registerTypeRule("FormAttributeColumns", "importFromXML", importFormAttributeColumnsFromXML)
+registerTypeRule("FormAttributeAdditionalColumns", "importFromXML", importFormAttributeAdditionalColumnsFromXML)

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.test.ts
@@ -8,6 +8,8 @@ import {
   mainAttributeTitleEqualsNameYAML,
   minimalFormAttributes,
   minimalFormAttributesYAML,
+  mixedColumnsFormAttribute,
+  mixedColumnsFormAttributeYAML,
   shortFormAttribute,
   shortFormAttributeYAML,
   tableWithColumnsFormAttribute,
@@ -94,5 +96,11 @@ describe("importFormAttributesFromYAML", () => {
     const result = importFormAttributesFromYAML(mockContext, mockRule, withAdditionalColumnFormAttributeYAML)
 
     expect(result).toEqual(withAdditionalColumnFormAttribute)
+  })
+
+  it("should import mixed columns", () => {
+    const result = importFormAttributesFromYAML(mockContext, mockRule, mixedColumnsFormAttributeYAML)
+
+    expect(result).toEqual(mixedColumnsFormAttribute)
   })
 })

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.ts
@@ -5,12 +5,12 @@ import { importMetadataItemFromYAML, registerTypeRule } from "~/metadata/orchest
 import { FormAttributeColumnRules, FormAttributeRules } from "./rules"
 import {
   FormAttribute,
-  FormAttributeAdditionalColumn,
-  FormAttributeAdditionalColumnYAML,
+  FormAttributeAdditionalColumns,
   FormAttributeColumn,
   FormAttributeColumnYAML,
   FormAttributeColumns,
   FormAttributeColumnsYAML,
+  FormAttributeWithAdditionalColumns,
   FormAttributeYAML,
   FormAttributes,
   FormAttributesYAML,
@@ -55,21 +55,27 @@ const importFormAttributeFromYAML = (
     name,
   }
 
-  const columns = importFormAttributeColumnsFromYAML(context, yaml, attribute as FormAttribute)
+  const columns = importFormAttributeColumnsFromYAML(context, yaml)
+  const additionalColumns = importFormAttributeAdditionalColumnsFromYAML(context, yaml)
 
   if (columns == undefined) throw new Error("Columns are required")
 
-  return {
+  const result: FormAttributeWithAdditionalColumns = {
     ...attribute,
     columns,
     itemType: "FormAttribute",
   }
+
+  if (additionalColumns.length > 0) {
+    result.additionalColumns = additionalColumns
+  }
+
+  return result
 }
 
 const importFormAttributeColumnsFromYAML = (
   context: ConfigurationContext,
-  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML,
-  formAttribute: FormAttribute
+  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML
 ): FormAttributeColumns => {
   if (
     typeof yamlWithColumns !== "object" ||
@@ -84,14 +90,7 @@ const importFormAttributeColumnsFromYAML = (
     return []
   }
 
-  const formObjectTypes = ["ValueTable", "ValueTree", "ChoiceList"]
-  const isFormObject = formAttribute.type?.type.some((t) => formObjectTypes.includes(t))
-
-  const columns = isFormObject
-    ? importColumnsFromYAML(context, columnsData)
-    : importAdditionalColumnsFromYAML(context, columnsData as FormAttributeAdditionalColumnYAML)
-
-  return columns ?? []
+  return importColumnsFromYAML(context, columnsData)
 }
 
 const importColumnsFromYAML = (
@@ -129,11 +128,30 @@ const importColumnFromYAML = (
 const importAdditionalColumnsFromYAML = (
   context: ConfigurationContext,
   data: Record<string, Record<string, FormAttributeColumnYAML>>
-): FormAttributeAdditionalColumn[] => {
+): FormAttributeAdditionalColumns[] => {
   return Object.entries(data).map(([tableName, columns]) => ({
     table: tableName,
     columns: importColumnsFromYAML(context, columns) as FormAttributeColumn[],
   }))
+}
+
+const importFormAttributeAdditionalColumnsFromYAML = (
+  context: ConfigurationContext,
+  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML
+): FormAttributeAdditionalColumns[] => {
+  if (
+    typeof yamlWithColumns !== "object" ||
+    yamlWithColumns === null ||
+    Array.isArray(yamlWithColumns) ||
+    !("ДополнительныеКолонки" in yamlWithColumns)
+  ) {
+    return []
+  }
+
+  const additionalColumnsData = (yamlWithColumns as FormAttributeYAML).ДополнительныеКолонки
+  if (additionalColumnsData == null) return []
+
+  return importAdditionalColumnsFromYAML(context, additionalColumnsData)
 }
 
 registerTypeRule("FormAttributes", "importFromYAML", importFormAttributesFromYAML)

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.ts
@@ -5,6 +5,7 @@ import { importMetadataItemFromYAML, registerTypeRule } from "~/metadata/orchest
 import { FormAttributeColumnRules, FormAttributeRules } from "./rules"
 import {
   FormAttribute,
+  FormAttributeAdditionalColumnYAML,
   FormAttributeAdditionalColumns,
   FormAttributeColumn,
   FormAttributeColumnYAML,
@@ -55,8 +56,8 @@ const importFormAttributeFromYAML = (
     name,
   }
 
-  const columns = importFormAttributeColumnsFromYAML(context, yaml)
-  const additionalColumns = importFormAttributeAdditionalColumnsFromYAML(context, yaml)
+  const columns = importFormAttributeColumnsFromYAML(context, yaml, attribute as FormAttribute)
+  const additionalColumns = importFormAttributeAdditionalColumnsFromYAML(context, yaml, attribute as FormAttribute)
 
   if (columns == undefined) throw new Error("Columns are required")
 
@@ -75,7 +76,8 @@ const importFormAttributeFromYAML = (
 
 const importFormAttributeColumnsFromYAML = (
   context: ConfigurationContext,
-  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML
+  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML,
+  formAttribute: FormAttribute
 ): FormAttributeColumns => {
   if (
     typeof yamlWithColumns !== "object" ||
@@ -90,7 +92,16 @@ const importFormAttributeColumnsFromYAML = (
     return []
   }
 
+  if (!isFormObject(formAttribute)) {
+    return []
+  }
+
   return importColumnsFromYAML(context, columnsData)
+}
+
+const isFormObject = (formAttribute: FormAttribute): boolean => {
+  const formObjectTypes = ["ValueTable", "ValueTree", "ChoiceList"]
+  return formAttribute.type?.type.some((type) => formObjectTypes.includes(type)) ?? false
 }
 
 const importColumnsFromYAML = (
@@ -137,21 +148,23 @@ const importAdditionalColumnsFromYAML = (
 
 const importFormAttributeAdditionalColumnsFromYAML = (
   context: ConfigurationContext,
-  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML
+  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML,
+  formAttribute: FormAttribute
 ): FormAttributeAdditionalColumns[] => {
-  if (
-    typeof yamlWithColumns !== "object" ||
-    yamlWithColumns === null ||
-    Array.isArray(yamlWithColumns) ||
-    !("ДополнительныеКолонки" in yamlWithColumns)
-  ) {
+  if (typeof yamlWithColumns !== "object" || yamlWithColumns === null || Array.isArray(yamlWithColumns)) {
     return []
   }
 
-  const additionalColumnsData = (yamlWithColumns as FormAttributeYAML).ДополнительныеКолонки
-  if (additionalColumnsData == null) return []
+  const formAttributeYAML = yamlWithColumns as FormAttributeYAML
+  if (formAttributeYAML.ДополнительныеКолонки != null) {
+    return importAdditionalColumnsFromYAML(context, formAttributeYAML.ДополнительныеКолонки)
+  }
 
-  return importAdditionalColumnsFromYAML(context, additionalColumnsData)
+  if (!isFormObject(formAttribute) && formAttributeYAML.Колонки != null) {
+    return importAdditionalColumnsFromYAML(context, formAttributeYAML.Колонки as FormAttributeAdditionalColumnYAML)
+  }
+
+  return []
 }
 
 registerTypeRule("FormAttributes", "importFromYAML", importFormAttributesFromYAML)

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.ts
@@ -5,7 +5,6 @@ import { importMetadataItemFromYAML, registerTypeRule } from "~/metadata/orchest
 import { FormAttributeColumnRules, FormAttributeRules } from "./rules"
 import {
   FormAttribute,
-  FormAttributeAdditionalColumnYAML,
   FormAttributeAdditionalColumns,
   FormAttributeColumn,
   FormAttributeColumnYAML,
@@ -56,10 +55,8 @@ const importFormAttributeFromYAML = (
     name,
   }
 
-  const columns = importFormAttributeColumnsFromYAML(context, yaml, attribute as FormAttribute)
-  const additionalColumns = importFormAttributeAdditionalColumnsFromYAML(context, yaml, attribute as FormAttribute)
-
-  if (columns == undefined) throw new Error("Columns are required")
+  const columns = importFormAttributeColumnsFromYAML(context, yaml)
+  const additionalColumns = importFormAttributeAdditionalColumnsFromYAML(context, yaml)
 
   const result: FormAttributeWithAdditionalColumns = {
     ...attribute,
@@ -76,8 +73,7 @@ const importFormAttributeFromYAML = (
 
 const importFormAttributeColumnsFromYAML = (
   context: ConfigurationContext,
-  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML,
-  formAttribute: FormAttribute
+  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML
 ): FormAttributeColumns => {
   if (
     typeof yamlWithColumns !== "object" ||
@@ -92,16 +88,7 @@ const importFormAttributeColumnsFromYAML = (
     return []
   }
 
-  if (!isFormObject(formAttribute)) {
-    return []
-  }
-
   return importColumnsFromYAML(context, columnsData)
-}
-
-const isFormObject = (formAttribute: FormAttribute): boolean => {
-  const formObjectTypes = ["ValueTable", "ValueTree", "ChoiceList"]
-  return formAttribute.type?.type.some((type) => formObjectTypes.includes(type)) ?? false
 }
 
 const importColumnsFromYAML = (
@@ -148,8 +135,7 @@ const importAdditionalColumnsFromYAML = (
 
 const importFormAttributeAdditionalColumnsFromYAML = (
   context: ConfigurationContext,
-  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML,
-  formAttribute: FormAttribute
+  yamlWithColumns: FormAttributeYAML | TypeDescriptionYAML
 ): FormAttributeAdditionalColumns[] => {
   if (typeof yamlWithColumns !== "object" || yamlWithColumns === null || Array.isArray(yamlWithColumns)) {
     return []
@@ -158,10 +144,6 @@ const importFormAttributeAdditionalColumnsFromYAML = (
   const formAttributeYAML = yamlWithColumns as FormAttributeYAML
   if (formAttributeYAML.ДополнительныеКолонки != null) {
     return importAdditionalColumnsFromYAML(context, formAttributeYAML.ДополнительныеКолонки)
-  }
-
-  if (!isFormObject(formAttribute) && formAttributeYAML.Колонки != null) {
-    return importAdditionalColumnsFromYAML(context, formAttributeYAML.Колонки as FormAttributeAdditionalColumnYAML)
   }
 
   return []

--- a/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.test.ts
@@ -122,7 +122,7 @@ describe("FormAttributeColumns buildGraphFromModel", () => {
     buildGraphFromModel({
       model: {
         name: "Объект",
-        columns: [
+        additionalColumns: [
           {
             table: "КакаяТоТаблица",
             columns: [{ name: "КолонкаТаблицы", itemType: "FormAttributeColumn" }],
@@ -156,6 +156,50 @@ describe("FormAttributeColumns buildGraphFromModel", () => {
     )
     expect(additionalColumnEdges).toHaveLength(1)
     expect(additionalColumnEdges[0].target).toBe(columnNodeId)
+  })
+
+  it("mixed columns → direct column and additional-column proxy are both created", () => {
+    const graph = makeGraph()
+    graph.ensureNode(ATTR_NODE_ID, { name: "График" })
+
+    buildGraphFromModel({
+      model: {
+        name: "График",
+        columns: [{ name: "Отступ", itemType: "FormAttributeColumn" }],
+        additionalColumns: [
+          {
+            table: "Объект.ГрафикНачислений",
+            columns: [{ name: "Сумма", itemType: "FormAttributeColumn" }],
+          },
+        ],
+        itemType: "FormAttribute",
+      },
+      yamlMap: undefined,
+      rule: FormAttributeRules,
+      graph,
+      parentNodeId: ATTR_NODE_ID,
+      filePath: FILE_PATH,
+    })
+
+    const directColumnNodeId = `${ATTR_NODE_ID}.Отступ`
+    const proxyNodeId = `${ATTR_NODE_ID}.ГрафикНачислений`
+    const additionalColumnNodeId = `${proxyNodeId}.Сумма`
+
+    expect(graph.hasNode(directColumnNodeId)).toBe(true)
+    expect(graph.hasNode(proxyNodeId)).toBe(true)
+    expect(graph.hasNode(additionalColumnNodeId)).toBe(true)
+
+    expect(
+      [...graph.outEdgeEntries(ATTR_NODE_ID)].filter((e) => e.attributes.kind === "FORM_COLUMN"),
+    ).toHaveLength(1)
+    expect(
+      [...graph.outEdgeEntries(ATTR_NODE_ID)].filter((e) => e.attributes.kind === "TABLE_EXTENSION"),
+    ).toHaveLength(1)
+    expect(
+      [...graph.outEdgeEntries(proxyNodeId)].filter(
+        (e) => e.attributes.kind === "ADDITIONAL_COLUMN",
+      ),
+    ).toHaveLength(1)
   })
 
   it("узел колонки несёт item и filePaths", () => {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts
@@ -29,18 +29,6 @@ registerTypeRule("FormAttributes", "graphChild", {
   itemRule: FormAttributeRules,
 })
 
-/**
- * Обрабатывает коллекцию колонок реквизита формы.
- *
- * - inner: тип реквизита = ТаблицаЗначений / ДеревоЗначений / СписокВыбора.
- *   Колонка → дочерний узел `<реквизит>.<колонка>` + ребро «КолонкаФормы»
- *   + recurse по FormAttributeColumnRules для типов колонки.
- * - additional: дополнительные колонки к реквизитам прикладного объекта.
- *   Прокси-узел `<реквизит>.<lastSeg(table)>` + ребро «ДополнениеТаблицы»,
- *   ребро «Таблица» от прокси к ТЧ через formLocalReferences,
- *   per-column узлы под прокси + рёбра «ДополнительнаяКолонка»
- *   + recurse по FormAttributeColumnRules.
- */
 const buildFormAttributeColumnsGraph: BuildGraphFromModelFunction = ({
   model,
   parentNodeId,
@@ -49,80 +37,6 @@ const buildFormAttributeColumnsGraph: BuildGraphFromModelFunction = ({
 }): GraphOps[] | undefined => {
   if (!Array.isArray(model) || model.length === 0) return undefined
 
-  const first = model[0] as Record<string, unknown>
-
-  // ---- Additional columns (PRD #116) ----
-  if (typeof first.table === "string") {
-    // parentNodeId = <formNodeId>.Реквизит.<attrName>; формируем formNodeId обратным путём
-    const formNodeId = parentNodeId.split(".").slice(0, -2).join(".")
-    const sections: GraphOps[] = []
-
-    for (const raw of model) {
-      const group = raw as FormAttributeAdditionalColumns
-      const tablePath = group.table
-      const lastSegment = tablePath.split(".").pop()
-      if (!lastSegment) continue
-
-      const proxyNodeId = `${parentNodeId}.${lastSegment}`
-
-      // (1) Прокси-узел: owning-ребро «ДополнениеТаблицы» от реквизита к прокси
-      sections.push({
-        children: [
-          {
-            idSuffix: lastSegment,
-            name: lastSegment,
-            item: { itemType: "AdditionalColumnsProxy", table: tablePath },
-          },
-        ],
-        edgeKind: ADDITION_EDGE_KIND,
-        edgeYaml: ADDITION_EDGE_YAML,
-      })
-
-      // (2) Reference-ребро «Таблица» от прокси к ТЧ через resolveFormLocalPath
-      sections.push({
-        formLocalReferences: [
-          {
-            formLocalPath: tablePath,
-            formNodeId,
-            parentOverride: proxyNodeId,
-          },
-        ],
-        edgeKind: TABLE_EDGE_KIND,
-        edgeYaml: TABLE_EDGE_YAML,
-      })
-
-      // (3) Дочерние колонки прокси + рекурсия по FormAttributeColumnRules
-      const columnChildren: GraphOpsChild[] = []
-      const columnRecurses: GraphOpsRecurse[] = []
-      for (const column of group.columns) {
-        const columnName = column.name
-        if (!columnName) continue
-        columnChildren.push({
-          idSuffix: columnName,
-          name: columnName,
-          item: column as unknown as Record<string, unknown>,
-          parentOverride: proxyNodeId,
-        })
-        columnRecurses.push({
-          model: column as unknown as Record<string, unknown>,
-          rule: FormAttributeColumnRules,
-          parentNodeId: `${proxyNodeId}.${columnName}`,
-        })
-      }
-      if (columnChildren.length > 0) {
-        sections.push({
-          children: columnChildren,
-          recurse: columnRecurses,
-          edgeKind: ADDITIONAL_COLUMN_EDGE_KIND,
-          edgeYaml: ADDITIONAL_COLUMN_EDGE_YAML,
-        })
-      }
-    }
-
-    return sections.length > 0 ? sections : undefined
-  }
-
-  // ---- Inner columns ----
   const columnsKey = propRule.yaml // "Колонки"
   const columnsYamlMap = columnsKey && yamlMap ? findSubmap(yamlMap, columnsKey) : undefined
 
@@ -158,5 +72,83 @@ const buildFormAttributeColumnsGraph: BuildGraphFromModelFunction = ({
   ]
 }
 
+const buildFormAttributeAdditionalColumnsGraph: BuildGraphFromModelFunction = ({
+  model,
+  parentNodeId,
+}): GraphOps[] | undefined => {
+  if (!Array.isArray(model) || model.length === 0) return undefined
+
+  // parentNodeId = <formNodeId>.Реквизит.<attrName>; формируем formNodeId обратным путём.
+  const formNodeId = parentNodeId.split(".").slice(0, -2).join(".")
+  const sections: GraphOps[] = []
+
+  for (const raw of model) {
+    const group = raw as FormAttributeAdditionalColumns
+    const tablePath = group.table
+    const lastSegment = tablePath.split(".").pop()
+    if (!lastSegment) continue
+
+    const proxyNodeId = `${parentNodeId}.${lastSegment}`
+
+    sections.push({
+      children: [
+        {
+          idSuffix: lastSegment,
+          name: lastSegment,
+          item: { itemType: "AdditionalColumnsProxy", table: tablePath },
+        },
+      ],
+      edgeKind: ADDITION_EDGE_KIND,
+      edgeYaml: ADDITION_EDGE_YAML,
+    })
+
+    sections.push({
+      formLocalReferences: [
+        {
+          formLocalPath: tablePath,
+          formNodeId,
+          parentOverride: proxyNodeId,
+        },
+      ],
+      edgeKind: TABLE_EDGE_KIND,
+      edgeYaml: TABLE_EDGE_YAML,
+    })
+
+    const columnChildren: GraphOpsChild[] = []
+    const columnRecurses: GraphOpsRecurse[] = []
+    for (const column of group.columns) {
+      const columnName = column.name
+      if (!columnName) continue
+
+      columnChildren.push({
+        idSuffix: columnName,
+        name: columnName,
+        item: column as unknown as Record<string, unknown>,
+        parentOverride: proxyNodeId,
+      })
+      columnRecurses.push({
+        model: column as unknown as Record<string, unknown>,
+        rule: FormAttributeColumnRules,
+        parentNodeId: `${proxyNodeId}.${columnName}`,
+      })
+    }
+
+    if (columnChildren.length > 0) {
+      sections.push({
+        children: columnChildren,
+        recurse: columnRecurses,
+        edgeKind: ADDITIONAL_COLUMN_EDGE_KIND,
+        edgeYaml: ADDITIONAL_COLUMN_EDGE_YAML,
+      })
+    }
+  }
+
+  return sections.length > 0 ? sections : undefined
+}
+
 registerTypeRule("FormAttributeColumns", "buildGraphFromModel", buildFormAttributeColumnsGraph)
-registerTypeRule("FormAttributeAdditionalColumns", "buildGraphFromModel", buildFormAttributeColumnsGraph)
+registerTypeRule(
+  "FormAttributeAdditionalColumns",
+  "buildGraphFromModel",
+  buildFormAttributeAdditionalColumnsGraph,
+)

--- a/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/graphFromModel.ts
@@ -67,22 +67,26 @@ const buildFormAttributeColumnsGraph: BuildGraphFromModelFunction = ({
 
       // (1) Прокси-узел: owning-ребро «ДополнениеТаблицы» от реквизита к прокси
       sections.push({
-        children: [{
-          idSuffix: lastSegment,
-          name: lastSegment,
-          item: { itemType: "AdditionalColumnsProxy", table: tablePath },
-        }],
+        children: [
+          {
+            idSuffix: lastSegment,
+            name: lastSegment,
+            item: { itemType: "AdditionalColumnsProxy", table: tablePath },
+          },
+        ],
         edgeKind: ADDITION_EDGE_KIND,
         edgeYaml: ADDITION_EDGE_YAML,
       })
 
       // (2) Reference-ребро «Таблица» от прокси к ТЧ через resolveFormLocalPath
       sections.push({
-        formLocalReferences: [{
-          formLocalPath: tablePath,
-          formNodeId,
-          parentOverride: proxyNodeId,
-        }],
+        formLocalReferences: [
+          {
+            formLocalPath: tablePath,
+            formNodeId,
+            parentOverride: proxyNodeId,
+          },
+        ],
         edgeKind: TABLE_EDGE_KIND,
         edgeYaml: TABLE_EDGE_YAML,
       })
@@ -144,12 +148,15 @@ const buildFormAttributeColumnsGraph: BuildGraphFromModelFunction = ({
 
   if (children.length === 0) return undefined
 
-  return [{
-    children,
-    recurse: recurses,
-    edgeKind: COLUMN_EDGE_KIND,
-    edgeYaml: COLUMN_EDGE_YAML,
-  }]
+  return [
+    {
+      children,
+      recurse: recurses,
+      edgeKind: COLUMN_EDGE_KIND,
+      edgeYaml: COLUMN_EDGE_YAML,
+    },
+  ]
 }
 
 registerTypeRule("FormAttributeColumns", "buildGraphFromModel", buildFormAttributeColumnsGraph)
+registerTypeRule("FormAttributeAdditionalColumns", "buildGraphFromModel", buildFormAttributeColumnsGraph)

--- a/packages/core/metadata/forms/commonObjects/formAttribute/rules.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/rules.ts
@@ -87,6 +87,8 @@ export const FormAttributeRules = {
       type: "FormAttributeAdditionalColumns",
       fromXML: false,
       toXML: false,
+      fromYAML: false,
+      toYAML: false,
     },
 
     functionalOptions: {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/rules.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/rules.ts
@@ -76,9 +76,17 @@ export const FormAttributeRules = {
     columns: {
       yaml: "Колонки",
       type: "FormAttributeColumns",
+      fromXML: false,
+      toXML: false,
       fromYAML: false,
       defaultValue: [],
       required: true,
+    },
+    additionalColumns: {
+      yaml: "ДополнительныеКолонки",
+      type: "FormAttributeAdditionalColumns",
+      fromXML: false,
+      toXML: false,
     },
 
     functionalOptions: {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/rules.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/rules.ts
@@ -88,7 +88,6 @@ export const FormAttributeRules = {
       fromXML: false,
       toXML: false,
       fromYAML: false,
-      toYAML: false,
     },
 
     functionalOptions: {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts
@@ -19,6 +19,7 @@ import { attributeAnyType } from "./__fixtures__/attributeAnyType"
 import { columnAnyType } from "./__fixtures__/columnAnyType"
 import { mixedColumns } from "./__fixtures__/mixedColumns"
 import { tableWithColumns } from "./__fixtures__/tableWithColumns"
+import { titleColumnsType } from "./__fixtures__/titleColumnsType"
 import { treeWithColumn } from "./__fixtures__/treeWithColumn"
 import { twoTables } from "./__fixtures__/twoTables"
 import { exportFormAttributesToXML } from "./toXML"
@@ -204,6 +205,19 @@ describe("exportFormAttributesToXML", () => {
       xmlRootTag: "Attribute",
       exportXmlDataAsRoot: true,
       path: "mixedColumns.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("export titleColumnsType", () => {
+    const { result, expectedResult } = testExportPropertyToXML({
+      rule: formAttributesRule,
+      value: titleColumnsType,
+      xmlRootTag: "Attribute",
+      exportXmlDataAsRoot: true,
+      path: "titleColumnsType.xml",
       importMetaUrl: import.meta.url,
     })
 

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts
@@ -17,6 +17,7 @@ import { xmlExport } from "~/xml/export/exporter"
 import { setIdsToElements } from "../../clientApplicationForm/toXML"
 import { attributeAnyType } from "./__fixtures__/attributeAnyType"
 import { columnAnyType } from "./__fixtures__/columnAnyType"
+import { mixedColumns } from "./__fixtures__/mixedColumns"
 import { tableWithColumns } from "./__fixtures__/tableWithColumns"
 import { treeWithColumn } from "./__fixtures__/treeWithColumn"
 import { twoTables } from "./__fixtures__/twoTables"
@@ -190,6 +191,19 @@ describe("exportFormAttributesToXML", () => {
       xmlRootTag: "Attribute",
       exportXmlDataAsRoot: true,
       path: "twoTables.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("export mixedColumns", () => {
+    const { result, expectedResult } = testExportPropertyToXML({
+      rule: formAttributesRule,
+      value: mixedColumns,
+      xmlRootTag: "Attribute",
+      exportXmlDataAsRoot: true,
+      path: "mixedColumns.xml",
       importMetaUrl: import.meta.url,
     })
 

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
@@ -1,16 +1,16 @@
 import { ConfigurationContextWithExportToXML } from "~/metadata/context/types"
 import { PropertyRule } from "~/metadata/forms/elements/calendarField/rules"
-import { ElementXML, ExportToXMLFunctionNew, exportPropertiesToXML, registerTypeRule } from "~/metadata/orchestration"
+import { ElementXML, exportPropertiesToXML, registerTypeRule } from "~/metadata/orchestration"
 import { FormAttributeColumnRules, FormAttributeRules } from "./rules"
 import {
   FormAttribute,
-  FormAttributeAdditionalColumn,
+  FormAttributeAdditionalColumns,
   FormAttributeAdditionalColumnXML,
   FormAttributeColumn,
-  FormAttributeColumns,
   FormAttributeColumnsXML,
   FormAttributeColumnXML,
   FormAttributes,
+  FormAttributeWithAdditionalColumns,
   FormAttributeXML,
 } from "./types"
 
@@ -66,7 +66,41 @@ const exportFormAttributeToXML = (
     rule: FormAttributeRules,
   })
 
+  const legacyAdditionalColumns = isAdditionalColumns(data.columns) ? data.columns : []
+  const directColumns = isAdditionalColumns(data.columns) ? [] : data.columns
+  const referenceLegacyAdditionalColumns = isAdditionalColumns(referenceData?.columns) ? referenceData?.columns : []
+  const referenceDirectColumns = isAdditionalColumns(referenceData?.columns) ? [] : referenceData?.columns
+
+  const columns = exportColumnsToXML(context, directColumns, referenceDirectColumns, data)
+  const additionalColumns = exportAdditionalColumnsToXML(
+    context,
+    (data as FormAttributeWithAdditionalColumns).additionalColumns ?? legacyAdditionalColumns,
+    (referenceData as FormAttributeWithAdditionalColumns | undefined)?.additionalColumns ??
+      referenceLegacyAdditionalColumns,
+    data
+  )
+
+  const columnsXML =
+    columns || additionalColumns
+      ? {
+          ...(columns ? { Column: columns.Column } : {}),
+          ...(additionalColumns ? { AdditionalColumns: additionalColumns.AdditionalColumns } : {}),
+        }
+      : undefined
+
+  if (columnsXML && !shouldPlaceColumnsAfterProperties(referenceData)) {
+    result.Columns = {
+      ...columnsXML,
+    }
+  }
+
   Object.assign(result, properties)
+
+  if (columnsXML && shouldPlaceColumnsAfterProperties(referenceData)) {
+    result.Columns = {
+      ...columnsXML,
+    }
+  }
 
   if (data.type?.type.includes("ValueListType") || result.Settings !== undefined) {
     result.Settings = {
@@ -97,6 +131,26 @@ const findReferenceColumn = (
 ): FormAttributeColumn | undefined => {
   if (!referenceData) return undefined
   return referenceData.find((referenceItem) => referenceItem.name === data.name)
+}
+
+const isAdditionalColumns = (columns: unknown): columns is FormAttributeAdditionalColumns[] => {
+  return (
+    Array.isArray(columns) &&
+    columns.length > 0 &&
+    typeof columns[0] === "object" &&
+    columns[0] !== null &&
+    "table" in columns[0]
+  )
+}
+
+const shouldPlaceColumnsAfterProperties = (referenceData: FormAttribute | undefined): boolean => {
+  if (!referenceData) return false
+
+  const keys = Object.keys(referenceData)
+  const columnsIndex = keys.indexOf("columns")
+  if (columnsIndex < 0) return false
+
+  return keys.slice(0, columnsIndex).some((key) => key !== "itemType" && key !== "id" && key !== "name")
 }
 
 // const exportFormAttributeSettingsToXML = (params: {
@@ -137,30 +191,13 @@ const findReferenceColumn = (
 //   return undefined
 // }
 
-const exportFormAttributeColumnsToXML: ExportToXMLFunctionNew = (params): FormAttributeColumnsXML | undefined => {
-  const context = params.context
-  const columns = params.value as FormAttributeColumns
-  const referenceMetadata = params.referenceMetadata as FormAttributeColumns | undefined
-  const metadataItem = params.metadataItem as FormAttribute | undefined
-  if (columns.length === 0) return undefined
-
-  const isAdditionalColumns = "table" in columns[0]
-
-  if (isAdditionalColumns) {
-    return exportAdditionalColumnsToXML(
-      context,
-      columns as FormAttributeAdditionalColumn[],
-      referenceMetadata as FormAttributeAdditionalColumn[] | undefined,
-      metadataItem
-    )
-  }
-
-  return exportColumnsToXML(
-    context,
-    columns as FormAttributeColumn[],
-    referenceMetadata as FormAttributeColumn[] | undefined,
-    metadataItem
-  )
+const exportFormAttributeColumnsToXML = (
+  context: ConfigurationContextWithExportToXML,
+  _rule: PropertyRule | undefined,
+  columns: FormAttributeColumn[] | undefined,
+  referenceColumns?: FormAttributeColumn[] | undefined
+): FormAttributeColumnsXML | undefined => {
+  return exportColumnsToXML(context, columns ?? [], referenceColumns)
 }
 
 const exportColumnsToXML = (
@@ -202,8 +239,8 @@ const exportColumnsToXML = (
 
 const exportAdditionalColumnsToXML = (
   context: ConfigurationContextWithExportToXML,
-  additionalColumns: FormAttributeAdditionalColumn[],
-  referenceAdditionalColumns?: FormAttributeAdditionalColumn[] | undefined,
+  additionalColumns: FormAttributeAdditionalColumns[],
+  referenceAdditionalColumns?: FormAttributeAdditionalColumns[] | undefined,
   numberingScope?: unknown
 ): { AdditionalColumns: FormAttributeAdditionalColumnXML[] } | undefined => {
   const result: FormAttributeAdditionalColumnXML[] = additionalColumns.map((additionalColumn) => {
@@ -228,6 +265,16 @@ const exportAdditionalColumnsToXML = (
   return { AdditionalColumns: result }
 }
 
+const exportFormAttributeAdditionalColumnsToXML = (
+  context: ConfigurationContextWithExportToXML,
+  _rule: PropertyRule | undefined,
+  additionalColumns: FormAttributeAdditionalColumns[] | undefined,
+  referenceAdditionalColumns?: FormAttributeAdditionalColumns[] | undefined
+): { AdditionalColumns: FormAttributeAdditionalColumnXML[] } | undefined => {
+  return exportAdditionalColumnsToXML(context, additionalColumns ?? [], referenceAdditionalColumns)
+}
+
 registerTypeRule("FormAttributes", "exportToXML", exportFormAttributesToXML)
 registerTypeRule("FormAttributeColumns", "exportToXML", exportFormAttributeColumnsToXML)
+registerTypeRule("FormAttributeAdditionalColumns", "exportToXML", exportFormAttributeAdditionalColumnsToXML)
 // registerTypeRule("FormAttributeSettings", "exportToXML", exportFormAttributeSettingsToXML)

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
@@ -66,17 +66,11 @@ const exportFormAttributeToXML = (
     rule: FormAttributeRules,
   })
 
-  const legacyAdditionalColumns = isAdditionalColumns(data.columns) ? data.columns : []
-  const directColumns = isAdditionalColumns(data.columns) ? [] : data.columns
-  const referenceLegacyAdditionalColumns = isAdditionalColumns(referenceData?.columns) ? referenceData?.columns : []
-  const referenceDirectColumns = isAdditionalColumns(referenceData?.columns) ? [] : referenceData?.columns
-
-  const columns = exportColumnsToXML(context, directColumns, referenceDirectColumns, data)
+  const columns = exportColumnsToXML(context, data.columns, referenceData?.columns, data)
   const additionalColumns = exportAdditionalColumnsToXML(
     context,
-    (data as FormAttributeWithAdditionalColumns).additionalColumns ?? legacyAdditionalColumns,
-    (referenceData as FormAttributeWithAdditionalColumns | undefined)?.additionalColumns ??
-      referenceLegacyAdditionalColumns,
+    (data as FormAttributeWithAdditionalColumns).additionalColumns ?? [],
+    (referenceData as FormAttributeWithAdditionalColumns | undefined)?.additionalColumns,
     data
   )
 
@@ -131,16 +125,6 @@ const findReferenceColumn = (
 ): FormAttributeColumn | undefined => {
   if (!referenceData) return undefined
   return referenceData.find((referenceItem) => referenceItem.name === data.name)
-}
-
-const isAdditionalColumns = (columns: unknown): columns is FormAttributeAdditionalColumns[] => {
-  return (
-    Array.isArray(columns) &&
-    columns.length > 0 &&
-    typeof columns[0] === "object" &&
-    columns[0] !== null &&
-    "table" in columns[0]
-  )
 }
 
 const shouldPlaceColumnsAfterProperties = (referenceData: FormAttribute | undefined): boolean => {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
@@ -1,3 +1,4 @@
+import { capitalize } from "~/helpers/capitalize"
 import { ConfigurationContextWithExportToXML } from "~/metadata/context/types"
 import { PropertyRule } from "~/metadata/forms/elements/calendarField/rules"
 import { ElementXML, exportPropertiesToXML, registerTypeRule } from "~/metadata/orchestration"
@@ -82,19 +83,7 @@ const exportFormAttributeToXML = (
         }
       : undefined
 
-  if (columnsXML && !shouldPlaceColumnsAfterProperties(referenceData)) {
-    result.Columns = {
-      ...columnsXML,
-    }
-  }
-
-  Object.assign(result, properties)
-
-  if (columnsXML && shouldPlaceColumnsAfterProperties(referenceData)) {
-    result.Columns = {
-      ...columnsXML,
-    }
-  }
+  assignPropertiesWithColumns(result, properties, columnsXML, referenceData)
 
   if (data.type?.type.includes("ValueListType") || result.Settings !== undefined) {
     result.Settings = {
@@ -127,14 +116,60 @@ const findReferenceColumn = (
   return referenceData.find((referenceItem) => referenceItem.name === data.name)
 }
 
-const shouldPlaceColumnsAfterProperties = (referenceData: FormAttribute | undefined): boolean => {
-  if (!referenceData) return false
+const assignPropertiesWithColumns = (
+  result: FormAttributeXML,
+  properties: Record<string, unknown>,
+  columnsXML: FormAttributeColumnsXML | undefined,
+  referenceData: FormAttribute | undefined
+): void => {
+  if (!columnsXML) {
+    Object.assign(result, properties)
+    return
+  }
 
+  const insertIndex = getReferenceColumnsInsertIndex(referenceData, properties)
+  if (insertIndex === undefined) {
+    result.Columns = columnsXML
+    Object.assign(result, properties)
+    return
+  }
+
+  const propertyEntries = Object.entries(properties)
+  const safeInsertIndex = Math.max(0, Math.min(insertIndex, propertyEntries.length))
+
+  for (const [index, [key, value]] of propertyEntries.entries()) {
+    if (index === safeInsertIndex) {
+      result.Columns = columnsXML
+    }
+    ;(result as Record<string, unknown>)[key] = value
+  }
+
+  if (safeInsertIndex === propertyEntries.length) {
+    result.Columns = columnsXML
+  }
+}
+
+const getReferenceColumnsInsertIndex = (
+  referenceData: FormAttribute | undefined,
+  properties: Record<string, unknown>
+): number | undefined => {
+  if (!referenceData) return undefined
   const keys = Object.keys(referenceData)
   const columnsIndex = keys.indexOf("columns")
-  if (columnsIndex < 0) return false
+  if (columnsIndex < 0) return undefined
 
-  return keys.slice(0, columnsIndex).some((key) => key !== "itemType" && key !== "id" && key !== "name")
+  return keys.slice(0, columnsIndex).filter((key) => isExportedPropertyKey(key, properties)).length
+}
+
+const isExportedPropertyKey = (key: string, properties: Record<string, unknown>): boolean => {
+  if (key === "itemType" || key === "id" || key === "name" || key === "columns" || key === "additionalColumns") {
+    return false
+  }
+
+  const rule = FormAttributeRules.properties[key as keyof typeof FormAttributeRules.properties]
+  const xmlKey = rule !== undefined && "xml" in rule && rule.xml !== undefined ? rule.xml : capitalize(key)
+
+  return xmlKey in properties
 }
 
 // const exportFormAttributeSettingsToXML = (params: {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toYAML.test.ts
@@ -5,6 +5,8 @@ import {
   choiceListFormAttributeYAML,
   fullFormAttributes,
   fullFormAttributesYAML,
+  mixedColumnsFormAttribute,
+  mixedColumnsFormAttributeYAML,
   shortFormAttribute,
   shortFormAttributeYAML,
   tableWithColumnsFormAttribute,
@@ -95,5 +97,11 @@ describe("exportFormAttributesToYAML", () => {
     const result = exportFormAttributesToYAML(context, mockRule, withAdditionalColumnFormAttribute)
 
     expect(result).toEqual(withAdditionalColumnFormAttributeYAML)
+  })
+
+  it("should export mixed columns", () => {
+    const result = exportFormAttributesToYAML(context, mockRule, mixedColumnsFormAttribute)
+
+    expect(result).toEqual(mixedColumnsFormAttributeYAML)
   })
 })

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toYAML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toYAML.ts
@@ -11,6 +11,7 @@ import {
   FormAttributeColumnYAML,
   FormAttributeColumns,
   FormAttributeColumnsYAML,
+  FormAttributeWithAdditionalColumns,
   FormAttributeYAML,
   FormAttributes,
   FormAttributesYAML,
@@ -39,6 +40,11 @@ const exportFormAttributeToYAML = (
     rule: FormAttributeRules,
   })!
 
+  const additionalColumns = (data as FormAttributeWithAdditionalColumns).additionalColumns
+  if (additionalColumns !== undefined && additionalColumns.length > 0) {
+    result.ДополнительныеКолонки = exportAdditionalColumnsToYAML(context, undefined, additionalColumns)
+  }
+
   return result
 
   // if (data.settings !== undefined) {
@@ -56,20 +62,12 @@ const exportFormAttributeToYAML = (
   // }
 }
 
-const isAdditionalColumns = (columns: FormAttributeColumns): columns is FormAttributeAdditionalColumns[] => {
-  return columns.length > 0 && "table" in columns[0]
-}
-
 const exportFormAttributeColumnsToYAML = (
   context: ConfigurationContext,
   _rule: PropertyRule | undefined,
   columns: FormAttributeColumns
 ): FormAttributeColumnsYAML | undefined => {
   if (columns.length === 0) return undefined
-
-  if (isAdditionalColumns(columns)) {
-    return exportAdditionalColumnsToYAML(context, undefined, columns)
-  }
 
   return exportColumnsToYAML(context, undefined, columns)
 }

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toYAML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toYAML.ts
@@ -11,7 +11,6 @@ import {
   FormAttributeColumnYAML,
   FormAttributeColumns,
   FormAttributeColumnsYAML,
-  FormAttributeWithAdditionalColumns,
   FormAttributeYAML,
   FormAttributes,
   FormAttributesYAML,
@@ -39,11 +38,6 @@ const exportFormAttributeToYAML = (
     data: data,
     rule: FormAttributeRules,
   })!
-
-  const additionalColumns = (data as FormAttributeWithAdditionalColumns).additionalColumns
-  if (additionalColumns !== undefined && additionalColumns.length > 0) {
-    result.ДополнительныеКолонки = exportAdditionalColumnsToYAML(context, undefined, additionalColumns)
-  }
 
   return result
 
@@ -108,11 +102,13 @@ export const exportFormAttributeColumnToYAML = (
 const exportAdditionalColumnsToYAML = (
   context: ConfigurationContext,
   _rule: PropertyRule | undefined,
-  additionalColumns: FormAttributeAdditionalColumns[]
-): FormAttributeAdditionalColumnYAML => {
+  additionalColumns: FormAttributeAdditionalColumns[] | undefined
+): FormAttributeAdditionalColumnYAML | undefined => {
+  if (additionalColumns === undefined || additionalColumns.length === 0) return undefined
+
   return Object.fromEntries(
     additionalColumns.map((additionalColumn) => [
-      additionalColumn.table.split(".").pop()!,
+      additionalColumn.table,
       exportColumnsToYAML(context, undefined, additionalColumn.columns),
     ])
   )
@@ -120,3 +116,4 @@ const exportAdditionalColumnsToYAML = (
 
 registerTypeRule("FormAttributes", "exportToYAML", exportFormAttributesToYAML)
 registerTypeRule("FormAttributeColumns", "exportToYAML", exportFormAttributeColumnsToYAML)
+registerTypeRule("FormAttributeAdditionalColumns", "exportToYAML", exportAdditionalColumnsToYAML)

--- a/packages/core/metadata/forms/commonObjects/formAttribute/types.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/types.ts
@@ -15,11 +15,6 @@ import { FormTypeByRule } from "~/metadata/orchestration/metadataItem/element"
 import { FillCheckingYAML } from "~/metadata/systemEnumerations/types"
 import { FormAttributeColumnRules, FormAttributeRules } from "./rules"
 
-export interface FormAttributeAdditionalColumn {
-  table: string
-  columns: FormAttributeColumn[]
-}
-
 export type FormAttribute = FormTypeByRule<typeof FormAttributeRules>
 
 export type FormAttributeColumn = FormTypeByRule<typeof FormAttributeColumnRules>
@@ -28,7 +23,16 @@ export interface FormAttributeAdditionalColumns {
   table: string
   columns: FormAttributeColumn[]
 }
-export type FormAttributeColumns = FormAttributeColumn[] | FormAttributeAdditionalColumns[]
+
+export type FormAttributeColumns = FormAttributeColumn[]
+
+export type FormAttributeAdditionalColumnsCollection = FormAttributeAdditionalColumns[]
+
+export type FormAttributeAdditionalColumn = FormAttributeAdditionalColumns
+
+export type FormAttributeWithAdditionalColumns = FormAttribute & {
+  additionalColumns?: FormAttributeAdditionalColumns[]
+}
 
 interface SettingsTypeDescriptionXML extends TypeDescriptionXML {
   "_xsi:type": "v8:TypeDescription"
@@ -71,7 +75,7 @@ export interface FormAttributeAdditionalColumnYAML {
   [tableName: string]: Record<string, FormAttributeColumnYAML>
 }
 
-export type FormAttributeColumnsYAML = Record<string, FormAttributeColumnYAML> | FormAttributeAdditionalColumnYAML
+export type FormAttributeColumnsYAML = Record<string, FormAttributeColumnYAML>
 
 export interface FormAttributeYAML {
   Заголовок?: I8nTextYAML
@@ -85,6 +89,7 @@ export interface FormAttributeYAML {
   [UserEditKeysYAML.Allow]?: UserEditYAML
   [UserEditKeysYAML.Deny]?: UserEditYAML
   Колонки?: FormAttributeColumnsYAML
+  ДополнительныеКолонки?: FormAttributeAdditionalColumnYAML
   ФункциональныеОпции?: FunctionalOptionsYAML
   ИспользоватьВсегда?: FieldsListYAML
   ПроверкаЗаполнения?: FillCheckingYAML

--- a/packages/core/metadata/orchestration/importMetadataFileWithGraph.test.ts
+++ b/packages/core/metadata/orchestration/importMetadataFileWithGraph.test.ts
@@ -978,7 +978,7 @@ describe("importMetadataFileWithGraph — form, FormAttributeAdditionalColumns (
   Объект:
     Тип: Справочник.Товары
   ДопКолонки:
-    Колонки:
+    ДополнительныеКолонки:
       "Объект.Состав":
         ДопКолонка:
           Тип: Строка(50)
@@ -1034,7 +1034,7 @@ describe("importMetadataFileWithGraph — form, FormAttributeAdditionalColumns (
   Объект:
     Тип: Справочник.Товары
   ДопКолонки:
-    Колонки:
+    ДополнительныеКолонки:
       "Объект.Состав":
         Контрагент:
           Тип: Справочник.Контрагенты
@@ -1072,7 +1072,7 @@ describe("importMetadataFileWithGraph — form, FormAttributeAdditionalColumns (
   Объект:
     Тип: Справочник.Товары
   ДопКолонки:
-    Колонки:
+    ДополнительныеКолонки:
       "Объект.Состав":
         ДопКолонка: {}
 `,

--- a/packages/core/metadata/orchestration/property/registry.ts
+++ b/packages/core/metadata/orchestration/property/registry.ts
@@ -204,6 +204,8 @@ import { CommandSet, CommandSetYAML } from "~/metadata/forms/commonObjects/comma
 import { DataPath } from "~/metadata/forms/commonObjects/dataPath/types"
 import { DynamicList, DynamicListYAML } from "~/metadata/forms/commonObjects/dynamicList/types"
 import {
+  FormAttributeAdditionalColumnYAML,
+  FormAttributeAdditionalColumnsCollection,
   FormAttributeColumns,
   FormAttributeColumnsYAML,
   FormAttributes,
@@ -569,6 +571,11 @@ export type PropertyTypeRegistry = {
     yaml: FormAttributeColumnsYAML
   }
 
+  FormAttributeAdditionalColumns: {
+    item: FormAttributeAdditionalColumnsCollection
+    yaml: FormAttributeAdditionalColumnYAML
+  }
+
   // FormAttributeSettings: {
   //   item: FormAttributeSettings
   //   enterprise: unknown
@@ -864,6 +871,7 @@ export const PropertyRuleTypeKeys = Object.keys({
   FormCommands: "FormCommands",
   FormAttributes: "FormAttributes",
   FormAttributeColumns: "FormAttributeColumns",
+  FormAttributeAdditionalColumns: "FormAttributeAdditionalColumns",
   FormParameters: "FormParameters",
   InternalInfo: "InternalInfo",
   XMLRoot: "XMLRoot",

--- a/packages/core/tests/fixtures/formAttributes/data.ts
+++ b/packages/core/tests/fixtures/formAttributes/data.ts
@@ -445,3 +445,54 @@ export const withAdditionalColumnFormAttributeYAML: FormAttributesYAML = {
 }
 
 //#endregion
+
+//#region MixedColumns
+
+export const mixedColumnsFormAttribute: FormAttributes = [
+  {
+    name: "График",
+    title: { items: { ru: "" } },
+    type: { type: ["ValueTable"] },
+    columns: [
+      {
+        name: "Отступ",
+        type: { type: ["string"] },
+        itemType: "FormAttributeColumn",
+      },
+    ],
+    additionalColumns: [
+      {
+        table: "Объект.ГрафикНачислений",
+        columns: [
+          {
+            name: "Сумма",
+            type: { type: ["decimal"] },
+            itemType: "FormAttributeColumn",
+          },
+        ],
+      },
+    ],
+    itemType: "FormAttribute",
+  },
+]
+
+export const mixedColumnsFormAttributeYAML: FormAttributesYAML = {
+  График: {
+    Заголовок: "",
+    Тип: "ТаблицаЗначений",
+    Колонки: {
+      Отступ: {
+        Тип: "Строка",
+      },
+    },
+    ДополнительныеКолонки: {
+      "Объект.ГрафикНачислений": {
+        Сумма: {
+          Тип: "Число",
+        },
+      },
+    },
+  },
+}
+
+//#endregion

--- a/packages/core/tests/fixtures/formAttributes/data.ts
+++ b/packages/core/tests/fixtures/formAttributes/data.ts
@@ -411,7 +411,8 @@ export const withAdditionalColumnFormAttribute: FormAttributes = [
     name: "Объект",
     type: { type: ["string"] },
     title: { items: { ru: "" } },
-    columns: [
+    columns: [],
+    additionalColumns: [
       {
         table: "КакаяТоТаблица",
         columns: [
@@ -432,7 +433,7 @@ export const withAdditionalColumnFormAttributeYAML: FormAttributesYAML = {
   Объект: {
     Заголовок: "",
     Тип: "Строка",
-    Колонки: {
+    ДополнительныеКолонки: {
       КакаяТоТаблица: {
         КолонкаТаблицы: {
           Заголовок: "Описание колонки",


### PR DESCRIPTION
## Summary
- Разделены direct columns и additionalColumns в модели FormAttribute.
- XML/YAML round-trip теперь сохраняет смешанный Columns с Column и AdditionalColumns.
- Обновлено построение графа и интеграционные фикстуры под ДополнительныеКолонки.

## Test Plan
- [x] pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/formAttribute
- [x] pnpm --filter '@nakidka/core' exec vitest run metadata/orchestration/importMetadataFileWithGraph.test.ts -t "FormAttributeColumns|FormAttributeAdditionalColumns"
- [x] pnpm --filter '@nakidka/core' test