### PR TITLE
Сохранить типизированные Settings формы

### DIFF
--- a/docs/superpowers/plans/2026-05-09-form-attribute-typed-settings.md
+++ b/docs/superpowers/plans/2026-05-09-form-attribute-typed-settings.md
@@ -1,0 +1,848 @@
+# FormAttribute Typed Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve `FormAttribute.Settings` for `Chart` and `SpreadsheetDocument` as raw XML fragments in the model and YAML.
+
+**Architecture:** Add two property types, `Chart` and `SpreadsheetDocument`, that keep only the inner XML of `<Settings>` in the model. `FormAttribute` dispatches XML `Settings` by `xsi:type`, because multiple fields share the same XML tag. YAML uses normal rule keys: `Диаграмма` and `ТабличныйДокумент`, each storing an XML fragment string without the outer `Settings` tag.
+
+**Tech Stack:** TypeScript, Vitest, existing `metadata/orchestration` property registry, `fast-xml-parser` via `importContentFromXML` and `xmlExport`.
+
+---
+
+## File Structure
+
+- Create `packages/core/metadata/forms/commonObjects/settingsFragment/types.ts`: shared helpers for raw inner XML fragments.
+- Create `packages/core/metadata/forms/commonObjects/chart/types.ts`: registers property type `Chart`.
+- Create `packages/core/metadata/forms/commonObjects/spreadsheetDocument/types.ts`: registers property type `SpreadsheetDocument`.
+- Modify `packages/core/metadata/forms/commonObjects/index.ts`: import the two new type modules.
+- Modify `packages/core/metadata/orchestration/property/registry.ts`: add registry entries for `Chart` and `SpreadsheetDocument`.
+- Modify `packages/core/metadata/forms/commonObjects/formAttribute/rules.ts`: add `chart` and `spreadsheetDocument` YAML rules.
+- Modify `packages/core/metadata/forms/commonObjects/formAttribute/types.ts`: add XML and YAML typing.
+- Create `packages/core/metadata/forms/commonObjects/formAttribute/settings.ts`: dispatch XML `Settings` to typed properties and export typed settings back to XML.
+- Modify `packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts`: merge dispatched typed settings into imported `FormAttribute`.
+- Modify `packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts`: export typed settings before the existing `ValueListType` empty-settings logic.
+- Create four fixtures:
+  - `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.xml`
+  - `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.ts`
+  - `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.xml`
+  - `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.ts`
+- Modify formAttribute XML/YAML tests to cover import and export.
+
+---
+
+### Task 1: Add Raw Settings Fragment Types
+
+**Files:**
+- Create: `packages/core/metadata/forms/commonObjects/settingsFragment/types.ts`
+- Create: `packages/core/metadata/forms/commonObjects/chart/types.ts`
+- Create: `packages/core/metadata/forms/commonObjects/spreadsheetDocument/types.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/index.ts`
+- Modify: `packages/core/metadata/orchestration/property/registry.ts`
+
+- [ ] **Step 1: Create the shared fragment helper**
+
+Create `packages/core/metadata/forms/commonObjects/settingsFragment/types.ts`:
+
+```typescript
+import { ConfigurationContext } from "~/metadata/context/types"
+import { PropertyRule, registerTypeRule } from "~/metadata/orchestration"
+import { importContentFromXML } from "~/xml/import/importer"
+import { xmlExport } from "~/xml/export/exporter"
+
+export type SettingsFragment = Record<string, unknown>
+export type SettingsFragmentYAML = string
+export type SettingsFragmentXML = Record<string, unknown>
+
+type SettingsFragmentTypeOptions = {
+  propertyType: "Chart" | "SpreadsheetDocument"
+  canonicalAttributes: Record<string, string>
+  isMatchingXsiType: (xsiType: string) => boolean
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && value !== undefined && typeof value === "object" && !Array.isArray(value)
+
+const stripSettingsAttributes = (xml: Record<string, unknown>): SettingsFragment => {
+  return Object.fromEntries(
+    Object.entries(xml).filter(([key]) => key !== "_xsi:type" && !key.startsWith("_xmlns"))
+  )
+}
+
+const parseFragment = (value: string): SettingsFragment | undefined => {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return {}
+  const parsed = importContentFromXML<{ SettingsFragment?: SettingsFragment }>(
+    `<SettingsFragment>${trimmed}</SettingsFragment>`
+  )
+  return parsed.SettingsFragment ?? {}
+}
+
+const serializeFragment = (value: SettingsFragment | undefined): string | undefined => {
+  if (value === undefined) return undefined
+  return xmlExport(value, false)
+}
+
+export const registerSettingsFragmentType = (options: SettingsFragmentTypeOptions): void => {
+  registerTypeRule(
+    options.propertyType,
+    "importFromXML",
+    (_context: ConfigurationContext, _rule: PropertyRule | undefined, xml: unknown) => {
+      if (!isRecord(xml)) return undefined
+      const xsiType = xml["_xsi:type"]
+      if (typeof xsiType !== "string" || !options.isMatchingXsiType(xsiType)) return undefined
+      return stripSettingsAttributes(xml)
+    }
+  )
+
+  registerTypeRule(
+    options.propertyType,
+    "exportToXML",
+    (_context: ConfigurationContext, _rule: PropertyRule | undefined, value: SettingsFragment | undefined) => {
+      if (!isRecord(value)) return undefined
+      return {
+        ...options.canonicalAttributes,
+        ...value,
+      }
+    }
+  )
+
+  registerTypeRule(
+    options.propertyType,
+    "importFromYAML",
+    (_context: ConfigurationContext, _rule: PropertyRule | undefined, value: unknown) => {
+      if (typeof value !== "string") return undefined
+      return parseFragment(value)
+    }
+  )
+
+  registerTypeRule(
+    options.propertyType,
+    "exportToYAML",
+    (_context: ConfigurationContext, _rule: PropertyRule | undefined, value: SettingsFragment | undefined) => {
+      return serializeFragment(value)
+    }
+  )
+}
+```
+
+- [ ] **Step 2: Add the `Chart` property type**
+
+Create `packages/core/metadata/forms/commonObjects/chart/types.ts`:
+
+```typescript
+import {
+  registerSettingsFragmentType,
+  SettingsFragment,
+  SettingsFragmentXML,
+  SettingsFragmentYAML,
+} from "../settingsFragment/types"
+
+export type Chart = SettingsFragment
+export type ChartXML = SettingsFragmentXML
+export type ChartYAML = SettingsFragmentYAML
+
+registerSettingsFragmentType({
+  propertyType: "Chart",
+  canonicalAttributes: {
+    "_xmlns:d4p1": "http://v8.1c.ru/8.2/data/chart",
+    "_xsi:type": "d4p1:Chart",
+  },
+  isMatchingXsiType: (xsiType) => xsiType === "d4p1:Chart" || xsiType.endsWith(":Chart"),
+})
+```
+
+- [ ] **Step 3: Add the `SpreadsheetDocument` property type**
+
+Create `packages/core/metadata/forms/commonObjects/spreadsheetDocument/types.ts`:
+
+```typescript
+import {
+  registerSettingsFragmentType,
+  SettingsFragment,
+  SettingsFragmentXML,
+  SettingsFragmentYAML,
+} from "../settingsFragment/types"
+
+export type SpreadsheetDocument = SettingsFragment
+export type SpreadsheetDocumentXML = SettingsFragmentXML
+export type SpreadsheetDocumentYAML = SettingsFragmentYAML
+
+registerSettingsFragmentType({
+  propertyType: "SpreadsheetDocument",
+  canonicalAttributes: {
+    "_xmlns:mxl": "http://v8.1c.ru/8.2/data/spreadsheet",
+    "_xsi:type": "mxl:SpreadsheetDocument",
+  },
+  isMatchingXsiType: (xsiType) => xsiType === "mxl:SpreadsheetDocument" || xsiType.endsWith(":SpreadsheetDocument"),
+})
+```
+
+- [ ] **Step 4: Register modules in commonObjects index**
+
+Modify `packages/core/metadata/forms/commonObjects/index.ts` and add these imports near the other common object imports:
+
+```typescript
+import "./chart/types"
+import "./spreadsheetDocument/types"
+```
+
+- [ ] **Step 5: Add property registry entries**
+
+Modify `packages/core/metadata/orchestration/property/registry.ts`.
+
+Add imports near the existing form common object imports:
+
+```typescript
+import { Chart, ChartYAML } from "~/metadata/forms/commonObjects/chart/types"
+import {
+  SpreadsheetDocument,
+  SpreadsheetDocumentYAML,
+} from "~/metadata/forms/commonObjects/spreadsheetDocument/types"
+```
+
+Add entries near `DynamicList`:
+
+```typescript
+  Chart: {
+    item: Chart
+    yaml: ChartYAML
+  }
+
+  SpreadsheetDocument: {
+    item: SpreadsheetDocument
+    yaml: SpreadsheetDocumentYAML
+  }
+```
+
+### Task 2: Wire Typed Settings Into FormAttribute
+
+**Files:**
+- Modify: `packages/core/metadata/forms/commonObjects/formAttribute/rules.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/formAttribute/types.ts`
+- Create: `packages/core/metadata/forms/commonObjects/formAttribute/settings.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts`
+
+- [ ] **Step 1: Add rules for YAML and model fields**
+
+Modify `packages/core/metadata/forms/commonObjects/formAttribute/rules.ts` inside `FormAttributeRules.properties`, after `dynamicList`:
+
+```typescript
+    chart: {
+      type: "Chart",
+      xml: "Settings",
+      yaml: "Диаграмма",
+      fromXML: false,
+      toXML: false,
+    },
+    spreadsheetDocument: {
+      type: "SpreadsheetDocument",
+      xml: "Settings",
+      yaml: "ТабличныйДокумент",
+      fromXML: false,
+      toXML: false,
+    },
+```
+
+The explicit `fromXML: false` and `toXML: false` avoid the generic duplicate-`Settings` collision. XML import/export for these fields is handled by `formAttribute/settings.ts`; YAML still uses these rules.
+
+- [ ] **Step 2: Add FormAttribute types**
+
+Modify `packages/core/metadata/forms/commonObjects/formAttribute/types.ts`.
+
+Add imports:
+
+```typescript
+import { ChartXML, ChartYAML } from "~/metadata/forms/commonObjects/chart/types"
+import {
+  SpreadsheetDocumentXML,
+  SpreadsheetDocumentYAML,
+} from "~/metadata/forms/commonObjects/spreadsheetDocument/types"
+```
+
+Change `FormAttributeXML.Settings`:
+
+```typescript
+  Settings?: SettingsTypeDescriptionXML | DynamicListXML | ChartXML | SpreadsheetDocumentXML
+```
+
+Add YAML keys:
+
+```typescript
+  Диаграмма?: ChartYAML
+  ТабличныйДокумент?: SpreadsheetDocumentYAML
+```
+
+- [ ] **Step 3: Create XML settings dispatcher**
+
+Create `packages/core/metadata/forms/commonObjects/formAttribute/settings.ts`:
+
+```typescript
+import { ConfigurationContextFromXML, ConfigurationContextWithExportToXML } from "~/metadata/context/types"
+import { exportPropertyToXML, importPropertyFromXML } from "~/metadata/orchestration"
+import { FormAttribute, FormAttributeXML } from "./types"
+
+const chartRule = { type: "Chart", xml: "Settings", yaml: "Диаграмма" } as const
+const spreadsheetDocumentRule = {
+  type: "SpreadsheetDocument",
+  xml: "Settings",
+  yaml: "ТабличныйДокумент",
+} as const
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && value !== undefined && typeof value === "object" && !Array.isArray(value)
+
+const getXsiType = (settings: unknown): string | undefined => {
+  if (!isRecord(settings)) return undefined
+  const xsiType = settings["_xsi:type"]
+  return typeof xsiType === "string" ? xsiType : undefined
+}
+
+export const importTypedFormAttributeSettingsFromXML = (
+  context: ConfigurationContextFromXML,
+  settings: FormAttributeXML["Settings"]
+): Pick<FormAttribute, "chart" | "spreadsheetDocument"> => {
+  const xsiType = getXsiType(settings)
+  if (xsiType === undefined) return {}
+
+  if (xsiType === "d4p1:Chart" || xsiType.endsWith(":Chart")) {
+    const chart = importPropertyFromXML({ context, rule: chartRule, value: settings, name: "chart" })
+    return chart === undefined ? {} : { chart }
+  }
+
+  if (xsiType === "mxl:SpreadsheetDocument" || xsiType.endsWith(":SpreadsheetDocument")) {
+    const spreadsheetDocument = importPropertyFromXML({
+      context,
+      rule: spreadsheetDocumentRule,
+      value: settings,
+      name: "spreadsheetDocument",
+    })
+    return spreadsheetDocument === undefined ? {} : { spreadsheetDocument }
+  }
+
+  return {}
+}
+
+export const exportTypedFormAttributeSettingsToXML = (
+  context: ConfigurationContextWithExportToXML,
+  data: FormAttribute
+): FormAttributeXML["Settings"] | undefined => {
+  if (data.chart !== undefined) {
+    return exportPropertyToXML({
+      context,
+      rule: chartRule,
+      value: data.chart,
+      metadataItem: data,
+    })
+  }
+
+  if (data.spreadsheetDocument !== undefined) {
+    return exportPropertyToXML({
+      context,
+      rule: spreadsheetDocumentRule,
+      value: data.spreadsheetDocument,
+      metadataItem: data,
+    })
+  }
+
+  return undefined
+}
+```
+
+- [ ] **Step 4: Merge typed settings during XML import**
+
+Modify `packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts`.
+
+Add import:
+
+```typescript
+import { importTypedFormAttributeSettingsFromXML } from "./settings"
+```
+
+Inside `importFormAttributeFromXML`, after `properties` is created and before `result` is returned, compute:
+
+```typescript
+  const typedSettings = importTypedFormAttributeSettingsFromXML(context, xml.Settings)
+```
+
+In the `forReference` branch, before returning:
+
+```typescript
+    Object.assign(result, typedSettings)
+```
+
+In the normal branch, add typed settings to the result:
+
+```typescript
+  const result: FormAttributeWithAdditionalColumns = {
+    ...properties,
+    ...typedSettings,
+    itemType: FormAttributeRules.itemType,
+    name: xml._name,
+    title: properties.title!,
+    columns,
+  }
+```
+
+- [ ] **Step 5: Export typed settings during XML export**
+
+Modify `packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts`.
+
+Add import:
+
+```typescript
+import { exportTypedFormAttributeSettingsToXML } from "./settings"
+```
+
+In `exportFormAttributeToXML`, after `assignPropertiesWithColumns(result, properties, columnsXML, referenceData)`, insert:
+
+```typescript
+  const typedSettings = exportTypedFormAttributeSettingsToXML(context, data)
+  if (typedSettings !== undefined) {
+    result.Settings = typedSettings
+  }
+```
+
+Then change the existing `ValueListType` guard to avoid wrapping typed settings:
+
+```typescript
+  if (typedSettings === undefined && (data.type?.type.includes("ValueListType") || result.Settings !== undefined)) {
+    result.Settings = {
+      "_xsi:type": "v8:TypeDescription",
+      ...result.Settings,
+    }
+  }
+```
+
+- [ ] **Step 6: Run focused type check**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec tsc --noEmit
+```
+
+Expected: PASS.
+
+---
+
+### Task 3: Add XML Round-Trip Fixtures and Tests
+
+**Files:**
+- Create: `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.xml`
+- Create: `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.ts`
+- Create: `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.xml`
+- Create: `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts`
+
+- [ ] **Step 1: Add `chartSettings.xml`**
+
+Create `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.xml`:
+
+```xml
+<Attribute name="Диаграмма" id="1">
+	<Type>
+		<v8:Type xmlns:d5p1="http://v8.1c.ru/8.2/data/chart">d5p1:Chart</v8:Type>
+	</Type>
+	<Settings xmlns:d4p1="http://v8.1c.ru/8.2/data/chart" xsi:type="d4p1:Chart">
+		<d4p1:seriesCurId>1</d4p1:seriesCurId>
+		<d4p1:pointsCurId>0</d4p1:pointsCurId>
+		<d4p1:realExSeriesData>
+			<d4p1:id>1</d4p1:id>
+			<d4p1:color>auto</d4p1:color>
+			<d4p1:line width="2" gap="false">
+				<v8ui:style xsi:type="v8ui:ChartLineType">Solid</v8ui:style>
+			</d4p1:line>
+			<d4p1:text/>
+		</d4p1:realExSeriesData>
+		<d4p1:valuesAxis/>
+		<d4p1:pointsAxis/>
+	</Settings>
+</Attribute>
+```
+
+- [ ] **Step 2: Add `chartSettings.ts`**
+
+Create `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.ts`:
+
+```typescript
+import type { FormAttributes } from "../types"
+
+export const chartSettings = [
+  {
+    itemType: "FormAttribute",
+    name: "Диаграмма",
+    type: { type: ["Chart"] },
+    title: { items: { ru: "" } },
+    columns: [],
+    chart: {
+      "d4p1:seriesCurId": "1",
+      "d4p1:pointsCurId": "0",
+      "d4p1:realExSeriesData": {
+        "d4p1:id": "1",
+        "d4p1:color": "auto",
+        "d4p1:line": {
+          _width: "2",
+          _gap: "false",
+          "v8ui:style": {
+            "_xsi:type": "v8ui:ChartLineType",
+            "#text": "Solid",
+          },
+        },
+        "d4p1:text": undefined,
+      },
+      "d4p1:valuesAxis": undefined,
+      "d4p1:pointsAxis": undefined,
+    },
+  },
+] satisfies FormAttributes
+```
+
+- [ ] **Step 3: Add `spreadsheetDocumentSettings.xml`**
+
+Create `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.xml`:
+
+```xml
+<Attribute name="Макет" id="1">
+	<Type>
+		<v8:Type xmlns:mxl="http://v8.1c.ru/8.2/data/spreadsheet">mxl:SpreadsheetDocument</v8:Type>
+	</Type>
+	<Settings xmlns:mxl="http://v8.1c.ru/8.2/data/spreadsheet" xsi:type="mxl:SpreadsheetDocument">
+		<mxl:languageSettings>
+			<mxl:currentLanguage/>
+			<mxl:defaultLanguage/>
+		</mxl:languageSettings>
+		<mxl:columns>
+			<mxl:size>3</mxl:size>
+		</mxl:columns>
+		<mxl:rowsItem>
+			<mxl:index>0</mxl:index>
+			<mxl:row>
+				<mxl:empty>true</mxl:empty>
+			</mxl:row>
+		</mxl:rowsItem>
+		<mxl:format>
+			<mxl:width>72</mxl:width>
+		</mxl:format>
+	</Settings>
+</Attribute>
+```
+
+- [ ] **Step 4: Add `spreadsheetDocumentSettings.ts`**
+
+Create `packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.ts`:
+
+```typescript
+import type { FormAttributes } from "../types"
+
+export const spreadsheetDocumentSettings = [
+  {
+    itemType: "FormAttribute",
+    name: "Макет",
+    type: { type: ["SpreadsheetDocument"] },
+    title: { items: { ru: "" } },
+    columns: [],
+    spreadsheetDocument: {
+      "mxl:languageSettings": {
+        "mxl:currentLanguage": undefined,
+        "mxl:defaultLanguage": undefined,
+      },
+      "mxl:columns": {
+        "mxl:size": "3",
+      },
+      "mxl:rowsItem": {
+        "mxl:index": "0",
+        "mxl:row": {
+          "mxl:empty": "true",
+        },
+      },
+      "mxl:format": {
+        "mxl:width": "72",
+      },
+    },
+  },
+] satisfies FormAttributes
+```
+
+- [ ] **Step 5: Add imports in XML tests**
+
+Modify `packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts` and `toXML.test.ts`:
+
+```typescript
+import { chartSettings } from "./__fixtures__/chartSettings"
+import { spreadsheetDocumentSettings } from "./__fixtures__/spreadsheetDocumentSettings"
+```
+
+- [ ] **Step 6: Add failing XML import tests**
+
+In `fromXML.test.ts`, add:
+
+```typescript
+  it("import chartSettings", () => {
+    const result = testImportPropertyFromXML({
+      rule: formAttributesRule,
+      path: "chartSettings.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(chartSettings)
+  })
+
+  it("import spreadsheetDocumentSettings", () => {
+    const result = testImportPropertyFromXML({
+      rule: formAttributesRule,
+      path: "spreadsheetDocumentSettings.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(spreadsheetDocumentSettings)
+  })
+```
+
+- [ ] **Step 7: Run import tests and verify failure before implementation**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts -t "import chartSettings|import spreadsheetDocumentSettings"
+```
+
+Expected before Task 2 implementation: FAIL because `chart` and `spreadsheetDocument` are missing.
+
+- [ ] **Step 8: Add XML export tests**
+
+In `toXML.test.ts`, add:
+
+```typescript
+  it("export chartSettings", () => {
+    const { result, expectedResult } = testExportPropertyToXML({
+      rule: formAttributesRule,
+      value: chartSettings,
+      xmlRootTag: "Attribute",
+      exportXmlDataAsRoot: true,
+      path: "chartSettings.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("export spreadsheetDocumentSettings", () => {
+    const { result, expectedResult } = testExportPropertyToXML({
+      rule: formAttributesRule,
+      value: spreadsheetDocumentSettings,
+      xmlRootTag: "Attribute",
+      exportXmlDataAsRoot: true,
+      path: "spreadsheetDocumentSettings.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+```
+
+- [ ] **Step 9: Run XML tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts -t "chartSettings|spreadsheetDocumentSettings"
+```
+
+Expected after Task 2 implementation: PASS.
+
+---
+
+### Task 4: Add YAML Fragment Tests
+
+**Files:**
+- Modify: `packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.test.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/formAttribute/toYAML.test.ts`
+
+- [ ] **Step 1: Import the fixtures**
+
+In both YAML test files, add:
+
+```typescript
+import { chartSettings } from "./__fixtures__/chartSettings"
+import { spreadsheetDocumentSettings } from "./__fixtures__/spreadsheetDocumentSettings"
+```
+
+- [ ] **Step 2: Add YAML fixture objects inside tests**
+
+Use these constants in both YAML test files:
+
+```typescript
+const chartSettingsYAML = {
+  Диаграмма: {
+    Тип: "Chart",
+    Диаграмма: `<d4p1:seriesCurId>1</d4p1:seriesCurId>
+<d4p1:pointsCurId>0</d4p1:pointsCurId>
+<d4p1:realExSeriesData>
+\t<d4p1:id>1</d4p1:id>
+\t<d4p1:color>auto</d4p1:color>
+\t<d4p1:line width="2" gap="false">
+\t\t<v8ui:style xsi:type="v8ui:ChartLineType">Solid</v8ui:style>
+\t</d4p1:line>
+\t<d4p1:text/>
+</d4p1:realExSeriesData>
+<d4p1:valuesAxis/>
+<d4p1:pointsAxis/>`,
+  },
+}
+
+const spreadsheetDocumentSettingsYAML = {
+  Макет: {
+    Тип: "SpreadsheetDocument",
+    ТабличныйДокумент: `<mxl:languageSettings>
+\t<mxl:currentLanguage/>
+\t<mxl:defaultLanguage/>
+</mxl:languageSettings>
+<mxl:columns>
+\t<mxl:size>3</mxl:size>
+</mxl:columns>
+<mxl:rowsItem>
+\t<mxl:index>0</mxl:index>
+\t<mxl:row>
+\t\t<mxl:empty>true</mxl:empty>
+\t</mxl:row>
+</mxl:rowsItem>
+<mxl:format>
+\t<mxl:width>72</mxl:width>
+</mxl:format>`,
+  },
+}
+```
+
+- [ ] **Step 3: Add YAML import tests**
+
+In `fromYAML.test.ts`, add:
+
+```typescript
+  it("imports chartSettings YAML fragment", () => {
+    const result = importFormAttributesFromYAML(mockContext, mockRule, chartSettingsYAML)
+
+    expect(result).toEqual(chartSettings)
+  })
+
+  it("imports spreadsheetDocumentSettings YAML fragment", () => {
+    const result = importFormAttributesFromYAML(mockContext, mockRule, spreadsheetDocumentSettingsYAML)
+
+    expect(result).toEqual(spreadsheetDocumentSettings)
+  })
+```
+
+- [ ] **Step 4: Add YAML export tests**
+
+In `toYAML.test.ts`, add:
+
+```typescript
+  it("exports chartSettings YAML fragment", () => {
+    const result = exportFormAttributesToYAML(mockContext, mockRule, chartSettings)
+
+    expect(result).toEqual(chartSettingsYAML)
+  })
+
+  it("exports spreadsheetDocumentSettings YAML fragment", () => {
+    const result = exportFormAttributesToYAML(mockContext, mockRule, spreadsheetDocumentSettings)
+
+    expect(result).toEqual(spreadsheetDocumentSettingsYAML)
+  })
+```
+
+- [ ] **Step 5: Run YAML tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.test.ts packages/core/metadata/forms/commonObjects/formAttribute/toYAML.test.ts -t "chartSettings|spreadsheetDocumentSettings"
+```
+
+Expected after implementation: PASS.
+
+---
+
+### Task 5: Verify Existing Settings Behavior
+
+**Files:**
+- Modify only if a regression appears: `packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts`
+
+- [ ] **Step 1: Run existing FormAttribute tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/formAttribute
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run DynamicList tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/forms/commonObjects/dynamicList
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run targeted core type check**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec tsc --noEmit
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/metadata/forms/commonObjects/settingsFragment/types.ts \
+  packages/core/metadata/forms/commonObjects/chart/types.ts \
+  packages/core/metadata/forms/commonObjects/spreadsheetDocument/types.ts \
+  packages/core/metadata/forms/commonObjects/index.ts \
+  packages/core/metadata/orchestration/property/registry.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/rules.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/types.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/settings.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.test.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/toYAML.test.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.xml \
+  packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.ts \
+  packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.xml \
+  packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.ts
+git commit -m "feat: preserve form attribute typed settings"
+```
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- `Chart` type with YAML key `Диаграмма`: Task 1 and Task 2.
+- YAML stores only inner XML, without outer `Settings`: Task 1 and Task 4.
+- XML export uses canonical chart wrapper: Task 1.
+- `SpreadsheetDocument` type with YAML key `ТабличныйДокумент`: Task 1 and Task 2.
+- XML export uses canonical spreadsheet wrapper: Task 1.
+- Existing `valueType` and `dynamicList` semantics stay unchanged: Task 2 and Task 5.
+
+Placeholder scan:
+
+- The plan contains concrete file paths, code, commands, and expected outcomes.
+- No unresolved placeholder sections are left.
+
+Type consistency:
+
+- Property names are `chart` and `spreadsheetDocument`.
+- Property types are `Chart` and `SpreadsheetDocument`.
+- YAML keys are `Диаграмма` and `ТабличныйДокумент`.

--- a/docs/superpowers/specs/2026-05-09-form-round-trip-diffs-1-5-design.md
+++ b/docs/superpowers/specs/2026-05-09-form-round-trip-diffs-1-5-design.md
@@ -1,0 +1,176 @@
+# FormAttribute typed Settings: Chart and SpreadsheetDocument design
+
+Дата: 2026-05-09
+
+## Контекст
+
+Short round-trip по XML-дампу `trade` показал пачку расхождений 1-5. В этой спецификации
+зафиксирована согласованная часть этой пачки: большие типизированные `FormAttribute.Settings`,
+которые сейчас полностью теряются при XML round-trip.
+
+1. `Catalogs/ВариантыАнализаЦелевыхПоказателей/Forms/НастройкаДемоДанных/Ext/Form.xml`
+2. `Catalogs/Номенклатура/Forms/ФормаЭлемента/Ext/Form.xml`
+
+Остальные diff'ы из triage-пачки не входят в текущую реализацию и должны разбираться отдельно.
+
+## Проблема 1: Settings Chart у FormAttribute
+
+### Исходный diff
+
+Файл:
+`Catalogs/ВариантыАнализаЦелевыхПоказателей/Forms/НастройкаДемоДанных/Ext/Form.xml`
+
+После round-trip у реквизита формы с типом `d5p1:Chart` полностью пропадает узел `Settings`
+с настройками диаграммы:
+
+```diff
+ <Attribute name="Диаграмма" id="4">
+   <Type>
+     <v8:Type xmlns:d5p1="http://v8.1c.ru/8.2/data/chart">d5p1:Chart</v8:Type>
+   </Type>
+-  <Settings xmlns:d4p1="http://v8.1c.ru/8.2/data/chart" xsi:type="d4p1:Chart">
+-    <d4p1:seriesCurId>1</d4p1:seriesCurId>
+-    ...
+-    <d4p1:valuesAxis/>
+-    <d4p1:pointsAxis/>
+-  </Settings>
+ </Attribute>
+```
+
+Владеющий модуль:
+`packages/core/metadata/forms/commonObjects/formAttribute`.
+
+### Текущая логика
+
+`FormAttributeRules` использует XML-тег `Settings` для двух свойств:
+
+- `valueType`: `TypeDescription`, экспортируется в `<Settings xsi:type="v8:TypeDescription">`;
+- `dynamicList`: `DynamicList`, экспортируется в `<Settings xsi:type="DynamicList">`.
+
+Настройки диаграммы имеют собственный `xsi:type="d4p1:Chart"` и не являются ни `TypeDescription`,
+ни `DynamicList`. Поэтому import не кладёт их в модель, а export не может восстановить XML-узел.
+
+### Цель
+
+Сохранять `Settings xsi:type="...:Chart"` у `FormAttribute` без потери структуры и порядка XML.
+
+`Chart` является отдельным большим типом. На этом этапе не нужно раскладывать его в доменную модель.
+Нужно сохранить XML-фрагмент в модели как есть, чтобы round-trip возвращал исходный `Settings`
+без изменений.
+
+### Решение
+
+Добавить отдельный тип `Chart` для настроек формы:
+
+- модельное значение хранит внутренности `Settings` как XML-объект, включая имена узлов с префиксами
+  и пустые элементы;
+- import принимает `Settings`, у которого `xsi:type` указывает на chart-тип;
+- export всегда восстанавливает каноническую оболочку
+  `<Settings xmlns:d4p1="http://v8.1c.ru/8.2/data/chart" xsi:type="d4p1:Chart">`
+  и возвращает сохранённые внутренности без преобразования;
+- YAML хранит `Chart` прямо в основном YAML формы как XML-фрагмент строкой, без смыслового
+  преобразования структуры.
+
+В `FormAttribute` должно появиться отдельное свойство `chart`, использующее тот же XML-тег
+`Settings`, но обрабатывающее только chart-typed XML. YAML-ключ свойства: `Диаграмма`.
+Существующая семантика `valueType` и `dynamicList` не меняется:
+
+1. `Settings xsi:type="v8:TypeDescription"` остаётся `valueType`.
+2. `Settings xsi:type="DynamicList"` остаётся `dynamicList`.
+3. `Settings xsi:type="...:Chart"` становится новым `chart`-свойством.
+4. При экспорте без chart в модели новый `Settings` не создаётся.
+
+### YAML
+
+Основной YAML формы хранит содержимое `Chart` в ключе `Диаграмма` как строковый XML-фрагмент без
+внешнего тега `Settings`: только внутренние узлы (`<d4p1:seriesCurId>...</d4p1:seriesCurId>...`).
+Это временное, но явное представление большого объекта, пока для `Chart` нет полноценной доменной
+модели. Импорт из YAML должен разобрать эту строку обратно в XML-объект внутренностей `Settings`,
+а export в XML должен снова обернуть его в канонический chart-`Settings`:
+`xmlns:d4p1="http://v8.1c.ru/8.2/data/chart" xsi:type="d4p1:Chart"`.
+
+Такой подход не использует `externalFile` и не требует обобщения механики внешних файлов.
+
+### Тесты
+
+Нужен focused reproducer в `packages/core/metadata/forms/commonObjects/formAttribute`:
+
+- XML-фикстура `chartSettings.xml`: один `Attribute` с `Type` = `Chart` и полным
+  `Settings xsi:type="...:Chart"` с несколькими характерными узлами, включая вложенные элементы,
+  атрибуты namespace и пустые элементы.
+- TS-фикстура `chartSettings.ts`: ожидаемая модель `FormAttributes`, где `chart` содержит внутренности
+  `Settings` как XML-структуру.
+
+Проверки:
+
+- import читает chart-settings в отдельное свойство модели и не смешивает его с `valueType`;
+- export возвращает `Settings xsi:type="...:Chart"` байт-в-байт для фикстуры;
+- export to YAML кладёт chart-settings в YAML как XML-фрагмент строкой без внешнего тега `Settings`;
+- import from YAML восстанавливает chart-settings из XML-фрагмента строки;
+- XML с `Settings xsi:type="v8:TypeDescription"` продолжает работать как `valueType`;
+- XML с `Settings xsi:type="DynamicList"` продолжает работать как `dynamicList`;
+- без chart-settings export не создаёт новый `Settings`.
+
+### Не входит
+
+- Полная доменная модель `Chart`.
+- Человеческое YAML-представление отдельных свойств диаграммы.
+- Вынесение `Chart` во внешний файл.
+- Изменение поведения пустого `Settings xsi:type="v8:TypeDescription"` для `ValueListType`.
+- Человеческое YAML-представление отдельных свойств `SpreadsheetDocument`.
+
+## Проблема 3: Settings SpreadsheetDocument у FormAttribute
+
+### Исходный diff
+
+Файл:
+`Catalogs/Номенклатура/Forms/ФормаЭлемента/Ext/Form.xml`
+
+После round-trip у реквизита формы с типом `mxl:SpreadsheetDocument` полностью пропадает большой
+узел `Settings` с настройками табличного документа:
+
+```diff
+ <Attribute name="..." id="...">
+   <Type>
+     <v8:Type xmlns:mxl="http://v8.1c.ru/8.2/data/spreadsheet">mxl:SpreadsheetDocument</v8:Type>
+   </Type>
+-  <Settings xmlns:mxl="http://v8.1c.ru/8.2/data/spreadsheet" xsi:type="mxl:SpreadsheetDocument">
+-    <mxl:languageSettings>
+-      ...
+-    </mxl:languageSettings>
+-    ...
+-  </Settings>
+ </Attribute>
+```
+
+Владеющий модуль:
+`packages/core/metadata/forms/commonObjects/formAttribute`.
+
+### Решение
+
+Для `SpreadsheetDocument` используется тот же подход, что и для `Chart`, но с отдельным типом:
+
+- в `FormAttribute` появляется отдельное свойство `spreadsheetDocument`;
+- YAML-ключ: `ТабличныйДокумент`;
+- YAML хранит строкой только внутренние XML-узлы `Settings`, без внешнего тега `Settings`;
+- import из XML принимает `Settings` с `xsi:type="mxl:SpreadsheetDocument"`;
+- export в XML всегда восстанавливает каноническую оболочку
+  `<Settings xmlns:mxl="http://v8.1c.ru/8.2/data/spreadsheet" xsi:type="mxl:SpreadsheetDocument">`
+  и возвращает сохранённые внутренности без преобразования.
+
+### Тесты
+
+Нужен focused reproducer в `packages/core/metadata/forms/commonObjects/formAttribute`:
+
+- XML-фикстура `spreadsheetDocumentSettings.xml`: один `Attribute` с `Type` =
+  `SpreadsheetDocument` и характерными внутренними узлами `Settings`.
+- TS-фикстура `spreadsheetDocumentSettings.ts`: ожидаемая модель `FormAttributes`, где
+  `spreadsheetDocument` содержит внутренности `Settings` как XML-структуру.
+
+Проверки аналогичны `Chart`:
+
+- import читает spreadsheet-settings в отдельное свойство модели и не смешивает его с `valueType`;
+- export возвращает `Settings xsi:type="mxl:SpreadsheetDocument"` для фикстуры;
+- export to YAML кладёт spreadsheet-settings в YAML как XML-фрагмент строкой без внешнего тега
+  `Settings`;
+- import from YAML восстанавливает spreadsheet-settings из XML-фрагмента строки.

--- a/packages/core/metadata/forms/commonObjects/chart/types.ts
+++ b/packages/core/metadata/forms/commonObjects/chart/types.ts
@@ -1,0 +1,19 @@
+import { registerSettingsFragmentType } from "~/metadata/forms/commonObjects/settingsFragment/types"
+import type {
+  SettingsFragment,
+  SettingsFragmentXML,
+  SettingsFragmentYAML,
+} from "~/metadata/forms/commonObjects/settingsFragment/types"
+
+export type Chart = SettingsFragment
+export type ChartXML = SettingsFragmentXML
+export type ChartYAML = SettingsFragmentYAML
+
+registerSettingsFragmentType<Chart>({
+  propertyType: "Chart",
+  canonicalAttributes: {
+    "_xmlns:d4p1": "http://v8.1c.ru/8.2/data/chart",
+    "_xsi:type": "d4p1:Chart",
+  },
+  matchXsiType: (xsiType) => xsiType === "d4p1:Chart" || xsiType.endsWith(":Chart"),
+})

--- a/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.ts
@@ -1,0 +1,30 @@
+import type { FormAttributes } from "../types"
+
+export const chartSettings = [
+  {
+    itemType: "FormAttribute",
+    name: "Диаграмма",
+    type: { type: ["Chart"] },
+    title: { items: { ru: "" } },
+    columns: [],
+    chart: {
+      "d4p1:seriesCurId": "1",
+      "d4p1:pointsCurId": "0",
+      "d4p1:realExSeriesData": {
+        "d4p1:id": "1",
+        "d4p1:color": "auto",
+        "d4p1:line": {
+          _width: "2",
+          _gap: "false",
+          "v8ui:style": {
+            "_xsi:type": "v8ui:ChartLineType",
+            "#text": "Solid",
+          },
+        },
+        "d4p1:text": undefined,
+      },
+      "d4p1:valuesAxis": undefined,
+      "d4p1:pointsAxis": undefined,
+    },
+  },
+] satisfies FormAttributes

--- a/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.xml
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/chartSettings.xml
@@ -1,0 +1,19 @@
+<Attribute name="Диаграмма" id="1">
+	<Type>
+		<v8:Type xmlns:d5p1="http://v8.1c.ru/8.2/data/chart">d5p1:Chart</v8:Type>
+	</Type>
+	<Settings xmlns:d4p1="http://v8.1c.ru/8.2/data/chart" xsi:type="d4p1:Chart">
+		<d4p1:seriesCurId>1</d4p1:seriesCurId>
+		<d4p1:pointsCurId>0</d4p1:pointsCurId>
+		<d4p1:realExSeriesData>
+			<d4p1:id>1</d4p1:id>
+			<d4p1:color>auto</d4p1:color>
+			<d4p1:line width="2" gap="false">
+				<v8ui:style xsi:type="v8ui:ChartLineType">Solid</v8ui:style>
+			</d4p1:line>
+			<d4p1:text/>
+		</d4p1:realExSeriesData>
+		<d4p1:valuesAxis/>
+		<d4p1:pointsAxis/>
+	</Settings>
+</Attribute>

--- a/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.ts
@@ -1,0 +1,29 @@
+import type { FormAttributes } from "../types"
+
+export const spreadsheetDocumentSettings = [
+  {
+    itemType: "FormAttribute",
+    name: "Макет",
+    type: { type: ["SpreadsheetDocument"] },
+    title: { items: { ru: "" } },
+    columns: [],
+    spreadsheetDocument: {
+      "mxl:languageSettings": {
+        "mxl:currentLanguage": undefined,
+        "mxl:defaultLanguage": undefined,
+      },
+      "mxl:columns": {
+        "mxl:size": "3",
+      },
+      "mxl:rowsItem": {
+        "mxl:index": "0",
+        "mxl:row": {
+          "mxl:empty": "true",
+        },
+      },
+      "mxl:format": {
+        "mxl:width": "72",
+      },
+    },
+  },
+] satisfies FormAttributes

--- a/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.xml
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/__fixtures__/spreadsheetDocumentSettings.xml
@@ -1,0 +1,23 @@
+<Attribute name="Макет" id="1">
+	<Type>
+		<v8:Type xmlns:mxl="http://v8.1c.ru/8.2/data/spreadsheet">mxl:SpreadsheetDocument</v8:Type>
+	</Type>
+	<Settings xmlns:mxl="http://v8.1c.ru/8.2/data/spreadsheet" xsi:type="mxl:SpreadsheetDocument">
+		<mxl:languageSettings>
+			<mxl:currentLanguage/>
+			<mxl:defaultLanguage/>
+		</mxl:languageSettings>
+		<mxl:columns>
+			<mxl:size>3</mxl:size>
+		</mxl:columns>
+		<mxl:rowsItem>
+			<mxl:index>0</mxl:index>
+			<mxl:row>
+				<mxl:empty>true</mxl:empty>
+			</mxl:row>
+		</mxl:rowsItem>
+		<mxl:format>
+			<mxl:width>72</mxl:width>
+		</mxl:format>
+	</Settings>
+</Attribute>

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts
@@ -14,8 +14,10 @@ import { mockContextFromXML, mockRule } from "~/tests/mockContext"
 import { testImportPropertyFromXML } from "~/tests/property/importPropertyFromXML"
 import { readAndParseXMLFile } from "~/tests/readAndParseXMLFile"
 import { attributeAnyType } from "./__fixtures__/attributeAnyType"
+import { chartSettings } from "./__fixtures__/chartSettings"
 import { columnAnyType } from "./__fixtures__/columnAnyType"
 import { mixedColumns } from "./__fixtures__/mixedColumns"
+import { spreadsheetDocumentSettings } from "./__fixtures__/spreadsheetDocumentSettings"
 import { tableWithColumns } from "./__fixtures__/tableWithColumns"
 import { treeWithColumn } from "./__fixtures__/treeWithColumn"
 import { twoTables } from "./__fixtures__/twoTables"
@@ -168,6 +170,26 @@ describe("importFormAttributesFromXML", () => {
     })
 
     expect(result).toEqual(columnAnyType)
+  })
+
+  it("import chartSettings", () => {
+    const result = testImportPropertyFromXML({
+      rule: formAttributesRule,
+      path: "chartSettings.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(chartSettings)
+  })
+
+  it("import spreadsheetDocumentSettings", () => {
+    const result = testImportPropertyFromXML({
+      rule: formAttributesRule,
+      path: "spreadsheetDocumentSettings.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(spreadsheetDocumentSettings)
   })
 
   // it("should throw error when ConditionalAppearance is present in XML", () => {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.ts
@@ -2,6 +2,7 @@ import { ConfigurationContextFromXML } from "~/metadata/context/types"
 import { PropertyRule } from "~/metadata/forms/elements/calendarField/rules"
 import { importMetadataItemFromXML, registerTypeRule } from "~/metadata/orchestration"
 import { FormAttributeColumnRules, FormAttributeRules } from "./rules"
+import { importTypedFormAttributeSettingsFromXML } from "./settings"
 import {
   FormAttribute,
   FormAttributeAdditionalColumns,
@@ -58,6 +59,7 @@ const importFormAttributeFromXML = (context: ConfigurationContextFromXML, xml: F
 
   const columns = importColumnsFromXML(context, xml.Columns?.Column)
   const additionalColumns = importAdditionalColumnsFromXML(context, xml.Columns?.AdditionalColumns)
+  const typedSettings = importTypedFormAttributeSettingsFromXML(context, xml.Settings)
   const {
     columns: _importedColumns,
     additionalColumns: _importedAdditionalColumns,
@@ -88,12 +90,14 @@ const importFormAttributeFromXML = (context: ConfigurationContextFromXML, xml: F
     if (result.columns === undefined) result.columns = columns
     if (result.additionalColumns === undefined && additionalColumns.length > 0)
       result.additionalColumns = additionalColumns
+    Object.assign(result, typedSettings)
 
     return result as FormAttribute
   }
 
   const result: FormAttributeWithAdditionalColumns = {
     ...properties,
+    ...typedSettings,
     itemType: FormAttributeRules.itemType,
     name: xml._name,
     title: properties.title!,

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.test.ts
@@ -24,7 +24,51 @@ import {
   withFunctionalOptionsFormAttributeYAML,
 } from "~/tests/fixtures/formAttributes/data"
 import { mockContext, mockRule } from "~/tests/mockContext"
+import { chartSettings } from "./__fixtures__/chartSettings"
+import { spreadsheetDocumentSettings } from "./__fixtures__/spreadsheetDocumentSettings"
 import { importFormAttributesFromYAML } from "./fromYAML"
+
+const chartSettingsYAML = {
+  Диаграмма: {
+    Тип: "Диаграмма",
+    Заголовок: "",
+    Диаграмма: `<d4p1:seriesCurId>1</d4p1:seriesCurId>
+<d4p1:pointsCurId>0</d4p1:pointsCurId>
+<d4p1:realExSeriesData>
+	<d4p1:id>1</d4p1:id>
+	<d4p1:color>auto</d4p1:color>
+	<d4p1:line width="2" gap="false">
+		<v8ui:style xsi:type="v8ui:ChartLineType">Solid</v8ui:style>
+	</d4p1:line>
+	<d4p1:text/>
+</d4p1:realExSeriesData>
+<d4p1:valuesAxis/>
+<d4p1:pointsAxis/>`,
+  },
+}
+
+const spreadsheetDocumentSettingsYAML = {
+  Макет: {
+    Тип: "ТабличныйДокумент",
+    Заголовок: "",
+    ТабличныйДокумент: `<mxl:languageSettings>
+	<mxl:currentLanguage/>
+	<mxl:defaultLanguage/>
+</mxl:languageSettings>
+<mxl:columns>
+	<mxl:size>3</mxl:size>
+</mxl:columns>
+<mxl:rowsItem>
+	<mxl:index>0</mxl:index>
+	<mxl:row>
+		<mxl:empty>true</mxl:empty>
+	</mxl:row>
+</mxl:rowsItem>
+<mxl:format>
+	<mxl:width>72</mxl:width>
+</mxl:format>`,
+  },
+}
 
 describe("importFormAttributesFromYAML", () => {
   it("should return undefined when data is undefined", () => {
@@ -102,5 +146,17 @@ describe("importFormAttributesFromYAML", () => {
     const result = importFormAttributesFromYAML(mockContext, mockRule, mixedColumnsFormAttributeYAML)
 
     expect(result).toEqual(mixedColumnsFormAttribute)
+  })
+
+  it("should import chartSettings", () => {
+    const result = importFormAttributesFromYAML(mockContext, mockRule, chartSettingsYAML)
+
+    expect(result).toEqual(chartSettings)
+  })
+
+  it("should import spreadsheetDocumentSettings", () => {
+    const result = importFormAttributesFromYAML(mockContext, mockRule, spreadsheetDocumentSettingsYAML)
+
+    expect(result).toEqual(spreadsheetDocumentSettings)
   })
 })

--- a/packages/core/metadata/forms/commonObjects/formAttribute/rules.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/rules.ts
@@ -108,6 +108,20 @@ export const FormAttributeRules = {
       xml: "Settings",
       yaml: "ДинамическийСписок",
     },
+    chart: {
+      type: "Chart",
+      xml: "Settings",
+      yaml: "Диаграмма",
+      fromXML: false,
+      toXML: false,
+    },
+    spreadsheetDocument: {
+      type: "SpreadsheetDocument",
+      xml: "Settings",
+      yaml: "ТабличныйДокумент",
+      fromXML: false,
+      toXML: false,
+    },
   },
 } as const satisfies MetadataItemRule
 

--- a/packages/core/metadata/forms/commonObjects/formAttribute/settings.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/settings.ts
@@ -1,0 +1,78 @@
+import { ConfigurationContextFromXML, ConfigurationContextWithExportToXML } from "~/metadata/context/types"
+import { importPropertyFromXML } from "~/metadata/orchestration/property/fromXML"
+import { exportPropertyToXML } from "~/metadata/orchestration/property/toXML"
+import { PropertyRule } from "~/metadata/orchestration/property/types"
+import { FormAttribute, FormAttributeXML } from "./types"
+
+const chartSettingsRule = {
+  type: "Chart",
+  xml: "Settings",
+  yaml: "Диаграмма",
+} as const satisfies PropertyRule
+
+const spreadsheetDocumentSettingsRule = {
+  type: "SpreadsheetDocument",
+  xml: "Settings",
+  yaml: "ТабличныйДокумент",
+} as const satisfies PropertyRule
+
+type TypedFormAttributeSettings = Pick<FormAttribute, "chart" | "spreadsheetDocument">
+
+const getXsiType = (settings: FormAttributeXML["Settings"] | undefined): string | undefined => {
+  if (settings === undefined || settings === null || typeof settings !== "object" || Array.isArray(settings)) {
+    return undefined
+  }
+
+  const xsiType = settings["_xsi:type"]
+  return typeof xsiType === "string" ? xsiType : undefined
+}
+
+export const importTypedFormAttributeSettingsFromXML = (
+  context: ConfigurationContextFromXML,
+  settings: FormAttributeXML["Settings"] | undefined
+): TypedFormAttributeSettings => {
+  const xsiType = getXsiType(settings)
+
+  if (xsiType === "d4p1:Chart" || xsiType?.endsWith(":Chart")) {
+    const chart = importPropertyFromXML({
+      context,
+      rule: chartSettingsRule,
+      value: settings,
+      name: "chart",
+    }) as FormAttribute["chart"] | undefined
+
+    return chart === undefined ? {} : { chart }
+  }
+
+  if (xsiType === "mxl:SpreadsheetDocument" || xsiType?.endsWith(":SpreadsheetDocument")) {
+    const spreadsheetDocument = importPropertyFromXML({
+      context,
+      rule: spreadsheetDocumentSettingsRule,
+      value: settings,
+      name: "spreadsheetDocument",
+    }) as FormAttribute["spreadsheetDocument"] | undefined
+
+    return spreadsheetDocument === undefined ? {} : { spreadsheetDocument }
+  }
+
+  return {}
+}
+
+export const exportTypedFormAttributeSettingsToXML = (
+  context: ConfigurationContextWithExportToXML,
+  data: TypedFormAttributeSettings
+): FormAttributeXML["Settings"] | undefined => {
+  const chart = exportPropertyToXML({
+    context,
+    rule: chartSettingsRule,
+    value: data.chart,
+  }) as FormAttributeXML["Settings"] | undefined
+
+  if (chart !== undefined) return chart
+
+  return exportPropertyToXML({
+    context,
+    rule: spreadsheetDocumentSettingsRule,
+    value: data.spreadsheetDocument,
+  }) as FormAttributeXML["Settings"] | undefined
+}

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts
@@ -16,8 +16,10 @@ import { readXMLFileAsString } from "~/tests/readAndParseXMLFile"
 import { xmlExport } from "~/xml/export/exporter"
 import { setIdsToElements } from "../../clientApplicationForm/toXML"
 import { attributeAnyType } from "./__fixtures__/attributeAnyType"
+import { chartSettings } from "./__fixtures__/chartSettings"
 import { columnAnyType } from "./__fixtures__/columnAnyType"
 import { mixedColumns } from "./__fixtures__/mixedColumns"
+import { spreadsheetDocumentSettings } from "./__fixtures__/spreadsheetDocumentSettings"
 import { tableWithColumns } from "./__fixtures__/tableWithColumns"
 import { titleColumnsType } from "./__fixtures__/titleColumnsType"
 import { treeWithColumn } from "./__fixtures__/treeWithColumn"
@@ -244,6 +246,32 @@ describe("exportFormAttributesToXML", () => {
       xmlRootTag: "Attribute",
       exportXmlDataAsRoot: true,
       path: "columnAnyType.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("export chartSettings", () => {
+    const { result, expectedResult } = testExportPropertyToXML({
+      rule: formAttributesRule,
+      value: chartSettings,
+      xmlRootTag: "Attribute",
+      exportXmlDataAsRoot: true,
+      path: "chartSettings.xml",
+      importMetaUrl: import.meta.url,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it("export spreadsheetDocumentSettings", () => {
+    const { result, expectedResult } = testExportPropertyToXML({
+      rule: formAttributesRule,
+      value: spreadsheetDocumentSettings,
+      xmlRootTag: "Attribute",
+      exportXmlDataAsRoot: true,
+      path: "spreadsheetDocumentSettings.xml",
       importMetaUrl: import.meta.url,
     })
 

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
@@ -3,6 +3,7 @@ import { ConfigurationContextWithExportToXML } from "~/metadata/context/types"
 import { PropertyRule } from "~/metadata/forms/elements/calendarField/rules"
 import { ElementXML, exportPropertiesToXML, registerTypeRule } from "~/metadata/orchestration"
 import { FormAttributeColumnRules, FormAttributeRules } from "./rules"
+import { exportTypedFormAttributeSettingsToXML } from "./settings"
 import {
   FormAttribute,
   FormAttributeAdditionalColumns,
@@ -85,7 +86,12 @@ const exportFormAttributeToXML = (
 
   assignPropertiesWithColumns(result, properties, columnsXML, referenceData)
 
-  if (data.type?.type.includes("ValueListType") || result.Settings !== undefined) {
+  const typedSettings = exportTypedFormAttributeSettingsToXML(context, data)
+  if (typedSettings !== undefined) {
+    result.Settings = typedSettings
+  }
+
+  if (typedSettings === undefined && (data.type?.type.includes("ValueListType") || result.Settings !== undefined)) {
     result.Settings = {
       "_xsi:type": "v8:TypeDescription",
       ...result.Settings,

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toYAML.test.ts
@@ -21,9 +21,53 @@ import {
   withFunctionalOptionsFormAttributeYAML,
 } from "~/tests/fixtures/formAttributes/data"
 import { mockContext, mockRule } from "~/tests/mockContext"
+import { chartSettings } from "./__fixtures__/chartSettings"
+import { spreadsheetDocumentSettings } from "./__fixtures__/spreadsheetDocumentSettings"
 import { exportFormAttributesToYAML } from "./toYAML"
 
 let context: ConfigurationContext
+
+const chartSettingsYAML = {
+  Диаграмма: {
+    Тип: "Диаграмма",
+    Заголовок: "",
+    Диаграмма: `<d4p1:seriesCurId>1</d4p1:seriesCurId>
+<d4p1:pointsCurId>0</d4p1:pointsCurId>
+<d4p1:realExSeriesData>
+	<d4p1:id>1</d4p1:id>
+	<d4p1:color>auto</d4p1:color>
+	<d4p1:line width="2" gap="false">
+		<v8ui:style xsi:type="v8ui:ChartLineType">Solid</v8ui:style>
+	</d4p1:line>
+	<d4p1:text/>
+</d4p1:realExSeriesData>
+<d4p1:valuesAxis/>
+<d4p1:pointsAxis/>`,
+  },
+}
+
+const spreadsheetDocumentSettingsYAML = {
+  Макет: {
+    Тип: "ТабличныйДокумент",
+    Заголовок: "",
+    ТабличныйДокумент: `<mxl:languageSettings>
+	<mxl:currentLanguage/>
+	<mxl:defaultLanguage/>
+</mxl:languageSettings>
+<mxl:columns>
+	<mxl:size>3</mxl:size>
+</mxl:columns>
+<mxl:rowsItem>
+	<mxl:index>0</mxl:index>
+	<mxl:row>
+		<mxl:empty>true</mxl:empty>
+	</mxl:row>
+</mxl:rowsItem>
+<mxl:format>
+	<mxl:width>72</mxl:width>
+</mxl:format>`,
+  },
+}
 
 describe("exportFormAttributesToYAML", () => {
   beforeEach(() => {
@@ -103,5 +147,17 @@ describe("exportFormAttributesToYAML", () => {
     const result = exportFormAttributesToYAML(context, mockRule, mixedColumnsFormAttribute)
 
     expect(result).toEqual(mixedColumnsFormAttributeYAML)
+  })
+
+  it("should export chartSettings", () => {
+    const result = exportFormAttributesToYAML(context, mockRule, chartSettings)
+
+    expect(result).toEqual(chartSettingsYAML)
+  })
+
+  it("should export spreadsheetDocumentSettings", () => {
+    const result = exportFormAttributesToYAML(context, mockRule, spreadsheetDocumentSettings)
+
+    expect(result).toEqual(spreadsheetDocumentSettingsYAML)
   })
 })

--- a/packages/core/metadata/forms/commonObjects/formAttribute/types.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/types.ts
@@ -9,7 +9,12 @@ import {
   UserViewKeysYAML,
   UserViewYAML,
 } from "~/metadata/commonObjects/userVisible/types"
+import { ChartXML, ChartYAML } from "~/metadata/forms/commonObjects/chart/types"
 import { DynamicListXML, DynamicListYAML } from "~/metadata/forms/commonObjects/dynamicList/types"
+import {
+  SpreadsheetDocumentXML,
+  SpreadsheetDocumentYAML,
+} from "~/metadata/forms/commonObjects/spreadsheetDocument/types"
 import { ElementXML } from "~/metadata/orchestration"
 import { FormTypeByRule } from "~/metadata/orchestration/metadataItem/element"
 import { FillCheckingYAML } from "~/metadata/systemEnumerations/types"
@@ -52,7 +57,7 @@ export interface FormAttributeColumnsXML {
 
 export interface FormAttributeXML extends ElementXML {
   Columns?: FormAttributeColumnsXML
-  Settings?: SettingsTypeDescriptionXML | DynamicListXML
+  Settings?: SettingsTypeDescriptionXML | DynamicListXML | ChartXML | SpreadsheetDocumentXML
 }
 
 export interface ConditionalAppearanceXML {
@@ -84,6 +89,8 @@ export interface FormAttributeYAML {
   ОсновнойРеквизит?: StringboolYAML
   СохраняемыеДанные?: StringboolYAML
   ДинамическийСписок?: DynamicListYAML
+  Диаграмма?: ChartYAML
+  ТабличныйДокумент?: SpreadsheetDocumentYAML
   [UserViewKeysYAML.Allow]?: UserViewYAML
   [UserViewKeysYAML.Deny]?: UserViewYAML
   [UserEditKeysYAML.Allow]?: UserEditYAML

--- a/packages/core/metadata/forms/commonObjects/index.ts
+++ b/packages/core/metadata/forms/commonObjects/index.ts
@@ -56,5 +56,7 @@ import "./event/toXML"
 import "./event/toYAML"
 
 import "./dynamicList/types"
+import "./chart/types"
+import "./spreadsheetDocument/types"
 
 import "./elementId/toXML"

--- a/packages/core/metadata/forms/commonObjects/settingsFragment/types.ts
+++ b/packages/core/metadata/forms/commonObjects/settingsFragment/types.ts
@@ -1,0 +1,99 @@
+import { registerTypeRule } from "~/metadata/orchestration"
+import type { PropertyRuleType } from "~/metadata/orchestration/property/registry"
+import { importContentFromXML } from "~/xml/import/importer"
+import { xmlExport } from "~/xml/export/exporter"
+
+export type SettingsFragment = Record<string, unknown>
+export type SettingsFragmentXML = SettingsFragment & {
+  "_xsi:type"?: string
+  [attribute: `_xmlns${string}`]: string | undefined
+}
+export type SettingsFragmentYAML = string
+
+type SettingsFragmentTypeRegistration = {
+  propertyType: PropertyRuleType
+  canonicalAttributes: SettingsFragmentXML
+  matchXsiType: (xsiType: string) => boolean
+}
+
+const isSettingsFragmentXML = (value: unknown): value is SettingsFragmentXML =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+
+const omitSettingsAttributes = (xml: SettingsFragmentXML): SettingsFragment => {
+  const result: SettingsFragment = {}
+
+  for (const [key, value] of Object.entries(xml)) {
+    if (key === "_xsi:type" || key.startsWith("_xmlns")) continue
+    if (key === "#text" && typeof value === "string" && value.trim().length === 0) continue
+    result[key] = normalizeImportedFragment(value)
+  }
+
+  return result
+}
+
+const normalizeImportedFragment = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(normalizeImportedFragment)
+
+  if (isSettingsFragmentXML(value)) {
+    const result: SettingsFragment = {}
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (key === "#text" && typeof nestedValue === "string" && nestedValue.trim().length === 0) continue
+      result[key] = normalizeImportedFragment(nestedValue)
+    }
+
+    return result
+  }
+
+  return value
+}
+
+const expandEmptyElements = (value: unknown): unknown => {
+  if (value === undefined) return {}
+  if (Array.isArray(value)) return value.map(expandEmptyElements)
+
+  if (isSettingsFragmentXML(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, nestedValue]) => [key, expandEmptyElements(nestedValue)]))
+  }
+
+  return value
+}
+
+export const registerSettingsFragmentType = <TModel extends SettingsFragment>({
+  propertyType,
+  canonicalAttributes,
+  matchXsiType,
+}: SettingsFragmentTypeRegistration): void => {
+  registerTypeRule(propertyType, "importFromXML", (_context, _rule, xml) => {
+    if (!isSettingsFragmentXML(xml)) return undefined
+
+    const xsiType = xml["_xsi:type"]
+    if (typeof xsiType !== "string" || !matchXsiType(xsiType)) return undefined
+
+    return omitSettingsAttributes(xml) as TModel
+  })
+
+  registerTypeRule(propertyType, "exportToXML", (_context, _rule, value: TModel | undefined) => {
+    if (value === undefined) return undefined
+    return {
+      ...canonicalAttributes,
+      ...(expandEmptyElements(value) as SettingsFragment),
+    }
+  })
+
+  registerTypeRule(propertyType, "importFromYAML", (_context, _rule, value) => {
+    if (typeof value !== "string") return undefined
+    const fragment = value.trim()
+    if (fragment.length === 0) return {} as TModel
+
+    const parsed = importContentFromXML<{ SettingsFragment?: SettingsFragment }>(
+      `<SettingsFragment>${fragment}</SettingsFragment>`
+    )
+    return normalizeImportedFragment(parsed.SettingsFragment) as TModel | undefined
+  })
+
+  registerTypeRule(propertyType, "exportToYAML", (_context, _rule, value: TModel | undefined) => {
+    if (value === undefined) return undefined
+    return xmlExport(expandEmptyElements(value) as SettingsFragment, false)
+  })
+}

--- a/packages/core/metadata/forms/commonObjects/spreadsheetDocument/types.ts
+++ b/packages/core/metadata/forms/commonObjects/spreadsheetDocument/types.ts
@@ -1,0 +1,19 @@
+import { registerSettingsFragmentType } from "~/metadata/forms/commonObjects/settingsFragment/types"
+import type {
+  SettingsFragment,
+  SettingsFragmentXML,
+  SettingsFragmentYAML,
+} from "~/metadata/forms/commonObjects/settingsFragment/types"
+
+export type SpreadsheetDocument = SettingsFragment
+export type SpreadsheetDocumentXML = SettingsFragmentXML
+export type SpreadsheetDocumentYAML = SettingsFragmentYAML
+
+registerSettingsFragmentType<SpreadsheetDocument>({
+  propertyType: "SpreadsheetDocument",
+  canonicalAttributes: {
+    "_xmlns:mxl": "http://v8.1c.ru/8.2/data/spreadsheet",
+    "_xsi:type": "mxl:SpreadsheetDocument",
+  },
+  matchXsiType: (xsiType) => xsiType === "mxl:SpreadsheetDocument" || xsiType.endsWith(":SpreadsheetDocument"),
+})

--- a/packages/core/metadata/orchestration/property/registry.ts
+++ b/packages/core/metadata/orchestration/property/registry.ts
@@ -204,6 +204,7 @@ import { CommandInterface, CommandInterfaceYAML } from "~/metadata/forms/commonO
 import { CommandSet, CommandSetYAML } from "~/metadata/forms/commonObjects/commandSet/types"
 import { DataPath } from "~/metadata/forms/commonObjects/dataPath/types"
 import { DynamicList, DynamicListYAML } from "~/metadata/forms/commonObjects/dynamicList/types"
+import { Chart, ChartYAML } from "~/metadata/forms/commonObjects/chart/types"
 import {
   FormAttributeAdditionalColumnYAML,
   FormAttributeAdditionalColumnsCollection,
@@ -215,6 +216,10 @@ import {
 import { FormCommands, FormCommandsYAML } from "~/metadata/forms/commonObjects/formCommand/types"
 import { FormParameters, FormParametersYAML } from "~/metadata/forms/commonObjects/formParameter/types"
 import { ScrollBarUseEnterprise } from "~/metadata/forms/commonObjects/scrollBarUse/types"
+import {
+  SpreadsheetDocument,
+  SpreadsheetDocumentYAML,
+} from "~/metadata/forms/commonObjects/spreadsheetDocument/types"
 import { AutoCommandBar, AutoCommandBarYAML } from "~/metadata/forms/elements/autoCommandBar/types"
 import { ContextMenu, ContextMenuYAML } from "~/metadata/forms/elements/contextMenu/types"
 import { ExtendedTooltip, ExtendedTooltipYAML } from "~/metadata/forms/elements/extendedTooltip/types"
@@ -547,6 +552,16 @@ export type PropertyTypeRegistry = {
     yaml: DynamicListYAML
   }
 
+  Chart: {
+    item: Chart
+    yaml: ChartYAML
+  }
+
+  SpreadsheetDocument: {
+    item: SpreadsheetDocument
+    yaml: SpreadsheetDocumentYAML
+  }
+
   CommandSet: {
     item: CommandSet
     yaml: CommandSetYAML
@@ -868,6 +883,8 @@ export const PropertyRuleTypeKeys = Object.keys({
   AutoCommandBar: "AutoCommandBar",
   TableAutoCommandBar: "TableAutoCommandBar",
   DynamicList: "DynamicList",
+  Chart: "Chart",
+  SpreadsheetDocument: "SpreadsheetDocument",
   CommandSet: "CommandSet",
   FormCommands: "FormCommands",
   FormAttributes: "FormAttributes",


### PR DESCRIPTION
Summary:
- добавить pass-through типы Chart и SpreadsheetDocument для FormAttribute.Settings
- хранить внутренности Settings в YAML как XML-фрагмент
- добавить XML/YAML тесты для Chart и SpreadsheetDocument

Tests:
- pnpm --filter '@nakidka/core' exec tsc --noEmit
- pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/formAttribute
- pnpm --filter '@nakidka/core' exec vitest run metadata/forms/commonObjects/dynamicList
- pnpm test
- round-trip.sh --triage --batch-size 5