### PR TITLE
Сохранить порядок форм в round-trip XML

### DIFF
--- a/docs/superpowers/plans/2026-05-08-form-round-trip-order-and-auto-cell-height.md
+++ b/docs/superpowers/plans/2026-05-08-form-round-trip-order-and-auto-cell-height.md
@@ -1,0 +1,449 @@
+# Form Round-Trip Order And AutoCellHeight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve two remaining form XML round-trip cases: duplicate auto `CommandInterface` item order and explicit `AutoCellHeight` on regular form fields.
+
+**Architecture:** Keep `CommandInterface` changes local to its manual XML exporter by refining reference item lookup to include `index`. Move `autoCellHeight` into shared form field rules so ordinary `InputField` and `LabelField` imports can keep the XML node and exports can write it back through the existing reference-aware element test path.
+
+**Tech Stack:** TypeScript, Vitest, existing metadata rules, form element fixture matrix, `xmlExport`.
+
+---
+
+## File Structure
+
+- Modify: `packages/core/metadata/forms/commonObjects/commandInterface/toXML.ts`
+  - Match reference items by `command + commandGroup + index`.
+- Modify: `packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts`
+  - Normalize XML `Command` to a string because `<Command>0</Command>` can be parsed as number `0`.
+- Create: `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.xml`
+  - Minimal reference XML with two duplicate auto navigation items.
+- Create: `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.ts`
+  - Expected `CommandInterface` model for the XML fixture.
+- Modify: `packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts`
+  - Add import coverage for `duplicateAutoCommandOrder`.
+- Modify: `packages/core/metadata/forms/commonObjects/commandInterface/toXML.test.ts`
+  - Add export coverage with reference data for `duplicateAutoCommandOrder`.
+- Modify: `packages/core/metadata/forms/elements/formField/rules.ts`
+  - Move `autoCellHeight` from table-related properties to common properties.
+- Create: `packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.ts`
+  - Expected regular `InputField` model with `autoCellHeight: true`.
+- Create: `packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.xml`
+  - Regular `InputField` XML containing `<AutoCellHeight>true</AutoCellHeight>`.
+- Create: `packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.ts`
+  - Expected regular `LabelField` model with `autoCellHeight: true`.
+- Create: `packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.xml`
+  - Regular `LabelField` XML containing `<AutoCellHeight>true</AutoCellHeight>`.
+- Modify: `packages/core/metadata/forms/elements/__tests__/fixtures.ts`
+  - Register both new element fixtures in `ElementFixtures`.
+
+## Task 1: Add CommandInterface Duplicate Reproducer
+
+**Files:**
+- Create: `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.xml`
+- Create: `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/commandInterface/toXML.test.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts`
+
+- [ ] **Step 1: Create the XML fixture**
+
+Create `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.xml`:
+
+```xml
+<CommandInterface>
+	<NavigationPanel>
+		<Item>
+			<Command>0</Command>
+			<Type>Auto</Type>
+			<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
+			<DefaultVisible>false</DefaultVisible>
+			<Visible>
+				<xr:Common>false</xr:Common>
+			</Visible>
+		</Item>
+		<Item>
+			<Command>0</Command>
+			<Type>Auto</Type>
+			<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
+			<Index>1</Index>
+			<DefaultVisible>false</DefaultVisible>
+			<Visible>
+				<xr:Common>false</xr:Common>
+			</Visible>
+		</Item>
+	</NavigationPanel>
+</CommandInterface>
+```
+
+- [ ] **Step 2: Create the TS fixture**
+
+Create `packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.ts`:
+
+```typescript
+import type { CommandInterface } from "../types"
+
+export const duplicateAutoCommandOrder = {
+  itemType: "CommandInterface",
+  NavigationPanel: [
+    {
+      command: "0",
+      type: "Auto",
+      commandGroup: "FormNavigationPanelGoTo",
+      defaultVisible: false,
+      visible: {
+        common: false,
+        values: [],
+      },
+      itemType: "CommandInterfaceItem",
+    },
+    {
+      command: "0",
+      type: "Auto",
+      commandGroup: "FormNavigationPanelGoTo",
+      index: 1,
+      defaultVisible: false,
+      visible: {
+        common: false,
+        values: [],
+      },
+      itemType: "CommandInterfaceItem",
+    },
+  ],
+  CommandBar: [],
+} as const satisfies CommandInterface
+```
+
+- [ ] **Step 3: Normalize XML Command values**
+
+In `packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts`, normalize `Command`:
+
+```typescript
+  const values: Partial<CommandInterfaceItem> = {
+    command: String(item.Command),
+    type: item.Type,
+    index: item.Index,
+    commandGroup: item.CommandGroup,
+    defaultVisible: item.DefaultVisible ?? true,
+  }
+```
+
+- [ ] **Step 4: Add the fromXML test import**
+
+In `packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts`, add:
+
+```typescript
+import { duplicateAutoCommandOrder } from "./__fixtures__/duplicateAutoCommandOrder"
+```
+
+- [ ] **Step 5: Add the import test**
+
+Inside `describe("importCommandInterfaceFromXML", () => { ... })`, add:
+
+```typescript
+  it("import duplicateAutoCommandOrder", () => {
+    const xmlData = readAndParseXMLFile<{ CommandInterface: CommandInterfaceXML }>(
+      "duplicateAutoCommandOrder.xml",
+      fixturesDir
+    )
+
+    const result = importCommandInterfaceFromXML(mockContextFromXML(), mockRule, xmlData.CommandInterface)
+
+    expect(result).toEqual(duplicateAutoCommandOrder)
+  })
+```
+
+- [ ] **Step 6: Add the toXML test import**
+
+In `packages/core/metadata/forms/commonObjects/commandInterface/toXML.test.ts`, add:
+
+```typescript
+import { duplicateAutoCommandOrder } from "./__fixtures__/duplicateAutoCommandOrder"
+```
+
+- [ ] **Step 7: Add the export test**
+
+Inside `describe("exportCommandInterfaceToXML", () => { ... })`, add:
+
+```typescript
+  it("export duplicateAutoCommandOrder with reference order", () => {
+    const expectedResult = readXMLFileAsString("duplicateAutoCommandOrder.xml", fixturesDir).trimEnd()
+    const referenceXML = readAndParseXMLFile<{ CommandInterface: CommandInterfaceXML }>(
+      "duplicateAutoCommandOrder.xml",
+      fixturesDir
+    )
+    const referenceData = importCommandInterfaceFromXML(
+      mockContextFromXML({ forReference: true }),
+      mockRule,
+      referenceXML.CommandInterface
+    )
+    const xmlData = exportCommandInterfaceToXML(mockContext, mockRule, duplicateAutoCommandOrder, referenceData)
+
+    const result = xmlExport({ CommandInterface: xmlData }, false)
+
+    expect(result).toEqual(expectedResult)
+  })
+```
+
+- [ ] **Step 8: Run the focused CommandInterface test and verify failure**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/commandInterface/fromXML.test.ts metadata/forms/commonObjects/commandInterface/toXML.test.ts -t "duplicateAutoCommandOrder"
+```
+
+Expected before implementation: import passes; export fails because `CommandGroup` is emitted after `DefaultVisible`.
+
+## Task 2: Fix CommandInterface Reference Matching
+
+**Files:**
+- Modify: `packages/core/metadata/forms/commonObjects/commandInterface/toXML.ts`
+
+- [ ] **Step 1: Replace the reference matcher**
+
+In `packages/core/metadata/forms/commonObjects/commandInterface/toXML.ts`, replace `findReferenceCommandInterfaceItem` with:
+
+```typescript
+const findReferenceCommandInterfaceItem = (
+  item: CommandInterfaceItem,
+  referenceItems: CommandInterfaceItem[] | undefined
+): CommandInterfaceItem | undefined => {
+  if (!referenceItems) return undefined
+
+  const matches = referenceItems.filter(
+    (referenceItem) =>
+      referenceItem.command === item.command &&
+      referenceItem.commandGroup === item.commandGroup &&
+      referenceItem.index === item.index
+  )
+
+  return matches.length === 1 ? matches[0] : undefined
+}
+```
+
+This keeps `undefined` strict: an item without `index` only matches a reference item without `index`.
+
+- [ ] **Step 2: Run focused CommandInterface tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/commandInterface/fromXML.test.ts metadata/forms/commonObjects/commandInterface/toXML.test.ts -t "duplicateAutoCommandOrder|commandGroupReferenceOrder|indexedItemOrderSwap"
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 3: Commit the CommandInterface change**
+
+```bash
+git add packages/core/metadata/forms/commonObjects/commandInterface/toXML.ts \
+  packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts \
+  packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts \
+  packages/core/metadata/forms/commonObjects/commandInterface/toXML.test.ts \
+  packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.xml \
+  packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.ts
+git commit -m "fix: :bug: сохранить порядок duplicate CommandInterface"
+```
+
+## Task 3: Add AutoCellHeight Element Reproducers
+
+**Files:**
+- Create: `packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.xml`
+- Create: `packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.ts`
+- Create: `packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.xml`
+- Create: `packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.ts`
+- Modify: `packages/core/metadata/forms/elements/__tests__/fixtures.ts`
+
+- [ ] **Step 1: Create the InputField XML fixture**
+
+Create `packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.xml`:
+
+```xml
+<InputField name="ПолеАвтоВысотаЯчейки" id="1">
+	<AutoCellHeight>true</AutoCellHeight>
+	<ContextMenu name="ПолеАвтоВысотаЯчейкиКонтекстноеМеню" id="2"/>
+	<ExtendedTooltip name="ПолеАвтоВысотаЯчейкиРасширеннаяПодсказка" id="3"/>
+</InputField>
+```
+
+- [ ] **Step 2: Create the InputField TS fixture**
+
+Create `packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.ts`:
+
+```typescript
+import type { InputField } from "../types"
+
+export const autoCellHeightInputField = {
+  itemType: "InputField",
+  name: "ПолеАвтоВысотаЯчейки",
+  autoCellHeight: true,
+} as const satisfies InputField
+```
+
+- [ ] **Step 3: Create the LabelField XML fixture**
+
+Create `packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.xml`:
+
+```xml
+<LabelField name="НадписьАвтоВысотаЯчейки" id="1">
+	<AutoCellHeight>true</AutoCellHeight>
+	<ContextMenu name="НадписьАвтоВысотаЯчейкиКонтекстноеМеню" id="2"/>
+	<ExtendedTooltip name="НадписьАвтоВысотаЯчейкиРасширеннаяПодсказка" id="3"/>
+</LabelField>
+```
+
+- [ ] **Step 4: Create the LabelField TS fixture**
+
+Create `packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.ts`:
+
+```typescript
+import type { LabelField } from "../types"
+
+export const autoCellHeightLabelField = {
+  itemType: "LabelField",
+  name: "НадписьАвтоВысотаЯчейки",
+  autoCellHeight: true,
+} as const satisfies LabelField
+```
+
+- [ ] **Step 5: Import the new fixtures**
+
+In `packages/core/metadata/forms/elements/__tests__/fixtures.ts`, add imports near the existing input and label imports:
+
+```typescript
+import { autoCellHeightInputField } from "../inputField/__fixtures__/autoCellHeight"
+import { autoCellHeightLabelField } from "../labelField/__fixtures__/autoCellHeight"
+```
+
+- [ ] **Step 6: Register the InputField fixture**
+
+Inside the `//#region InputField` block in `packages/core/metadata/forms/elements/__tests__/fixtures.ts`, add:
+
+```typescript
+  {
+    group: "InputField",
+    name: "autoCellHeight InputField",
+    element: InputField,
+    xml: "autoCellHeight.xml",
+    xmlFolder: undefined,
+    model: autoCellHeightInputField,
+    yaml: { АвтоВысотаЯчейки: "Истина" },
+    enterprise: undefined,
+  },
+```
+
+- [ ] **Step 7: Register the LabelField fixture**
+
+Inside the `//#region LabelField` block in `packages/core/metadata/forms/elements/__tests__/fixtures.ts`, add:
+
+```typescript
+  {
+    group: "LabelField",
+    name: "autoCellHeight LabelField",
+    element: LabelField,
+    xml: "autoCellHeight.xml",
+    xmlFolder: undefined,
+    model: autoCellHeightLabelField,
+    yaml: { АвтоВысотаЯчейки: "Истина" },
+    enterprise: undefined,
+  },
+```
+
+- [ ] **Step 8: Run the focused element tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts -t "autoCellHeight"
+```
+
+Expected before implementation: import and export tests fail because `autoCellHeight` is not part of regular `InputField` / `LabelField` rules.
+
+## Task 4: Move AutoCellHeight To Common Form Field Rules
+
+**Files:**
+- Modify: `packages/core/metadata/forms/elements/formField/rules.ts`
+
+- [ ] **Step 1: Remove `autoCellHeight` from table-related properties**
+
+In `packages/core/metadata/forms/elements/formField/rules.ts`, remove this property from `formFieldTableRelatedProperties`:
+
+```typescript
+  autoCellHeight: {
+    yaml: "АвтоВысотаЯчейки",
+    type: "boolean",
+    defaultValueYAML: true,
+  },
+```
+
+- [ ] **Step 2: Add `autoCellHeight` to common properties**
+
+In the same file, add the property to `formFieldCommonProperties` near `cellHyperlink`:
+
+```typescript
+  cellHyperlink: { yaml: "ГиперссылкаЯчейки", type: "boolean", defaultValueYAML: false },
+  autoCellHeight: {
+    yaml: "АвтоВысотаЯчейки",
+    type: "boolean",
+    defaultValueYAML: true,
+  },
+  horizontalAlign: {
+```
+
+- [ ] **Step 3: Run focused element tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts -t "autoCellHeight|TableInputField|TableLabelField"
+```
+
+Expected: selected tests pass. Existing table variants still import/export `autoCellHeight`.
+
+- [ ] **Step 4: Run YAML focused tests for the new fixtures**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts -t "autoCellHeight"
+```
+
+Expected: selected YAML tests pass with `АвтоВысотаЯчейки: "Истина"` as the partial YAML expectation.
+
+- [ ] **Step 5: Commit the AutoCellHeight change**
+
+```bash
+git add packages/core/metadata/forms/elements/formField/rules.ts \
+  packages/core/metadata/forms/elements/__tests__/fixtures.ts \
+  packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.xml \
+  packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.ts \
+  packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.xml \
+  packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.ts
+git commit -m "fix: :bug: сохранить AutoCellHeight полей формы"
+```
+
+## Task 5: Run Final Focused Verification
+
+**Files:**
+- No file changes.
+
+- [ ] **Step 1: Run combined focused verification**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/commandInterface/fromXML.test.ts metadata/forms/commonObjects/commandInterface/toXML.test.ts metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts -t "duplicateAutoCommandOrder|commandGroupReferenceOrder|indexedItemOrderSwap|autoCellHeight"
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run full package test if the session owner asks for final verification**
+
+Run only when full verification is requested:
+
+```bash
+pnpm --filter '@nakidka/core' test
+```
+
+Expected: `@nakidka/core` tests pass. Full root `pnpm test` is left to the user unless they explicitly ask to run it.

--- a/docs/superpowers/specs/2026-05-08-form-round-trip-order-and-auto-cell-height-design.md
+++ b/docs/superpowers/specs/2026-05-08-form-round-trip-order-and-auto-cell-height-design.md
@@ -1,0 +1,141 @@
+# Form round-trip: CommandInterface duplicate order and AutoCellHeight
+
+## Context
+
+Short round-trip for `round-trip-source/trade` still reports form XML noise after the recent
+`CommandInterface` order fixes.
+
+Two confirmed clusters remain in the first triage batch:
+
+- `CommandInterface.NavigationPanel.Item` order changes when two auto commands have the same
+  `Command` and `CommandGroup`, and differ only by `Index`.
+- `AutoCellHeight` disappears from non-table `InputField` / `LabelField` XML nodes because the
+  property is currently defined only in table-related form field rules.
+
+The large `FormAttribute Settings xsi:type="...Chart"` diff is intentionally outside this spec.
+
+## Goals
+
+1. Preserve `CommandInterfaceItem` XML field order from reference XML when duplicate auto commands
+   differ by `Index`.
+2. Preserve explicit `<AutoCellHeight>true</AutoCellHeight>` on regular form fields that are not
+   imported through `TableChildItems`.
+3. Add narrow XML reproducers so the future fix can be verified without running the full project
+   test suite first.
+
+## Non-Goals
+
+- Do not redesign generic form element dispatch.
+- Do not change `CommandInterface` item array order.
+- Do not model chart settings for form attributes.
+- Do not add enterprise fixtures for `AutoCellHeight`; the driving behavior is XML round-trip
+  preservation. The shared element fixture matrix still needs minimal YAML expectations for
+  models that contain `autoCellHeight: true`, because `toYAML.test.ts` runs over the same fixtures.
+
+## CommandInterface Design
+
+`packages/core/metadata/forms/commonObjects/commandInterface/toXML.ts` already receives
+`referenceData` and uses it to preserve field order. The current matching function finds a
+reference item by:
+
+```text
+command + commandGroup
+```
+
+This is not enough for auto navigation panel items. Real XML can contain two items like:
+
+```xml
+<Item>
+	<Command>0</Command>
+	<Type>Auto</Type>
+	<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
+	<DefaultVisible>false</DefaultVisible>
+</Item>
+<Item>
+	<Command>0</Command>
+	<Type>Auto</Type>
+	<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
+	<Index>1</Index>
+	<DefaultVisible>false</DefaultVisible>
+</Item>
+```
+
+The reference lookup must match inside the same collection (`NavigationPanel` or `CommandBar`) by:
+
+```text
+command + commandGroup + index
+```
+
+`index: undefined` is a meaningful value and must only match another `undefined`. It must not be
+treated as `0`.
+
+When exactly one reference item matches, export uses that reference item's key order. When no item
+or multiple items match, export keeps the existing fallback order.
+
+`CommandInterfaceItem.command` is a string in the model. The XML parser can read
+`<Command>0</Command>` as number `0`, so `fromXML` must normalize `Command` with `String(...)`.
+This keeps the model type stable and lets reference matching compare the same command value on
+real auto command items.
+
+## AutoCellHeight Design
+
+`AutoCellHeight` currently lives in `formFieldTableRelatedProperties`:
+
+```typescript
+autoCellHeight: {
+  yaml: "АвтоВысотаЯчейки",
+  type: "boolean",
+  defaultValueYAML: true,
+}
+```
+
+That means it is available on `TableInputField`, `TableLabelField`, `TableCheckBoxField`, and
+`TablePictureField`, but not on regular `InputField` or `LabelField`.
+
+The real XML shows `AutoCellHeight` on regular child items too. In `trade/Catalogs`, the scan found
+48 occurrences:
+
+- 25 on `InputField`;
+- 23 on `LabelField`.
+
+The fix is to move `autoCellHeight` into `formFieldCommonProperties`. This makes the property part
+of the common form-field model surface used by regular field elements and table field elements.
+Table variants continue to inherit it through their existing spread of the base field rules.
+
+Reference XML order remains the source of truth for export order. The reproducer fixtures should
+therefore use `testExportElementToXML`, which imports the same XML as reference before exporting.
+Like neighboring minimal form-field fixtures, the XML should include generated `ContextMenu` and
+`ExtendedTooltip` nodes; otherwise export tests would fail on fixture calibration noise rather than
+on `AutoCellHeight`. The element fixture entries should set `yaml: { АвтоВысотаЯчейки: "Истина" }`
+so the shared YAML export tests stay green after `autoCellHeight` becomes a common property.
+
+## Testing Strategy
+
+Add focused reproducers before implementation:
+
+- `duplicateAutoCommandOrder` in `forms/commonObjects/commandInterface`.
+- `autoCellHeightInputField` in `forms/elements/inputField`.
+- `autoCellHeightLabelField` in `forms/elements/labelField`.
+
+Run narrow tests:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/commandInterface/fromXML.test.ts metadata/forms/commonObjects/commandInterface/toXML.test.ts -t "duplicateAutoCommandOrder"
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts -t "autoCellHeight"
+```
+
+Expected after implementation:
+
+- `duplicateAutoCommandOrder` imports and exports without moving `CommandGroup`.
+- `autoCellHeightInputField` imports and exports with `autoCellHeight: true`.
+- `autoCellHeightLabelField` imports and exports with `autoCellHeight: true`.
+
+Full `pnpm test` remains the final regression check after the implementation is complete.
+
+## Risks
+
+- Moving `autoCellHeight` into common form field properties broadens the generated TypeScript model
+  surface for every element that uses `formFieldCommonProperties`. This is intentional for XML
+  preservation, but focused tests should confirm existing table fixtures still pass.
+- The `CommandInterface` fix depends on strict `undefined` comparison for `Index`; accidentally
+  normalizing `undefined` to `0` would reintroduce ambiguity.

--- a/packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.ts
@@ -1,0 +1,31 @@
+import type { CommandInterface } from "../types"
+
+export const duplicateAutoCommandOrder = {
+  itemType: "CommandInterface",
+  NavigationPanel: [
+    {
+      command: "0",
+      type: "Auto",
+      commandGroup: "FormNavigationPanelGoTo",
+      defaultVisible: false,
+      visible: {
+        common: false,
+        values: [],
+      },
+      itemType: "CommandInterfaceItem",
+    },
+    {
+      command: "0",
+      type: "Auto",
+      commandGroup: "FormNavigationPanelGoTo",
+      index: 1,
+      defaultVisible: false,
+      visible: {
+        common: false,
+        values: [],
+      },
+      itemType: "CommandInterfaceItem",
+    },
+  ],
+  CommandBar: [],
+} as const satisfies CommandInterface

--- a/packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.xml
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/__fixtures__/duplicateAutoCommandOrder.xml
@@ -1,0 +1,23 @@
+<CommandInterface>
+	<NavigationPanel>
+		<Item>
+			<Command>0</Command>
+			<Type>Auto</Type>
+			<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
+			<DefaultVisible>false</DefaultVisible>
+			<Visible>
+				<xr:Common>false</xr:Common>
+			</Visible>
+		</Item>
+		<Item>
+			<Command>0</Command>
+			<Type>Auto</Type>
+			<CommandGroup>FormNavigationPanelGoTo</CommandGroup>
+			<Index>1</Index>
+			<DefaultVisible>false</DefaultVisible>
+			<Visible>
+				<xr:Common>false</xr:Common>
+			</Visible>
+		</Item>
+	</NavigationPanel>
+</CommandInterface>

--- a/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.test.ts
@@ -5,6 +5,7 @@ import { mockContextFromXML, mockRule } from "~/tests/mockContext"
 import { readAndParseXMLFile } from "~/tests/readAndParseXMLFile"
 import { commandBarIndexInsertion } from "./__fixtures__/commandBarIndexInsertion"
 import { commandGroupReferenceOrder } from "./__fixtures__/commandGroupReferenceOrder"
+import { duplicateAutoCommandOrder } from "./__fixtures__/duplicateAutoCommandOrder"
 import { indexedItemOrderSwap } from "./__fixtures__/indexedItemOrderSwap"
 import { fullCommandInterface } from "./__fixtures__/full"
 import { importCommandInterfaceFromXML } from "./fromXML"
@@ -58,5 +59,16 @@ describe("importCommandInterfaceFromXML", () => {
     const result = importCommandInterfaceFromXML(mockContextFromXML(), mockRule, xmlData.CommandInterface)
 
     expect(result).toEqual(commandGroupReferenceOrder)
+  })
+
+  it("import duplicateAutoCommandOrder", () => {
+    const xmlData = readAndParseXMLFile<{ CommandInterface: CommandInterfaceXML }>(
+      "duplicateAutoCommandOrder.xml",
+      fixturesDir
+    )
+
+    const result = importCommandInterfaceFromXML(mockContextFromXML(), mockRule, xmlData.CommandInterface)
+
+    expect(result).toEqual(duplicateAutoCommandOrder)
   })
 })

