### PR TITLE
fix: исправить type-check core

### DIFF
--- a/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/fromXML.ts
@@ -55,15 +55,15 @@ const importCommandInterfaceItemFromXML = (
     }
   }
 
-  const orderedKeys = context.fromXML.forReference
+  const orderedKeys: readonly (keyof CommandInterfaceItem)[] = context.fromXML.forReference
     ? getOrderedCommandInterfaceItemKeysFromXML(item)
-    : ["command", "type", "defaultVisible", "index", "commandGroup", "visible"]
+    : nonReferenceCommandInterfaceItemKeys
 
   const result = {} as CommandInterfaceItem
   for (const key of orderedKeys) {
     const value = values[key]
     if (value !== undefined) {
-      ;(result as Record<string, unknown>)[key] = value
+      ;(result as unknown as Record<keyof CommandInterfaceItem, unknown>)[key] = value
     }
   }
   result.itemType = "CommandInterfaceItem"
@@ -79,6 +79,15 @@ const commandInterfaceItemXmlToModelKeys = {
   DefaultVisible: "defaultVisible",
   Visible: "visible",
 } as const
+
+const nonReferenceCommandInterfaceItemKeys = [
+  "command",
+  "type",
+  "defaultVisible",
+  "index",
+  "commandGroup",
+  "visible",
+] as const satisfies readonly (keyof CommandInterfaceItem)[]
 
 const fallbackCommandInterfaceItemKeys = [
   "command",

--- a/packages/core/metadata/forms/commonObjects/commandInterface/toJSONSchema.test.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/toJSONSchema.test.ts
@@ -21,7 +21,7 @@ describe("exportCommandInterfaceToJSONSchema", () => {
       context: mockContext,
       rule: mockRule,
       value: undefined,
-    }) as ObjectSchema
+    }) as unknown as ObjectSchema
     const itemSchema = schema.properties.ПанельНавигации.items
 
     expect(itemSchema.properties.Автовидимость.const).toBe("Ложь")

--- a/packages/core/metadata/forms/commonObjects/commandInterface/toXML.ts
+++ b/packages/core/metadata/forms/commonObjects/commandInterface/toXML.ts
@@ -70,7 +70,7 @@ const exportCommandInterfaceItemToXML = (
   for (const key of orderedKeys) {
     const value = values[key]
     if (value !== undefined) {
-      ;(result as Record<string, unknown>)[key] = value
+      ;(result as unknown as Record<keyof CommandInterfaceItemXML, unknown>)[key] = value
     }
   }
 

--- a/packages/core/tests/fixtures/forms/base/formField/rules.ts
+++ b/packages/core/tests/fixtures/forms/base/formField/rules.ts
@@ -9,7 +9,7 @@ const baseExtendedTooltip = {
   title: { items: { ru: "Расширенная подсказка" }, formatted: false },
 } as const
 
-export const fullFormFieldCommonFixture = {
+const fullFormFieldCommonFixtureBase = {
   defaultItem: true,
   displayImportance: "High" as const,
   verticalAlign: "Top" as const,
@@ -66,6 +66,11 @@ export const fullFormFieldCommonFixture = {
   },
 }
 
+// AutoCellHeight покрыт отдельными фикстурами; full.xml-референсы его не содержат.
+export const fullFormFieldCommonFixture = fullFormFieldCommonFixtureBase as typeof fullFormFieldCommonFixtureBase & {
+  autoCellHeight: false
+}
+
 export const fullFormFieldTableRelatedFixture = {
   autoCellHeight: false,
   headerHorizontalAlign: "Left" as const,
@@ -74,7 +79,7 @@ export const fullFormFieldTableRelatedFixture = {
   fixingInTable: "None" as const,
 }
 
-export const fullFormFieldEnterpriseCommonFixture = {
+const fullFormFieldEnterpriseCommonFixtureBase = {
   CellHyperlink: true,
   DataPath: "prefix_Реквизит",
   DefaultItem: true,
@@ -143,6 +148,12 @@ export const fullFormFieldEnterpriseCommonFixture = {
   },
 } as const
 
+// AutoCellHeight покрыт отдельными фикстурами; full.xml-референсы его не содержат.
+export const fullFormFieldEnterpriseCommonFixture =
+  fullFormFieldEnterpriseCommonFixtureBase as typeof fullFormFieldEnterpriseCommonFixtureBase & {
+    readonly AutoCellHeight: false
+  }
+
 export const fullFormFieldEnterpriseTableRelatedFixture = {
   AutoCellHeight: false,
   HeaderHorizontalAlign: {
@@ -155,7 +166,7 @@ export const fullFormFieldEnterpriseTableRelatedFixture = {
   },
 } as const
 
-export const fullFormFieldPartialYAMLCommonFixture = {
+const fullFormFieldPartialYAMLCommonFixtureBase = {
   АктивизироватьПоУмолчанию: "Истина",
   ВажностьПриОтображении: "Высокая",
   ВертикальноеПоложение: "Верх",
@@ -195,6 +206,12 @@ export const fullFormFieldPartialYAMLCommonFixture = {
   ШрифтЗаголовка: "ОбычныйШрифтТекста",
   ШрифтПодвала: "ОбычныйШрифтТекста",
 } as const
+
+// AutoCellHeight покрыт отдельными фикстурами; full.xml-референсы его не содержат.
+export const fullFormFieldPartialYAMLCommonFixture =
+  fullFormFieldPartialYAMLCommonFixtureBase as typeof fullFormFieldPartialYAMLCommonFixtureBase & {
+    readonly АвтоВысотаЯчейки: "Ложь"
+  }
 
 export const fullFormFieldTableRelatedPartialYAMLCommonFixture = {
   АвтоВысотаЯчейки: "Ложь",


### PR DESCRIPTION
## Summary
- Исправлена типизация CommandInterface при сохранении порядка ключей XML-референса.
- Уточнены общие фикстуры AutoCellHeight без изменения существующих full.xml-референсов.

## Test plan
- pnpm --filter @nakidka/core type-check
- pnpm --filter @nakidka/core exec vitest run metadata/forms/commonObjects/commandInterface metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts metadata/forms/elements/__tests__/toEnterprise.test.ts
- pnpm --filter nkdk-language langium:generate
- pnpm test