### PR TITLE
Исправить round-trip ListSettings и Undefined

### DIFF
--- a/docs/superpowers/plans/2026-05-08-round-trip-diffs-10-14.md
+++ b/docs/superpowers/plans/2026-05-08-round-trip-diffs-10-14.md
@@ -1,0 +1,485 @@
+# Round-Trip Diffs 10-14 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two approved XML round-trip differences from indexes 10-14: preserve an empty `<ListSettings/>` for `DynamicList`, and preserve the reference `d6p1:Undefined` type marker for `DCSParameter.value` when the model value is missing or explicitly `undefined`.
+
+**Architecture:** Keep the fixes narrow. `DynamicList` uses the existing orchestration-level `requiredXMLParents` mechanism. `DCSParameter` gets a collection-level export wrapper that only patches `dcssch:value` from reference XML for the special `v8:Type` + `*:Undefined` case; `null` and ordinary undefined values continue through the existing export path.
+
+**Tech Stack:** TypeScript, Vitest, `fast-xml-parser`, existing `metadata/orchestration` export helpers, pnpm workspace commands.
+
+---
+
+## Boundaries
+
+- [ ] Do not address `DefaultVisible`; that difference is intentionally out of scope.
+- [ ] Do not modify existing XML fixtures; add a new focused fixture for empty `ListSettings`.
+- [ ] Do not add broad namespace preservation to `MetadataValue` or generic XML export.
+- [ ] Do not change XML import behavior.
+- [ ] Keep `null` exporting as `xsi:nil`.
+
+---
+
+## File Map
+
+- `packages/core/metadata/forms/commonObjects/dynamicList/rules.ts`: declares that `DynamicList` always materializes the `ListSettings` XML parent.
+- `packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/data.ts`: holds the expected model for the new empty-`ListSettings` fixture.
+- `packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/emptyListSettings.xml`: new source-of-truth fixture for `<ListSettings/>`.
+- `packages/core/metadata/forms/commonObjects/dynamicList/fromXML.test.ts`: covers import and round-trip for the new fixture.
+- `packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts`: covers direct export for the new fixture.
+- `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts`: contains the narrow collection export wrapper for `DCSParameter.value`.
+- `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/types.ts`: registers the custom `DCSParameters` XML exporter.
+- `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts`: covers reference `d6p1:Undefined` behavior and guards existing `xsi:nil` behavior.
+
+---
+
+## Task 1: Preserve Empty `ListSettings` For `DynamicList`
+
+**Files:**
+
+- `packages/core/metadata/forms/commonObjects/dynamicList/rules.ts`
+- `packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/data.ts`
+- `packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/emptyListSettings.xml`
+- `packages/core/metadata/forms/commonObjects/dynamicList/fromXML.test.ts`
+- `packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts`
+
+### 1. Add The Model Fixture
+
+- [ ] In `packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/data.ts`, add this fixture near `minimalDynamicList`:
+
+```ts
+export const emptyListSettingsDynamicList = {
+	customQuery: false,
+	dynamicDataRead: true,
+	itemType: "DynamicList",
+	mainTable: "Catalog.Справочник1",
+} as const satisfies DynamicList
+```
+
+### 2. Add The XML Fixture
+
+- [ ] Create `packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/emptyListSettings.xml`:
+
+```xml
+<Settings xsi:type="DynamicList">
+	<ManualQuery>false</ManualQuery>
+	<DynamicDataRead>true</DynamicDataRead>
+	<MainTable>Catalog.Справочник1</MainTable>
+	<ListSettings/>
+</Settings>
+```
+
+### 3. Add Import And Round-Trip Coverage
+
+- [ ] In `packages/core/metadata/forms/commonObjects/dynamicList/fromXML.test.ts`, extend the fixture import:
+
+```ts
+import {
+	emptyListSettingsDynamicList,
+	fullDynamicList,
+	minimalDynamicList,
+} from "./__fixtures__/data"
+```
+
+- [ ] Add this import test inside the existing `describe("DynamicListFromXML", ...)` block:
+
+```ts
+	it("should import empty ListSettings", () => {
+		const result = testImportPropertyFromXML({
+			rule,
+			path: "emptyListSettings.xml",
+			xmlRootTag: "Settings",
+			importMetaUrl: import.meta.url,
+		})
+
+		expect(result).toEqual(emptyListSettingsDynamicList)
+	})
+```
+
+- [ ] Add this round-trip test in the same file:
+
+```ts
+	it("round-trip: emptyListSettings.xml import -> export", () => {
+		const { expectedResult, result } = testRoundTripPropertyXML({
+			rule,
+			path: "emptyListSettings.xml",
+			xmlRootTag: "Settings",
+			importMetaUrl: import.meta.url,
+		})
+
+		expect(result).toEqual(expectedResult)
+	})
+```
+
+### 4. Add Export Coverage
+
+- [ ] In `packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts`, extend the fixture import:
+
+```ts
+import {
+	emptyListSettingsDynamicList,
+	fullDynamicList,
+	minimalDynamicList,
+} from "./__fixtures__/data"
+```
+
+- [ ] Add this export test inside the existing `describe("DynamicListToXML", ...)` block:
+
+```ts
+	it("should export empty ListSettings", () => {
+		const { expectedResult, result } = testExportPropertyToXML({
+			rule,
+			value: emptyListSettingsDynamicList,
+			path: "emptyListSettings.xml",
+			xmlRootTag: "Settings",
+			importMetaUrl: import.meta.url,
+		})
+
+		expect(result).toEqual(expectedResult)
+	})
+```
+
+### 5. Confirm The Failing Test First
+
+- [ ] Run the focused tests:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/dynamicList -t "empty ListSettings"
+```
+
+- [ ] Expected result before implementation: export or round-trip fails because `<ListSettings/>` is absent from the result XML.
+
+### 6. Implement The Minimal Rule Change
+
+- [ ] In `packages/core/metadata/forms/commonObjects/dynamicList/rules.ts`, add `requiredXMLParents` at the top level of `DynamicListRules`:
+
+```ts
+export const DynamicListRules = defineMetadataItemRule<DynamicList>({
+	itemType: "DynamicList",
+	requiredXMLParents: [["ListSettings"]],
+	properties: {
+```
+
+### 7. Verify The DynamicList Fix
+
+- [ ] Re-run the focused tests:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/dynamicList -t "empty ListSettings"
+```
+
+- [ ] Run the whole `DynamicList` test file set:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/dynamicList
+```
+
+- [ ] Expected result: all `DynamicList` tests pass.
+
+### 8. Commit Task 1
+
+- [ ] Stage only the `DynamicList` files:
+
+```bash
+git add packages/core/metadata/forms/commonObjects/dynamicList/rules.ts \
+	packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/data.ts \
+	packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/emptyListSettings.xml \
+	packages/core/metadata/forms/commonObjects/dynamicList/fromXML.test.ts \
+	packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts
+```
+
+- [ ] Commit:
+
+```bash
+git commit -m "fix: :bug: сохранить пустой ListSettings в DynamicList"
+```
+
+---
+
+## Task 2: Preserve Reference `d6p1:Undefined` For `DCSParameter.value`
+
+**Files:**
+
+- `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts`
+- `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/types.ts`
+- `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts`
+
+### 1. Add Focused Tests First
+
+- [ ] In `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts`, add these helpers near the existing `describe` setup:
+
+```ts
+const undefinedTypeReferenceValue = {
+	"_xmlns:d6p1": "http://v8.1c.ru/8.2/data/types",
+	"_xsi:type": "v8:Type",
+	"#text": "d6p1:Undefined",
+} as const
+
+const parameterWithoutValue = {
+	itemType: "DCSParameter",
+	name: "ТипЗначенияКлюча",
+	title: { items: { ru: "Тип значения ключа" } },
+} as const
+
+const parameterWithUndefinedTypeReference = {
+	...parameterWithoutValue,
+	value: undefinedTypeReferenceValue,
+} as const
+```
+
+- [ ] Add the missing-value test:
+
+```ts
+	it("exports missing value from reference d6p1 Undefined", () => {
+		const result = exportDCSParameters(
+			[parameterWithoutValue],
+			[parameterWithUndefinedTypeReference],
+		)
+
+		expect(result).toContain(
+			'<dcssch:value xmlns:d6p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d6p1:Undefined</dcssch:value>',
+		)
+	})
+```
+
+- [ ] Add the explicit-undefined test:
+
+```ts
+	it("exports explicit undefined value from reference d6p1 Undefined", () => {
+		const result = exportDCSParameters(
+			[{ ...parameterWithoutValue, value: undefined }],
+			[parameterWithUndefinedTypeReference],
+		)
+
+		expect(result).toContain(
+			'<dcssch:value xmlns:d6p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d6p1:Undefined</dcssch:value>',
+		)
+	})
+```
+
+- [ ] Keep the existing tests that assert ordinary `undefined` still exports as `xsi:nil`; those protect the narrowness of the fallback.
+
+### 2. Confirm The Failing Test First
+
+- [ ] Run the focused tests:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts -t "reference d6p1 Undefined"
+```
+
+- [ ] Expected result before implementation: the output lacks the namespace-preserving `dcssch:value` from the reference.
+
+### 3. Add A Collection Export Wrapper
+
+- [ ] Create `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts`:
+
+```ts
+import { exportMetadataItemToXML } from "~/metadata/orchestration"
+import type { NamedElementXML } from "~/metadata/orchestration/metadataCollection/types"
+import type { ExportToXMLFunctionNew } from "~/metadata/orchestration/property/fn"
+
+import { DCSParameterRules } from "./rules"
+import type { DCSParameter, DCSParameters } from "./types"
+
+type ReferenceUndefinedTypeValueXML = Record<string, unknown> & {
+	"#text": string
+	"_xsi:type": "v8:Type"
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+	value !== null && typeof value === "object"
+
+const getReferenceUndefinedTypeValue = (
+	value: unknown,
+): ReferenceUndefinedTypeValueXML | undefined => {
+	if (!isObject(value) || value["_xsi:type"] !== "v8:Type") {
+		return undefined
+	}
+
+	const text = value["#text"]
+	if (typeof text !== "string") {
+		return undefined
+	}
+
+	const [prefix, name] = text.split(":")
+	if (!prefix || name !== "Undefined") {
+		return undefined
+	}
+
+	const namespaceKey = `_xmlns:${prefix}`
+	if (typeof value[namespaceKey] !== "string") {
+		return undefined
+	}
+
+	return value as ReferenceUndefinedTypeValueXML
+}
+
+const hasMissingValue = (item: DCSParameter): boolean =>
+	!Object.prototype.hasOwnProperty.call(item, "value") ||
+	item.value === undefined
+
+const findReferenceItem = (
+	item: DCSParameter,
+	referenceData: DCSParameters | undefined,
+): DCSParameter | undefined =>
+	referenceData?.find((referenceItem) => referenceItem.name === item.name)
+
+export const exportDCSParametersToXML: ExportToXMLFunctionNew = (params) => {
+	const data = params.value as DCSParameters | undefined
+	const referenceData = params.referenceMetadata as DCSParameters | undefined
+	const inputData =
+		data !== undefined && data.length > 0
+			? data
+			: referenceData !== undefined && referenceData.length > 0
+				? referenceData
+				: []
+
+	if (inputData.length === 0) {
+		return undefined
+	}
+
+	const result = inputData.map((item, index) => {
+		const referenceItem =
+			findReferenceItem(item, referenceData) ?? referenceData?.[index]
+		const referenceUndefinedValue = hasMissingValue(item)
+			? getReferenceUndefinedTypeValue(referenceItem?.value)
+			: undefined
+		const referenceForExport =
+			referenceUndefinedValue !== undefined && referenceItem !== undefined
+				? { ...referenceItem, value: undefined }
+				: referenceItem
+
+		const itemXML =
+			(exportMetadataItemToXML({
+				context: params.context,
+				data: item,
+				referenceData: referenceForExport,
+				rule: DCSParameterRules,
+			}) as NamedElementXML | undefined) ?? {}
+
+		if (referenceUndefinedValue !== undefined) {
+			itemXML["dcssch:value"] = referenceUndefinedValue
+		}
+
+		return itemXML
+	})
+
+	return params.rule.xml === "Parameter" ? result : { Parameter: result }
+}
+```
+
+### 4. Register The Custom Exporter
+
+- [ ] In `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/types.ts`, add the import:
+
+```ts
+import { exportDCSParametersToXML } from "./toXML"
+```
+
+- [ ] Add `toXML` to the collection registration:
+
+```ts
+registerMetadataItemCollectionRule({
+	propertyType: "DCSParameters",
+	itemRule: DCSParameterRules,
+	xmlElement: "Parameter",
+	keyField: "name",
+	toXML: exportDCSParametersToXML,
+})
+```
+
+### 5. Verify The DCSParameter Fix
+
+- [ ] Re-run the focused tests:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts -t "reference d6p1 Undefined"
+```
+
+- [ ] Run all `DCSParameter` tests:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter
+```
+
+- [ ] Expected result: all `DCSParameter` tests pass, including existing `xsi:nil` cases.
+
+### 6. Commit Task 2
+
+- [ ] Stage only the `DCSParameter` files:
+
+```bash
+git add packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts \
+	packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/types.ts \
+	packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts
+```
+
+- [ ] Commit:
+
+```bash
+git commit -m "fix: :bug: сохранить reference Undefined в DCSParameter"
+```
+
+---
+
+## Task 3: Round-Trip And Full Verification
+
+### 1. Run The Original Round-Trip Slice
+
+- [ ] From `/Users/nikita/git/nakidka-core/.worktrees/round-trip-sequential`, run:
+
+```bash
+env NKDK_XML_REPO=/Users/nikita/git/round-trip-source NKDK_XML_DIR=/Users/nikita/git/round-trip-source/trade ./.agents/skills/round-trip-xml/round-trip.sh --triage --batch-size 5 --start-index 10
+```
+
+- [ ] Expected result: indexes 10-14 no longer include the empty `ListSettings` and `d6p1:Undefined` namespace differences. Other unrelated differences may remain outside this approved scope.
+
+### 2. Run Package Tests
+
+- [ ] Run the core package tests:
+
+```bash
+pnpm --filter '@nakidka/core' test
+```
+
+- [ ] Expected result: all core tests pass.
+
+### 3. Run Full Repository Tests
+
+- [ ] Because this is a fresh worktree, ensure Langium files are generated:
+
+```bash
+pnpm --filter nkdk-language langium:generate
+```
+
+- [ ] Run the full suite from the worktree root:
+
+```bash
+pnpm test
+```
+
+- [ ] Expected result: all package tests pass.
+
+### 4. Final Git Check
+
+- [ ] Confirm the worktree has only intentional committed changes:
+
+```bash
+git status --short
+```
+
+- [ ] If the plan file itself is still uncommitted, stage and commit it separately:
+
+```bash
+git add docs/superpowers/plans/2026-05-08-round-trip-diffs-10-14.md
+git commit -m "docs: :memo: описать план round-trip 10-14"
+```
+
+---
+
+## Notes For Review
+
+- `requiredXMLParents: [["ListSettings"]]` should create the parent only when missing and should not overwrite non-empty `ListSettings` content created by nested properties.
+- The `DCSParameter` fallback treats absent `value` and explicit `value: undefined` the same.
+- The `DCSParameter` fallback requires all of these reference conditions: `_xsi:type` is `v8:Type`, text is `<prefix>:Undefined`, and `_xmlns:<prefix>` is present.
+- `value: null` stays outside the fallback and remains `xsi:nil`.

--- a/docs/superpowers/specs/2026-05-08-empty-list-settings-design.md
+++ b/docs/superpowers/specs/2026-05-08-empty-list-settings-design.md
@@ -1,0 +1,83 @@
+# Empty ListSettings round-trip
+
+## Context
+
+Short round-trip по XML-дампу `trade` показывает один кластер расхождений в формах списка:
+
+- `Catalogs/КлассификаторТаможенныхПунктовСАТУРН/Forms/ФормаСписка/Ext/Form.xml`
+- `Catalogs/КлассификаторТерриториальныхУправленийСАТУРН/Forms/ФормаСписка/Ext/Form.xml`
+- `Catalogs/КлассификаторТранспортныхСредствСАТУРН/Forms/ФормаСписка/Ext/Form.xml`
+
+Во всех трех случаях после round-trip пропадает пустой XML-контейнер:
+
+```diff
+ <MainTable>Catalog...</MainTable>
+-<ListSettings/>
+```
+
+Владеющий модуль: `packages/core/metadata/forms/commonObjects/dynamicList`.
+
+## Goal
+
+Сохранить пустой `<ListSettings/>` при экспорте `DynamicList`, если исходный или ожидаемый XML содержит динамический список без пользовательских настроек внутри `ListSettings`.
+
+## Design
+
+Добавить на уровень `DynamicListRules` декларативный обязательный XML-контейнер:
+
+```ts
+requiredXMLParents: [["ListSettings"]]
+```
+
+Это использует уже существующий механизм `exportPropertiesToXML -> applyRequiredXMLParents`. Если свойства `filter`, `order`, `conditionalAppearance`, `dataParameters` или другие поля с `xmlParents: ["ListSettings"]` уже создали контейнер, он не перезаписывается. Если таких полей нет, экспорт материализует пустой объект, который сериализуется как `<ListSettings/>`.
+
+## Data Flow
+
+1. `fromXML` импортирует `Settings` динамического списка как сейчас.
+2. `toXML` экспортирует обычные свойства `DynamicList`: `Field`, `Parameter`, `MainTable` и другие.
+3. После обхода свойств `exportPropertiesToXML` вызывает `applyRequiredXMLParents`.
+4. `applyRequiredXMLParents` гарантирует наличие `ListSettings` в результате, не меняя уже заполненный контейнер.
+
+## Alternatives
+
+Рекомендованный подход: `requiredXMLParents` на `DynamicListRules`. Он точечно описывает доменную форму XML и не добавляет технических полей в модель.
+
+Отклоненные варианты:
+
+- Техническое свойство в `DynamicListRules` с `xmlParents/defaultValueXMLRaw`: добавляет шум в модель правил.
+- Изменение общего `orchestration` для восстановления пустых `xmlParents` из reference XML: шире по влиянию и может создать неожиданные пустые контейнеры в других metadataItem.
+
+## Tests
+
+Добавить новую XML-фикстуру для `DynamicList` с `MainTable` и пустым `<ListSettings/>`; существующие XML-фикстуры не менять.
+
+Проверки:
+
+- `fromXML` импортирует фикстуру в ожидаемую TS-форму.
+- `toXML` экспортирует ожидаемую TS-форму с пустым `<ListSettings/>`.
+- round-trip `import -> export` сохраняет контейнер.
+
+Быстрая проверка после реализации:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run -t "DynamicList"
+```
+
+Финальная проверка:
+
+```bash
+pnpm test
+```
+
+## Scope
+
+Входит:
+
+- только модуль `forms/commonObjects/dynamicList`;
+- новая фикстура и точечные тесты для пустого `ListSettings`.
+
+Не входит:
+
+- исправление namespace `xmlns:d6p1` в `DCSParameter`;
+- общая переработка `xmlParents`;
+- изменение существующих XML-фикстур.

--- a/docs/superpowers/specs/2026-05-08-empty-list-settings-design.md
+++ b/docs/superpowers/specs/2026-05-08-empty-list-settings-design.md
@@ -1,6 +1,8 @@
-# Empty ListSettings round-trip
+# Round-trip diffs 10-14 design notes
 
-## Context
+## Cluster 1: Empty ListSettings
+
+### Context
 
 Short round-trip по XML-дампу `trade` показывает один кластер расхождений в формах списка:
 
@@ -17,11 +19,11 @@ Short round-trip по XML-дампу `trade` показывает один кл�
 
 Владеющий модуль: `packages/core/metadata/forms/commonObjects/dynamicList`.
 
-## Goal
+### Goal
 
 Сохранить пустой `<ListSettings/>` при экспорте `DynamicList`, если исходный или ожидаемый XML содержит динамический список без пользовательских настроек внутри `ListSettings`.
 
-## Design
+### Design
 
 Добавить на уровень `DynamicListRules` декларативный обязательный XML-контейнер:
 
@@ -31,14 +33,14 @@ requiredXMLParents: [["ListSettings"]]
 
 Это использует уже существующий механизм `exportPropertiesToXML -> applyRequiredXMLParents`. Если свойства `filter`, `order`, `conditionalAppearance`, `dataParameters` или другие поля с `xmlParents: ["ListSettings"]` уже создали контейнер, он не перезаписывается. Если таких полей нет, экспорт материализует пустой объект, который сериализуется как `<ListSettings/>`.
 
-## Data Flow
+### Data Flow
 
 1. `fromXML` импортирует `Settings` динамического списка как сейчас.
 2. `toXML` экспортирует обычные свойства `DynamicList`: `Field`, `Parameter`, `MainTable` и другие.
 3. После обхода свойств `exportPropertiesToXML` вызывает `applyRequiredXMLParents`.
 4. `applyRequiredXMLParents` гарантирует наличие `ListSettings` в результате, не меняя уже заполненный контейнер.
 
-## Alternatives
+### Alternatives
 
 Рекомендованный подход: `requiredXMLParents` на `DynamicListRules`. Он точечно описывает доменную форму XML и не добавляет технических полей в модель.
 
@@ -47,7 +49,7 @@ requiredXMLParents: [["ListSettings"]]
 - Техническое свойство в `DynamicListRules` с `xmlParents/defaultValueXMLRaw`: добавляет шум в модель правил.
 - Изменение общего `orchestration` для восстановления пустых `xmlParents` из reference XML: шире по влиянию и может создать неожиданные пустые контейнеры в других metadataItem.
 
-## Tests
+### Tests
 
 Добавить новую XML-фикстуру для `DynamicList` с `MainTable` и пустым `<ListSettings/>`; существующие XML-фикстуры не менять.
 
@@ -69,7 +71,7 @@ pnpm --filter '@nakidka/core' exec vitest run -t "DynamicList"
 pnpm test
 ```
 
-## Scope
+### Scope
 
 Входит:
 
@@ -81,3 +83,94 @@ pnpm test
 - исправление namespace `xmlns:d6p1` в `DCSParameter`;
 - общая переработка `xmlParents`;
 - изменение существующих XML-фикстур.
+
+## Cluster 2: Reference d6p1 Undefined value
+
+### Context
+
+Следующие два расхождения относятся к `Catalogs/КлючиРеестраДокументов/Forms`:
+
+- `ФормаВыбора/Ext/Form.xml`
+- `ФормаСписка/Ext/Form.xml`
+
+В обоих случаях round-trip теряет локальное объявление namespace на значении параметра динамического списка:
+
+```diff
+-<dcssch:value xmlns:d6p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d6p1:Undefined</dcssch:value>
++<dcssch:value xsi:type="v8:Type">d6p1:Undefined</dcssch:value>
+```
+
+Владеющий модуль: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter`. Низкоуровневый экспорт значения проходит через `MetadataDcsMetadataValue` и `MetadataValue` `typeRef`.
+
+### Goal
+
+Сохранить reference-значение `d6p1:Undefined` целиком, включая `xmlns:d6p1`, когда модель не задаёт значение параметра явно, а исходный XML уже содержал такое значение.
+
+### Design
+
+Для `DCSParameter.value` добавить узкий fallback при экспорте:
+
+- поле `value` в модели отсутствует или равно `undefined`;
+- reference-элемент содержит `dcssch:value` с `_xsi:type: "v8:Type"`;
+- текст reference-значения имеет вид `<prefix>:Undefined`;
+- reference-значение содержит соответствующий namespace-атрибут `_xmlns:<prefix>`.
+
+Если условия выполнены, экспортирует reference-узел целиком. Это сохраняет исходный namespace и не требует расширять модель новым техническим полем.
+
+Явное `null` остаётся отдельной семантикой и продолжает экспортироваться как `xsi:nil`.
+
+### Data Flow
+
+1. `fromXML` обычного импорта может не хранить `value` в модели, если для параметра нет осмысленного значения в YAML.
+2. `fromXML` reference-импорта сохраняет XML-only значение параметра как reference-данные.
+3. `toXML` для `DCSParameter.value` видит `value === undefined` или отсутствие ключа.
+4. Если reference-значение соответствует `v8:Type` / `*:Undefined`, экспорт использует reference XML-узел вместо генерации нового `xsi:nil` или потери namespace.
+
+### Alternatives
+
+Рекомендованный подход: специальный fallback на уровне `DCSParameter.value`. Он совпадает с пользовательской семантикой: значение восстанавливается только тогда, когда модель его не задаёт, а reference уже содержит нужный XML.
+
+Отклоненные варианты:
+
+- Всегда добавлять namespace в `MetadataValue` `typeRef` для `*:Undefined`: меняет общий экспорт без reference и затрагивает существующие фикстуры.
+- Переносить namespace для любых совпавших DCS-значений: шире нужного и может скрыть отличия между моделью и reference.
+- Делать общий preserve XML-атрибутов для всех `preserveFromReferenceXML`: рискованно для `orchestration` и не требуется для текущего кластера.
+
+### Tests
+
+Добавить новый тестовый случай для `DCSParameter` с reference-значением:
+
+```xml
+<dcssch:value xmlns:d6p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d6p1:Undefined</dcssch:value>
+```
+
+Проверки:
+
+- если поле `value` отсутствует в модели, экспорт сохраняет reference-узел целиком;
+- если поле `value` явно задано как `undefined`, экспорт тоже сохраняет reference-узел целиком;
+- `value: null` продолжает давать `xsi:nil`.
+
+Быстрая проверка после реализации:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run -t "DCSParameter"
+```
+
+Финальная проверка:
+
+```bash
+pnpm test
+```
+
+### Scope
+
+Входит:
+
+- только поведение `DCSParameter.value` при наличии reference-значения `*:Undefined`;
+- тесты для отсутствующего `value` и явного `value: undefined`.
+
+Не входит:
+
+- изменение общего `MetadataValue` `typeRef`;
+- изменение XML-импорта;
+- общий preserve namespace-атрибутов для всех XML-узлов.

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts
@@ -40,16 +40,59 @@ const getXsiType = (root: unknown): string | undefined => {
   return undefined
 }
 
+type ReferenceUndefinedTypeValueXML = Record<string, unknown> & {
+  "#text": string
+  "_xsi:type": "v8:Type"
+}
+
+const getUndefinedTypePrefix = (root: unknown): string | undefined => {
+  if (typeof root !== "object" || root === null || getXsiType(root) !== "v8:Type") {
+    return undefined
+  }
+
+  const text = (root as Record<string, unknown>)["#text"]
+  if (typeof text !== "string") {
+    return undefined
+  }
+
+  const parts = text.split(":")
+  if (parts.length !== 2) {
+    return undefined
+  }
+
+  const [prefix, name] = parts
+  return prefix !== "" && name === "Undefined" ? prefix : undefined
+}
+
+const shouldImportUndefinedTypeAsMissing = (rule: DcsMetadataValuePropertyRule): boolean =>
+  rule.valueType === "Primitive" && rule.exportNilValue === true && rule.preserveFromReferenceXML === true
+
+const asReferenceUndefinedTypeValueXML = (
+  root: unknown,
+  prefix: string
+): ReferenceUndefinedTypeValueXML | undefined => {
+  if (typeof root !== "object" || root === null) {
+    return undefined
+  }
+
+  const namespaceKey = `_xmlns:${prefix}`
+  if (typeof (root as Record<string, unknown>)[namespaceKey] !== "string") {
+    return undefined
+  }
+
+  return root as ReferenceUndefinedTypeValueXML
+}
+
 const hasSystemEnumeration = (
   rule: DcsMetadataValuePropertyRule
 ): rule is DcsMetadataValuePropertyRule & { valueType: "SystemEnumeration"; typeSE: keyof SystemEnumerationTypeMap } =>
   rule.valueType === "SystemEnumeration" && rule.typeSE !== undefined
 
-export const importDcsMetadataValueFromDcsXML = (
+const importDcsMetadataValueFromDcsXMLInternal = (
   context: ConfigurationContextFromXML,
   rule: DcsMetadataValuePropertyRule,
   xml: MetadataDcsMetadataValueDcsRootXML
-): MetadataDcsMetadataValue => {
+): MetadataDcsMetadataValue | undefined => {
   const root = xml["dcscor:value"]
   if (root === undefined) {
     throw new Error("DCS MetadataValue: missing dcscor:value")
@@ -112,6 +155,15 @@ export const importDcsMetadataValueFromDcsXML = (
   }
 
   const metadataPrimitive = xsi !== undefined ? MetadataValueTypeFromXML(xsi as MetadataValueTypeXML) : undefined
+  const undefinedTypePrefix = getUndefinedTypePrefix(root)
+  if (undefinedTypePrefix !== undefined && shouldImportUndefinedTypeAsMissing(rule)) {
+    if (context.fromXML.forReference) {
+      return asReferenceUndefinedTypeValueXML(root, undefinedTypePrefix) as unknown as MetadataDcsMetadataValue | undefined
+    }
+
+    return undefined
+  }
+
   if (metadataPrimitive !== undefined) {
     return importMetadataValueFromXML({
       context,
@@ -131,6 +183,19 @@ export const importDcsMetadataValueFromDcsXML = (
   throw new Error(`DCS MetadataValue: unsupported xsi:type ${String(xsi)}`)
 }
 
+export const importDcsMetadataValueFromDcsXML = (
+  context: ConfigurationContextFromXML,
+  rule: DcsMetadataValuePropertyRule,
+  xml: MetadataDcsMetadataValueDcsRootXML
+): MetadataDcsMetadataValue => {
+  const result = importDcsMetadataValueFromDcsXMLInternal(context, rule, xml)
+  if (result === undefined) {
+    throw new Error("DCS MetadataValue: unexpected missing value")
+  }
+
+  return result
+}
+
 const isDcsMetadataValueRootXml = (value: unknown): value is MetadataDcsMetadataValueDcsRootXML =>
   typeof value === "object" && value !== null && !Array.isArray(value) && "dcscor:value" in value
 
@@ -143,7 +208,7 @@ const importDcsMetadataValueFromXMLForRule: (
   const xml: MetadataDcsMetadataValueDcsRootXML = isDcsMetadataValueRootXml(value)
     ? value
     : { "dcscor:value": value as MetadataDcsMetadataValueDcsRootXML["dcscor:value"] }
-  return importDcsMetadataValueFromDcsXML(context, rule as unknown as DcsMetadataValuePropertyRule, xml)
+  return importDcsMetadataValueFromDcsXMLInternal(context, rule as unknown as DcsMetadataValuePropertyRule, xml)
 }
 
 registerTypeRule("MetadataDcsMetadataValue", "importFromXML", importDcsMetadataValueFromXMLForRule)

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts
@@ -15,6 +15,29 @@ const xmlWithStringTitle = `<Settings>
 	</Parameter>
 </Settings>`
 
+const undefinedTypeReferenceValue = {
+  "_xmlns:d6p1": "http://v8.1c.ru/8.2/data/types",
+  "_xsi:type": "v8:Type",
+  "#text": "d6p1:Undefined",
+} as const
+
+const xmlWithUndefinedTypeValue = `<Settings>
+	<Parameter>
+		<dcssch:name>ТипЗначенияКлюча</dcssch:name>
+		<dcssch:title xsi:type="v8:LocalStringType">
+			<v8:item>
+				<v8:lang>ru</v8:lang>
+				<v8:content>Тип значения ключа</v8:content>
+			</v8:item>
+		</dcssch:title>
+		<dcssch:valueType>
+			<v8:Type>v8:Type</v8:Type>
+		</dcssch:valueType>
+		<dcssch:value xmlns:d6p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d6p1:Undefined</dcssch:value>
+		<dcssch:useRestriction>true</dcssch:useRestriction>
+	</Parameter>
+</Settings>`
+
 const exportDCSParameters = (value: unknown, referenceMetadata?: unknown): string => {
   const xmlData = exportPropertyToXML({
     context: mockContextToXML(),
@@ -71,5 +94,45 @@ describe("import DCSParameter from XML", () => {
     const exported = exportDCSParameters(result, referenceMetadata)
     expect(exported).toContain(`<dcssch:title xsi:type="xs:string">String title</dcssch:title>`)
     expect(exported).not.toContain(`<dcssch:title xsi:type="v8:LocalStringType">`)
+  })
+
+  it("imports v8 Type Undefined value as missing value", () => {
+    const result = testImportPropertyFromXML({
+      rule,
+      xmlString: xmlWithUndefinedTypeValue,
+      xmlRootTag: "Settings",
+    }) as Record<string, unknown>[]
+
+    expect(result).toEqual([
+      {
+        itemType: "DCSParameter",
+        name: "ТипЗначенияКлюча",
+        title: { items: { ru: "Тип значения ключа" } },
+        valueType: { type: ["Type"] },
+        useRestriction: true,
+      },
+    ])
+    expect(Object.prototype.hasOwnProperty.call(result[0], "value")).toBe(false)
+  })
+
+  it("imports reference v8 Type Undefined value so export preserves namespace", () => {
+    const result = testImportPropertyFromXML({
+      rule,
+      xmlString: xmlWithUndefinedTypeValue,
+      xmlRootTag: "Settings",
+    })
+    const referenceMetadata = testImportPropertyFromXML({
+      rule,
+      xmlString: xmlWithUndefinedTypeValue,
+      xmlRootTag: "Settings",
+      forReference: true,
+    }) as Record<string, unknown>[]
+
+    expect(referenceMetadata[0]?.value).toEqual(undefinedTypeReferenceValue)
+
+    const exported = exportDCSParameters(result, referenceMetadata)
+    expect(exported).toContain(
+      '<dcssch:value xmlns:d6p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d6p1:Undefined</dcssch:value>',
+    )
   })
 })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts
@@ -18,6 +18,23 @@ const exportDCSParameters = (value: unknown, referenceMetadata?: unknown): strin
   return xmlExport({ Settings: xmlData }, false)
 }
 
+const undefinedTypeReferenceValue = {
+  "_xmlns:d6p1": "http://v8.1c.ru/8.2/data/types",
+  "_xsi:type": "v8:Type",
+  "#text": "d6p1:Undefined",
+} as const
+
+const parameterWithoutValue = {
+  itemType: "DCSParameter",
+  name: "ТипЗначенияКлюча",
+  title: { items: { ru: "Тип значения ключа" } },
+} as const
+
+const parameterWithUndefinedTypeReference = {
+  ...parameterWithoutValue,
+  value: undefinedTypeReferenceValue,
+} as const
+
 describe("export DCSParameter to XML", () => {
   it("exports minimal.xml", () => {
     const { expectedResult, result } = testExportPropertyToXML({
@@ -89,6 +106,28 @@ describe("export DCSParameter to XML", () => {
 
     expect(result).toContain(`<dcssch:value xsi:nil="true"/>`)
     expect(result).not.toContain("reference")
+  })
+
+  it("exports missing value from reference d6p1 Undefined", () => {
+    const result = exportDCSParameters(
+      [parameterWithoutValue],
+      [parameterWithUndefinedTypeReference],
+    )
+
+    expect(result).toContain(
+      '<dcssch:value xmlns:d6p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d6p1:Undefined</dcssch:value>',
+    )
+  })
+
+  it("exports explicit undefined value from reference d6p1 Undefined", () => {
+    const result = exportDCSParameters(
+      [{ ...parameterWithoutValue, value: undefined }],
+      [parameterWithUndefinedTypeReference],
+    )
+
+    expect(result).toContain(
+      '<dcssch:value xmlns:d6p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d6p1:Undefined</dcssch:value>',
+    )
   })
 
   it("omits missing value when neither model nor reference has value key", () => {

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts
@@ -119,6 +119,21 @@ describe("export DCSParameter to XML", () => {
     )
   })
 
+  it("exports Parameter rule as array without wrapper", () => {
+    const result = exportPropertyToXML({
+      context: mockContextToXML(),
+      rule: { type: "DCSParameters", xml: "Parameter" },
+      value: [parameterWithoutValue],
+      referenceMetadata: [parameterWithUndefinedTypeReference],
+    })
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        "dcssch:value": undefinedTypeReferenceValue,
+      }),
+    ])
+  })
+
   it("exports explicit undefined value from reference d6p1 Undefined", () => {
     const result = exportDCSParameters(
       [{ ...parameterWithoutValue, value: undefined }],

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.test.ts
@@ -119,6 +119,29 @@ describe("export DCSParameter to XML", () => {
     )
   })
 
+  it("does not use reference d6p1 Undefined from item with different name", () => {
+    const result = exportDCSParameters(
+      [{ ...parameterWithoutValue, name: "НовоеИмя" }],
+      [{ ...parameterWithUndefinedTypeReference, name: "СтароеИмя" }],
+    )
+
+    expect(result).not.toContain("<dcssch:value")
+  })
+
+  it("does not use reference d6p1 Undefined with extra QName part", () => {
+    const result = exportDCSParameters(
+      [parameterWithoutValue],
+      [
+        {
+          ...parameterWithUndefinedTypeReference,
+          value: { ...undefinedTypeReferenceValue, "#text": "d6p1:Undefined:extra" },
+        },
+      ],
+    )
+
+    expect(result).not.toContain("<dcssch:value")
+  })
+
   it("exports Parameter rule as array without wrapper", () => {
     const result = exportPropertyToXML({
       context: mockContextToXML(),

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts
@@ -1,0 +1,87 @@
+import { exportMetadataItemToXML } from "~/metadata/orchestration"
+import type { NamedElementXML } from "~/metadata/orchestration/metadataCollection/types"
+import type { ExportToXMLFunctionNew } from "~/metadata/orchestration/property/fn"
+
+import { DCSParameterRules } from "./rules"
+import type { DCSParameter, DCSParameters } from "./types"
+
+type ReferenceUndefinedTypeValueXML = Record<string, unknown> & {
+  "#text": string
+  "_xsi:type": "v8:Type"
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object"
+
+const getReferenceUndefinedTypeValue = (value: unknown): ReferenceUndefinedTypeValueXML | undefined => {
+  if (!isObject(value) || value["_xsi:type"] !== "v8:Type") {
+    return undefined
+  }
+
+  const text = value["#text"]
+  if (typeof text !== "string") {
+    return undefined
+  }
+
+  const [prefix, name] = text.split(":")
+  if (!prefix || name !== "Undefined") {
+    return undefined
+  }
+
+  const namespaceKey = `_xmlns:${prefix}`
+  if (typeof value[namespaceKey] !== "string") {
+    return undefined
+  }
+
+  return value as ReferenceUndefinedTypeValueXML
+}
+
+const hasMissingValue = (item: DCSParameter): boolean =>
+  !Object.prototype.hasOwnProperty.call(item, "value") || item.value === undefined
+
+const findReferenceItem = (
+  item: DCSParameter,
+  referenceData: DCSParameters | undefined,
+): DCSParameter | undefined => referenceData?.find((referenceItem) => referenceItem.name === item.name)
+
+export const exportDCSParametersToXML: ExportToXMLFunctionNew = (params) => {
+  const data = params.value as DCSParameters | undefined
+  const referenceData = params.referenceMetadata as DCSParameters | undefined
+  const inputData =
+    data !== undefined && data.length > 0
+      ? data
+      : referenceData !== undefined && referenceData.length > 0
+        ? referenceData
+        : []
+
+  if (inputData.length === 0) {
+    return undefined
+  }
+
+  const result = inputData.map((item, index) => {
+    const referenceItem = findReferenceItem(item, referenceData) ?? referenceData?.[index]
+    const referenceUndefinedValue = hasMissingValue(item)
+      ? getReferenceUndefinedTypeValue(referenceItem?.value)
+      : undefined
+    const referenceForExport =
+      referenceUndefinedValue !== undefined && referenceItem !== undefined
+        ? { ...referenceItem, value: undefined }
+        : referenceItem
+
+    const itemXML =
+      (exportMetadataItemToXML({
+        context: params.context,
+        data: item,
+        referenceData: referenceForExport,
+        rule: DCSParameterRules,
+      }) as NamedElementXML | undefined) ?? {}
+
+    if (referenceUndefinedValue !== undefined) {
+      itemXML["dcssch:value"] = referenceUndefinedValue
+    }
+
+    return itemXML
+  })
+
+  return params.rule.xml === "Parameter" ? result : { Parameter: result }
+}

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts
@@ -1,6 +1,7 @@
 import { exportMetadataItemToXML } from "~/metadata/orchestration"
 import type { NamedElementXML } from "~/metadata/orchestration/metadataCollection/types"
 import type { ExportToXMLFunctionNew } from "~/metadata/orchestration/property/fn"
+import type { ItemXML } from "~/metadata/orchestration/property/types"
 
 import { DCSParameterRules } from "./rules"
 import type { DCSParameter, DCSParameters } from "./types"
@@ -68,7 +69,7 @@ export const exportDCSParametersToXML: ExportToXMLFunctionNew = (params) => {
         ? { ...referenceItem, value: undefined }
         : referenceItem
 
-    const itemXML =
+    const itemXML: ItemXML =
       (exportMetadataItemToXML({
         context: params.context,
         data: item,

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts
@@ -14,8 +14,11 @@ type ReferenceUndefinedTypeValueXML = Record<string, unknown> & {
 const isObject = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object"
 
+const isReferenceTypeValue = (value: unknown): value is Record<string, unknown> =>
+  isObject(value) && value["_xsi:type"] === "v8:Type"
+
 const getReferenceUndefinedTypeValue = (value: unknown): ReferenceUndefinedTypeValueXML | undefined => {
-  if (!isObject(value) || value["_xsi:type"] !== "v8:Type") {
+  if (!isReferenceTypeValue(value)) {
     return undefined
   }
 
@@ -24,8 +27,13 @@ const getReferenceUndefinedTypeValue = (value: unknown): ReferenceUndefinedTypeV
     return undefined
   }
 
-  const [prefix, name] = text.split(":")
-  if (!prefix || name !== "Undefined") {
+  const parts = text.split(":")
+  if (parts.length !== 2) {
+    return undefined
+  }
+
+  const [prefix, name] = parts
+  if (prefix === "" || name !== "Undefined") {
     return undefined
   }
 
@@ -45,6 +53,11 @@ const findReferenceItem = (
   referenceData: DCSParameters | undefined,
 ): DCSParameter | undefined => referenceData?.find((referenceItem) => referenceItem.name === item.name)
 
+const omitValue = (item: DCSParameter): DCSParameter => {
+  const { value: _value, ...itemWithoutValue } = item
+  return itemWithoutValue
+}
+
 export const exportDCSParametersToXML: ExportToXMLFunctionNew = (params) => {
   const data = params.value as DCSParameters | undefined
   const referenceData = params.referenceMetadata as DCSParameters | undefined
@@ -59,14 +72,21 @@ export const exportDCSParametersToXML: ExportToXMLFunctionNew = (params) => {
     return undefined
   }
 
-  const result = inputData.map((item, index) => {
-    const referenceItem = findReferenceItem(item, referenceData) ?? referenceData?.[index]
+  const result = inputData.map((item) => {
+    const referenceItem = findReferenceItem(item, referenceData)
     const referenceUndefinedValue = hasMissingValue(item)
       ? getReferenceUndefinedTypeValue(referenceItem?.value)
       : undefined
+    const hasInvalidReferenceTypeValue =
+      hasMissingValue(item) &&
+      referenceItem !== undefined &&
+      isReferenceTypeValue(referenceItem.value) &&
+      referenceUndefinedValue === undefined
     const referenceForExport =
       referenceUndefinedValue !== undefined && referenceItem !== undefined
         ? { ...referenceItem, value: undefined }
+        : hasInvalidReferenceTypeValue
+          ? omitValue(referenceItem)
         : referenceItem
 
     const itemXML: ItemXML =

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/types.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/types.ts
@@ -2,6 +2,7 @@ import { registerMetadataItemCollectionRule } from "~/metadata/orchestration"
 import { MetadataTypeByRule } from "~/metadata/orchestration/metadataItem/element"
 import { YAMLTypeByRule } from "~/metadata/orchestration/metadataItem/yaml"
 import { DCSParameterRules } from "./rules"
+import { exportDCSParametersToXML } from "./toXML"
 
 export type DCSParameter = MetadataTypeByRule<typeof DCSParameterRules>
 
@@ -15,4 +16,5 @@ registerMetadataItemCollectionRule({
   itemRule: DCSParameterRules,
   xmlElement: "Parameter",
   keyField: "name",
+  toXML: exportDCSParametersToXML,
 })

--- a/packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/data.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/data.ts
@@ -338,6 +338,13 @@ export const minimalDynamicList = {
   itemsUserSettingID: true,
 } as const satisfies DynamicList
 
+export const emptyListSettingsDynamicList = {
+  customQuery: false,
+  dynamicDataRead: true,
+  itemType: "DynamicList",
+  mainTable: "Catalog.Справочник1",
+} as const satisfies DynamicList
+
 export const customQueryDynamicList = {
   АвтоЗаполнениеДоступныхПолей: "Истина",
   АвтоматическоеСохранениеПользовательскихНастроек: "Истина",

--- a/packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/emptyListSettings.xml
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/__fixtures__/emptyListSettings.xml
@@ -1,0 +1,6 @@
+<Settings xsi:type="DynamicList">
+	<ManualQuery>false</ManualQuery>
+	<DynamicDataRead>true</DynamicDataRead>
+	<MainTable>Catalog.Справочник1</MainTable>
+	<ListSettings/>
+</Settings>

--- a/packages/core/metadata/forms/commonObjects/dynamicList/fromXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/fromXML.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { fullDynamicList, minimalDynamicList } from "~/metadata/forms/commonObjects/dynamicList/__fixtures__/data"
+import {
+  emptyListSettingsDynamicList,
+  fullDynamicList,
+  minimalDynamicList,
+} from "~/metadata/forms/commonObjects/dynamicList/__fixtures__/data"
 import { importPropertyFromXML, PropertyRule } from "~/metadata/orchestration"
 import { mockContextFromXML } from "~/tests/mockContext"
 import { testExportPropertyToXML } from "~/tests/property/exportPropertyToXML"
@@ -39,6 +43,17 @@ describe("import DynamicList from XML", () => {
     expect(result).toEqual(minimalDynamicList)
   })
 
+  it("should import empty ListSettings", () => {
+    const result = testImportPropertyFromXML({
+      rule,
+      path: "emptyListSettings.xml",
+      xmlRootTag: "Settings",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(emptyListSettingsDynamicList)
+  })
+
   it("round-trip: full.xml import → export", () => {
     const imported = testImportPropertyFromXML({
       rule,
@@ -68,6 +83,23 @@ describe("import DynamicList from XML", () => {
       value: imported,
       xmlRootTag: "Settings",
       path: "minimal.xml",
+      importMetaUrl: import.meta.url,
+    })
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("round-trip: emptyListSettings.xml import -> export", () => {
+    const imported = testImportPropertyFromXML({
+      rule,
+      path: "emptyListSettings.xml",
+      xmlRootTag: "Settings",
+      importMetaUrl: import.meta.url,
+    })
+    const { expectedResult, result } = testExportPropertyToXML({
+      rule,
+      value: imported,
+      xmlRootTag: "Settings",
+      path: "emptyListSettings.xml",
       importMetaUrl: import.meta.url,
     })
     expect(result).toEqual(expectedResult)

--- a/packages/core/metadata/forms/commonObjects/dynamicList/rules.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/rules.ts
@@ -3,6 +3,7 @@ import { MetadataItemRule } from "~/metadata/orchestration/property/types"
 export const DynamicListRules = {
   itemType: "DynamicList",
   xsiType: "DynamicList",
+  requiredXMLParents: [["ListSettings"]],
   properties: {
     autoFillAvailableFields: {
       type: "boolean",

--- a/packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { fullDynamicList, minimalDynamicList } from "~/metadata/forms/commonObjects/dynamicList/__fixtures__/data"
+import {
+  emptyListSettingsDynamicList,
+  fullDynamicList,
+  minimalDynamicList,
+} from "~/metadata/forms/commonObjects/dynamicList/__fixtures__/data"
 import { exportPropertyToXML, PropertyRule } from "~/metadata/orchestration"
 import { mockContextToXML } from "~/tests/mockContext"
 import { testExportPropertyToXML } from "~/tests/property/exportPropertyToXML"
@@ -37,6 +41,18 @@ describe("export DynamicList to XML", () => {
       path: "minimal.xml",
       importMetaUrl: import.meta.url,
     })
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("should export empty ListSettings", () => {
+    const { expectedResult, result } = testExportPropertyToXML({
+      rule,
+      value: emptyListSettingsDynamicList,
+      path: "emptyListSettings.xml",
+      xmlRootTag: "Settings",
+      importMetaUrl: import.meta.url,
+    })
+
     expect(result).toEqual(expectedResult)
   })
 })


### PR DESCRIPTION
Что сделано:
- Сохраняется пустой DynamicList ListSettings при XML round-trip.
- DCSParameter с d6p1:Undefined импортируется как отсутствующее value, а reference XML сохраняет namespace для обратного экспорта.
- Добавлены спецификации и план для разобранных round-trip расхождений.

Проверки:
- pnpm --filter nkdk-language langium:generate
- pnpm test
- pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/dataCompositionSystem/dcsParameter metadata/commonObjects/dataCompositionSystem/dcsMetadataValue
- round-trip triage --start-index 8: DIFF_COUNT=61, без d6p1:Undefined/xmlns:d6p1 в diff