--- a/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts
@@ -35,7 +35,7 @@ const importCommandInterfaceItemFromXML = (
   item: CommandInterfaceItemXML
 ): CommandInterfaceItem => {
   const values: Partial<CommandInterfaceItem> = {
-    command: item.Command,
+    command: String(item.Command),
     type: item.Type,
     index: item.Index,
     commandGroup: item.CommandGroup,

--- a/packages/core/metadata/forms/commonObjects/commandInterface/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/toXML.test.ts
@@ -6,6 +6,7 @@ import { readAndParseXMLFile, readXMLFileAsString } from "~/tests/readAndParseXM
 import { xmlExport } from "~/xml/export/exporter"
 import { commandBarIndexInsertion } from "./__fixtures__/commandBarIndexInsertion"
 import { commandGroupReferenceOrder } from "./__fixtures__/commandGroupReferenceOrder"
+import { duplicateAutoCommandOrder } from "./__fixtures__/duplicateAutoCommandOrder"
 import { indexedItemOrderSwap } from "./__fixtures__/indexedItemOrderSwap"
 import { fullCommandInterface } from "./__fixtures__/full"
 import { importCommandInterfaceFromXML } from "./fromXML"
@@ -70,6 +71,24 @@ describe("exportCommandInterfaceToXML", () => {
       referenceXML.CommandInterface
     )
     const xmlData = exportCommandInterfaceToXML(mockContext, mockRule, commandGroupReferenceOrder, referenceData)
+
+    const result = xmlExport({ CommandInterface: xmlData }, false)
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("export duplicateAutoCommandOrder with reference order", () => {
+    const expectedResult = readXMLFileAsString("duplicateAutoCommandOrder.xml", fixturesDir).trimEnd()
+    const referenceXML = readAndParseXMLFile<{ CommandInterface: CommandInterfaceXML }>(
+      "duplicateAutoCommandOrder.xml",
+      fixturesDir
+    )
+    const referenceData = importCommandInterfaceFromXML(
+      mockContextFromXML({ forReference: true }),
+      mockRule,
+      referenceXML.CommandInterface
+    )
+    const xmlData = exportCommandInterfaceToXML(mockContext, mockRule, duplicateAutoCommandOrder, referenceData)
 
     const result = xmlExport({ CommandInterface: xmlData }, false)
 

--- a/packages/core/metadata/forms/commonObjects/commandInterface/toXML.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/toXML.ts
@@ -102,7 +102,10 @@ const findReferenceCommandInterfaceItem = (
   if (!referenceItems) return undefined
 
   const matches = referenceItems.filter(
-    (referenceItem) => referenceItem.command === item.command && referenceItem.commandGroup === item.commandGroup
+    (referenceItem) =>
+      referenceItem.command === item.command &&
+      referenceItem.commandGroup === item.commandGroup &&
+      referenceItem.index === item.index
   )
 
   return matches.length === 1 ? matches[0] : undefined

--- a/packages/core/metadata/forms/elements/__tests__/fixtures.ts
+++ b/packages/core/metadata/forms/elements/__tests__/fixtures.ts
@@ -139,6 +139,7 @@ import {
   minimalTableInputField,
   minimalTableInputFieldTypedYAML,
 } from "../inputField/__fixtures__/data"
+import { autoCellHeightInputField } from "../inputField/__fixtures__/autoCellHeight"
 import {
   fullLabelDecoration,
   fullLabelDecorationEnterprise,
@@ -157,6 +158,7 @@ import {
   minimalTableLabelField,
   minimalTableLabelFieldTypedYAML,
 } from "../labelField/__fixtures__/data"
+import { autoCellHeightLabelField } from "../labelField/__fixtures__/autoCellHeight"
 import { fullPage, fullPageEnterprise, fullPagePartialYAML, minimalPage } from "../page/__fixtures__/data"
 import {
   fullPages,
@@ -311,6 +313,16 @@ export const ElementFixtures: ElementFixture[] = [
     model: minimalInputField,
     yaml: undefined,
     enterprise: minimalInputFieldEnterprise,
+  },
+  {
+    group: "InputField",
+    name: "autoCellHeight InputField",
+    element: InputField,
+    xml: "autoCellHeight.xml",
+    xmlFolder: undefined,
+    model: autoCellHeightInputField,
+    yaml: { АвтоВысотаЯчейки: "Истина" },
+    enterprise: undefined,
   },
   //#endregion
   //#region TableInputField
@@ -733,6 +745,16 @@ export const ElementFixtures: ElementFixture[] = [
     xmlFolder: undefined,
     model: minimalLabelField,
     yaml: undefined,
+    enterprise: undefined,
+  },
+  {
+    group: "LabelField",
+    name: "autoCellHeight LabelField",
+    element: LabelField,
+    xml: "autoCellHeight.xml",
+    xmlFolder: undefined,
+    model: autoCellHeightLabelField,
+    yaml: { АвтоВысотаЯчейки: "Истина" },
     enterprise: undefined,
   },
   //#endregion

--- a/packages/core/metadata/forms/elements/formField/rules.ts
+++ b/packages/core/metadata/forms/elements/formField/rules.ts
@@ -20,11 +20,6 @@ export const formFieldTableRelatedProperties = {
     type: "AssociatedTable",
     toEnterprise: false,
   },
-  autoCellHeight: {
-    yaml: "АвтоВысотаЯчейки",
-    type: "boolean",
-    defaultValueYAML: true,
-  },
   fixingInTable: {
     yaml: "ФиксацияВТаблице",
     xml: "FixingInTable",
@@ -84,6 +79,11 @@ export const formFieldCommonProperties = {
   visible: { yaml: "Видимость", type: "boolean", defaultValueYAML: true },
   titleHeight: { yaml: "ВысотаЗаголовка", type: "number" },
   cellHyperlink: { yaml: "ГиперссылкаЯчейки", type: "boolean", defaultValueYAML: false },
+  autoCellHeight: {
+    yaml: "АвтоВысотаЯчейки",
+    type: "boolean",
+    defaultValueYAML: true,
+  },
   horizontalAlign: {
     yaml: "ГоризонтальноеПоложение",
     type: "SystemEnumeration",

--- a/packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.ts
+++ b/packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.ts
@@ -1,0 +1,7 @@
+import type { InputField } from "../types"
+
+export const autoCellHeightInputField = {
+  itemType: "InputField",
+  name: "ПолеАвтоВысотаЯчейки",
+  autoCellHeight: true,
+} as const satisfies InputField

--- a/packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.xml
+++ b/packages/core/metadata/forms/elements/inputField/__fixtures__/autoCellHeight.xml
@@ -1,0 +1,5 @@
+<InputField name="ПолеАвтоВысотаЯчейки" id="1">
+	<AutoCellHeight>true</AutoCellHeight>
+	<ContextMenu name="ПолеАвтоВысотаЯчейкиКонтекстноеМеню" id="2"/>
+	<ExtendedTooltip name="ПолеАвтоВысотаЯчейкиРасширеннаяПодсказка" id="3"/>
+</InputField>

--- a/packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.ts
+++ b/packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.ts
@@ -1,0 +1,7 @@
+import type { LabelField } from "../types"
+
+export const autoCellHeightLabelField = {
+  itemType: "LabelField",
+  name: "НадписьАвтоВысотаЯчейки",
+  autoCellHeight: true,
+} as const satisfies LabelField

--- a/packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.xml
+++ b/packages/core/metadata/forms/elements/labelField/__fixtures__/autoCellHeight.xml
@@ -1,0 +1,5 @@
+<LabelField name="НадписьАвтоВысотаЯчейки" id="1">
+	<AutoCellHeight>true</AutoCellHeight>
+	<ContextMenu name="НадписьАвтоВысотаЯчейкиКонтекстноеМеню" id="2"/>
+	<ExtendedTooltip name="НадписьАвтоВысотаЯчейкиРасширеннаяПодсказка" id="3"/>
+</LabelField>


### PR DESCRIPTION
## Summary
- Исправляет сохранение reference-order для duplicate auto CommandInterface items через matching по command + commandGroup + index.
- Переносит AutoCellHeight в common form field rules, чтобы обычные InputField/LabelField сохраняли XML node.
- Добавляет узкие fixtures и переносит спецификацию/план в docs/superpowers.

## Test Plan
- pnpm test
- focused Vitest проверки CommandInterface и form elements round-trip