### PR TITLE
fix: сохранить свойства элементов формы в round-trip

### DIFF
--- a/docs/superpowers/plans/2026-05-09-form-elements-page-search-string.md
+++ b/docs/superpowers/plans/2026-05-09-form-elements-page-search-string.md
@@ -1,0 +1,312 @@
+# Form Elements Page And SearchStringAddition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve `Page.ChildItemsWidth` and `SearchStringAddition` width limit properties through XML and YAML round-trips.
+
+**Architecture:** Keep the changes declarative in existing `rules.ts` files. Update the centralized form-elements fixtures so XML, YAML, model, and enterprise expectations stay synchronized.
+
+**Tech Stack:** TypeScript, Vitest, existing metadata orchestration rules, centralized `packages/core/metadata/forms/elements/__tests__` fixture runner.
+
+---
+
+## File Structure
+
+- Modify `packages/core/metadata/forms/elements/page/rules.ts`: add XML mapping for existing `slaveItemsWidth`.
+- Modify `packages/core/metadata/forms/elements/page/__fixtures__/full.xml`: add `ChildItemsWidth`.
+- Modify `packages/core/metadata/forms/elements/page/__fixtures__/data.ts`: add model, YAML, and enterprise expectations for `slaveItemsWidth`.
+- Modify `packages/core/metadata/forms/elements/searchStringAddition/rules.ts`: add `autoMaxWidth` and `maxWidth`.
+- Modify `packages/core/metadata/forms/elements/searchStringAddition/types.ts`: add YAML fields for the two new properties.
+- Modify `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml`: add XML nodes for the two new properties.
+- Modify `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml`: add the same XML nodes for single-element coverage.
+- Modify `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/data.ts`: add model and YAML expectations for the two new properties.
+
+## Task 1: Page ChildItemsWidth
+
+**Files:**
+- Modify: `packages/core/metadata/forms/elements/page/rules.ts`
+- Modify: `packages/core/metadata/forms/elements/page/__fixtures__/full.xml`
+- Modify: `packages/core/metadata/forms/elements/page/__fixtures__/data.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/fromXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/fromYAML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toYAML.test.ts`
+
+- [ ] **Step 1: Write the failing fixture expectation**
+
+In `packages/core/metadata/forms/elements/page/__fixtures__/full.xml`, add `ChildItemsWidth` near the other child layout properties, after `HorizontalAlign` and before `VerticalAlign`:
+
+```xml
+	<HorizontalAlign>Right</HorizontalAlign>
+	<ChildItemsWidth>LeftNarrowest</ChildItemsWidth>
+	<VerticalAlign>Bottom</VerticalAlign>
+```
+
+In `packages/core/metadata/forms/elements/page/__fixtures__/data.ts`, change `fullPage` so `slaveItemsWidth` is no longer omitted from the required model type:
+
+```ts
+export const fullPage: RequiredFieldsElement<
+  Omit<Page, "showTitle" | "childItemsVerticalAlign" | "verticalScrollOnReduceSize">
+> = {
+```
+
+Then add the model field near the other child layout fields:
+
+```ts
+  childItemsHorizontalAlign: "Right",
+  slaveItemsWidth: "LeftNarrowest",
+  itemsAndTitlesAlign: "ItemsLeftTitlesLeft",
+```
+
+Add the YAML expectation to `fullPagePartialYAML` near `ГоризонтальноеПоложениеПодчиненных`:
+
+```ts
+  ГоризонтальноеПоложениеПодчиненных: "Право",
+  ШиринаПодчиненныхЭлементов: "ЛевыйОченьУзкий",
+  ВыравниваниеЭлементовИЗаголовков: "ЭлементыЛевоЗаголовкиЛево",
+```
+
+Update `fullPageEnterprise` so `SlaveItemsWidth` is no longer omitted:
+
+```ts
+} satisfies Required<
+  Omit<PageEnterprise, "ChildItemsVerticalAlign" | "ShowTitle" | "VerticalScrollOnReduceSize">
+>
+```
+
+Add the enterprise expectation near `ChildItemsHorizontalAlign`:
+
+```ts
+  ChildItemsHorizontalAlign: {
+    Type: "SystemEnumeration",
+    Value: "ItemHorizontalLocation.Right",
+  },
+  SlaveItemsWidth: {
+    Type: "SystemEnumeration",
+    Value: "ChildFormItemsWidth.LeftNarrowest",
+  },
+```
+
+- [ ] **Step 2: Run the narrow tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts
+```
+
+Expected before implementation:
+
+- `Page > all fields` fails in `fromXML.test.ts` because imported model lacks `slaveItemsWidth`.
+- `Page > all fields` fails in `toXML.test.ts` because exported XML lacks `ChildItemsWidth`.
+- YAML tests may fail because `PageRules.slaveItemsWidth` already has YAML mapping but the XML rule is still missing; if YAML passes, continue.
+
+- [ ] **Step 3: Implement the rule mapping**
+
+In `packages/core/metadata/forms/elements/page/rules.ts`, add `xml: "ChildItemsWidth"` to `slaveItemsWidth`:
+
+```ts
+    slaveItemsWidth: {
+      yaml: "ШиринаПодчиненныхЭлементов",
+      xml: "ChildItemsWidth",
+      type: "SystemEnumeration",
+      typeSE: "ChildFormItemsWidth",
+    },
+```
+
+- [ ] **Step 4: Run the narrow tests and verify Page passes**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts
+```
+
+Expected:
+
+- `Page > all fields` passes in XML and YAML tests.
+- Existing failures, if any, should only relate to `SearchStringAddition` after Task 2 fixture changes.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add packages/core/metadata/forms/elements/page/rules.ts packages/core/metadata/forms/elements/page/__fixtures__/full.xml packages/core/metadata/forms/elements/page/__fixtures__/data.ts
+git commit -m "fix: :bug: сохранить ширину подчинённых Page"
+```
+
+## Task 2: SearchStringAddition AutoMaxWidth And MaxWidth
+
+**Files:**
+- Modify: `packages/core/metadata/forms/elements/searchStringAddition/rules.ts`
+- Modify: `packages/core/metadata/forms/elements/searchStringAddition/types.ts`
+- Modify: `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml`
+- Modify: `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml`
+- Modify: `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/data.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/fromXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toXML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/fromYAML.test.ts`
+- Test: `packages/core/metadata/forms/elements/__tests__/toYAML.test.ts`
+
+- [ ] **Step 1: Write the failing fixture expectation**
+
+In both XML fixtures:
+
+- `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml`
+- `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml`
+
+add `AutoMaxWidth` and `MaxWidth`. Put them before `Width` so the size-related fields stay grouped:
+
+```xml
+	<Visible>true</Visible>
+	<AutoMaxWidth>false</AutoMaxWidth>
+	<MaxWidth>20</MaxWidth>
+	<Width>300</Width>
+```
+
+In `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/data.ts`, add the fields to `fullSingleSearchStringAddition` near `width`:
+
+```ts
+  visible: true,
+  autoMaxWidth: false,
+  maxWidth: 20,
+  width: 300,
+```
+
+Add the YAML expectation to `fullSingleSearchStringAdditionYAML` near the width fields:
+
+```ts
+  РастягиватьПоГоризонтали: "Истина",
+  АвтоМаксимальнаяШирина: "Ложь",
+  МаксимальнаяШирина: 20,
+  ЦветРамки: "Черный",
+```
+
+- [ ] **Step 2: Run the narrow tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts
+```
+
+Expected before implementation:
+
+- `SearchStringAddition > all fields` fails in `fromXML.test.ts` because imported model lacks `autoMaxWidth` and `maxWidth`.
+- `SearchStringAddition > all fields` fails in `toXML.test.ts` because exported XML lacks `AutoMaxWidth` and `MaxWidth`.
+- YAML tests fail or TypeScript reports missing YAML fields until `types.ts` and `rules.ts` are updated.
+
+- [ ] **Step 3: Implement the rule properties**
+
+In `packages/core/metadata/forms/elements/searchStringAddition/rules.ts`, add the two properties to local `commonProperties`. Place `autoMaxWidth` near `horizontalStretch`, and `maxWidth` near `width`:
+
+```ts
+  horizontalStretch: { yaml: "РастягиватьПоГоризонтали", type: "boolean" },
+  autoMaxWidth: { yaml: "АвтоМаксимальнаяШирина", type: "boolean" },
+  maxWidth: { yaml: "МаксимальнаяШирина", type: "number" },
+  textColor: { yaml: "ЦветТекста", type: "Color" },
+  width: { yaml: "Ширина", type: "number" },
+```
+
+- [ ] **Step 4: Update the manual YAML interfaces**
+
+In `packages/core/metadata/forms/elements/searchStringAddition/types.ts`, add the two optional YAML fields to `SearchStringAdditionYAML`:
+
+```ts
+  РастягиватьПоГоризонтали?: StringboolYAML
+  АвтоМаксимальнаяШирина?: StringboolYAML
+  МаксимальнаяШирина?: number
+  ЦветРамки?: ColorYAML
+```
+
+`SingleSearchStringAdditionYAML` extends this interface, so no separate field list is needed there.
+
+- [ ] **Step 5: Run the narrow tests and verify SearchStringAddition passes**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts
+```
+
+Expected:
+
+- `SearchStringAddition > all fields` passes in XML and YAML tests.
+- The four test files pass completely.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git add packages/core/metadata/forms/elements/searchStringAddition/rules.ts packages/core/metadata/forms/elements/searchStringAddition/types.ts packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/data.ts
+git commit -m "fix: :bug: сохранить размеры SearchStringAddition"
+```
+
+## Task 3: Final Verification
+
+**Files:**
+- Verify: `packages/core/metadata/forms/elements/page/rules.ts`
+- Verify: `packages/core/metadata/forms/elements/searchStringAddition/rules.ts`
+- Verify: `packages/core/metadata/forms/elements/page/__fixtures__/data.ts`
+- Verify: `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/data.ts`
+
+- [ ] **Step 1: Regenerate Langium files if needed**
+
+Run:
+
+```bash
+pnpm --filter nkdk-language langium:generate
+```
+
+Expected:
+
+```text
+Langium generator finished successfully
+```
+
+- [ ] **Step 2: Run the focused form-elements tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts metadata/forms/elements/__tests__/toEnterprise.test.ts
+```
+
+Expected:
+
+```text
+Test Files  5 passed
+```
+
+- [ ] **Step 3: Run the full project test suite**
+
+Run from repo root:
+
+```bash
+pnpm test
+```
+
+Expected:
+
+```text
+0 failures
+```
+
+- [ ] **Step 4: Commit any verification-only fixture adjustments**
+
+If Step 2 or Step 3 required fixture order adjustments only, commit them:
+
+```bash
+git add packages/core/metadata/forms/elements/page/__fixtures__/full.xml packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml
+git commit -m "test: :white_check_mark: уточнить фикстуры элементов формы"
+```
+
+If there are no changes after verification, skip this commit.
+
+## Self-Review
+
+- Spec coverage: Task 1 covers `Page.ChildItemsWidth`; Task 2 covers `SearchStringAddition` XML, YAML, and model fields; Task 3 covers focused and full verification.
+- Placeholder scan: no unresolved implementation notes or incomplete sections.
+- Type consistency: `slaveItemsWidth`, `autoMaxWidth`, `maxWidth`, `ШиринаПодчиненныхЭлементов`, `АвтоМаксимальнаяШирина`, and `МаксимальнаяШирина` match the existing naming style and rule conventions.

--- a/docs/superpowers/specs/2026-05-09-form-elements-page-search-string-design.md
+++ b/docs/superpowers/specs/2026-05-09-form-elements-page-search-string-design.md
@@ -1,0 +1,99 @@
+# Form Elements Page And SearchStringAddition Round-Trip Design
+
+## Контекст
+
+Short round-trip XML показал два независимых расхождения в элементах управляемой формы:
+
+- `Page` теряет XML-узел `<ChildItemsWidth>LeftNarrowest</ChildItemsWidth>`.
+- `SearchStringAddition` теряет XML-узлы `<AutoMaxWidth>false</AutoMaxWidth>` и `<MaxWidth>20</MaxWidth>`.
+
+Пункт с `FormAttribute Settings` не входит в эту спецификацию: он уже закрыт отдельной веткой `codex/form-attribute-typed-settings` коммитом `590f411a9`.
+
+## Цель
+
+Сохранить свойства `ChildItemsWidth`, `AutoMaxWidth` и `MaxWidth` в XML -> модель -> XML и YAML -> модель -> YAML циклах для соответствующих form-elements без изменения общих правил за пределами нужных элементов.
+
+## Границы
+
+Входит:
+
+- `PageRules.slaveItemsWidth` в `packages/core/metadata/forms/elements/page/rules.ts`.
+- `SearchStringAdditionRules` и `SingleSearchStringAdditionRules` через общий набор свойств в `packages/core/metadata/forms/elements/searchStringAddition/rules.ts`.
+- XML, TS-модель и YAML-ожидания fixture'ов для `Page` и `SearchStringAddition`.
+- Узкие проверки централизованных тестов form-elements для XML и YAML.
+
+Не входит:
+
+- Перенос `slaveItemsWidth` в `formGroupCommonProperties`.
+- Общий рефакторинг свойств `SearchStringAddition` и `SearchControlAddition`.
+- Новые правила `fromXML` / `toXML` / `fromYAML` / `toYAML`; изменения должны выражаться через `rules.ts`.
+- Изменения исходных XML-фикстур из внешнего XML-репозитория.
+
+## Решение 1: Page.ChildItemsWidth
+
+Сейчас `PageRules` уже содержит свойство модели `slaveItemsWidth`, но у него нет XML-маппинга. В `UsualGroupRules` то же свойство уже связано с XML-тегом `ChildItemsWidth`.
+
+Нужно добавить `xml: "ChildItemsWidth"` именно в `PageRules.slaveItemsWidth`.
+
+Не нужно переносить свойство в `formGroupCommonProperties`: этот общий набор используют `Pages`, `CommandBar`, `ButtonGroup`, `Popup`, `ColumnGroup` и другие элементы. Такой перенос расширит XML-поведение сразу на несколько типов и может начать экспортировать `ChildItemsWidth` там, где платформа его не ожидает.
+
+Fixture для `Page` должен явно проверять все направления:
+
+- XML: добавить `<ChildItemsWidth>LeftNarrowest</ChildItemsWidth>` в `packages/core/metadata/forms/elements/page/__fixtures__/full.xml`.
+- TS-модель: добавить `slaveItemsWidth: "LeftNarrowest"` в `fullPage`.
+- YAML: добавить `ШиринаПодчиненныхЭлементов: "ЛевыйОченьУзкий"` в `fullPagePartialYAML`.
+
+## Решение 2: SearchStringAddition sizes
+
+`SearchControlAddition` уже поддерживает `autoMaxWidth` и `maxWidth`, а `SearchStringAddition` нет. Из-за этого round-trip удаляет `<AutoMaxWidth>false</AutoMaxWidth>` и `<MaxWidth>20</MaxWidth>` из `SearchStringAddition`.
+
+Нужно добавить в `searchStringAddition.commonProperties`:
+
+- `autoMaxWidth: { yaml: "АвтоМаксимальнаяШирина", type: "boolean" }`
+- `maxWidth: { yaml: "МаксимальнаяШирина", type: "number" }`
+
+Это автоматически применится к `SingleSearchStringAdditionRules` и `SearchStringAdditionRules`, потому что оба используют один локальный `commonProperties`.
+
+Не нужно выносить общий набор с `SearchControlAddition`: у `SearchControlAddition` есть дополнительные свойства, например `childItems`, и общий рефакторинг увеличит границы изменения без пользы для текущего дефекта.
+
+Fixture для `SearchStringAddition` должен явно проверять все направления:
+
+- XML: добавить `<AutoMaxWidth>false</AutoMaxWidth>` и `<MaxWidth>20</MaxWidth>` в `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml`.
+- XML single: добавить те же узлы в `packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml`.
+- TS-модель: добавить `autoMaxWidth: false` и `maxWidth: 20` в `fullSingleSearchStringAddition`.
+- YAML: добавить `АвтоМаксимальнаяШирина: "Ложь"` и `МаксимальнаяШирина: 20` в `fullSingleSearchStringAdditionYAML`.
+
+## Тестирование
+
+Централизованные тесты form-elements уже читают `ElementFixtures` и проверяют:
+
+- `metadata/forms/elements/__tests__/fromXML.test.ts`
+- `metadata/forms/elements/__tests__/toXML.test.ts`
+- `metadata/forms/elements/__tests__/fromYAML.test.ts`
+- `metadata/forms/elements/__tests__/toYAML.test.ts`
+
+После изменения fixture'ов эти четыре файла должны ловить регрессии без отдельных `it(...)` блоков.
+
+Узкая проверка:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts
+```
+
+Перед закрытием задачи нужно выполнить проектное требование:
+
+```bash
+pnpm test
+```
+
+Если worktree свежий, перед полным тестом сначала выполнить:
+
+```bash
+pnpm --filter nkdk-language langium:generate
+```
+
+## Риски
+
+- Для `Page` важно не поднять `ChildItemsWidth` в общий `formGroupCommonProperties`, иначе поведение изменится у нескольких элементов сразу.
+- Для `SearchStringAddition` важно обновить XML, модель и YAML вместе; иначе часть централизованных тестов начнет падать не по целевому поведению, а из-за рассинхронизации fixture'ов.
+- Для `fullSingle.xml` важно сохранить согласованность с single-вариантом модели, потому что `SingleSearchStringAdditionRules` использует тот же набор свойств.

--- a/packages/core/metadata/forms/elements/page/__fixtures__/data.ts
+++ b/packages/core/metadata/forms/elements/page/__fixtures__/data.ts
@@ -7,7 +7,7 @@ import {
 } from "~/metadata/forms/elements/formGroup/__fixtures__/data"
 
 export const fullPage: RequiredFieldsElement<
-  Omit<Page, "showTitle" | "childItemsVerticalAlign" | "slaveItemsWidth" | "verticalScrollOnReduceSize">
+  Omit<Page, "showTitle" | "childItemsVerticalAlign" | "verticalScrollOnReduceSize">
 > = {
   itemType: "Page",
   name: "Страница",
@@ -25,6 +25,7 @@ export const fullPage: RequiredFieldsElement<
   },
   group: "AlwaysHorizontal",
   childItemsHorizontalAlign: "Right",
+  slaveItemsWidth: "LeftNarrowest",
   itemsAndTitlesAlign: "ItemsLeftTitlesLeft",
   horizontalSpacing: "OneAndHalf",
   scrollOnCompress: true,
@@ -50,6 +51,7 @@ export const fullPagePartialYAML: PagePartialYAML = {
   ВертикальноеПоложение: "Низ",
   ВертикальныйИнтервал: "Двойной",
   ГоризонтальноеПоложениеПодчиненных: "Право",
+  ШиринаПодчиненныхЭлементов: "ЛевыйОченьУзкий",
   ВыравниваниеЭлементовИЗаголовков: "ЭлементыЛевоЗаголовкиЛево",
   ГоризонтальныйИнтервал: "Полуторный",
   Группировка: "ГоризонтальнаяВсегда",
@@ -84,6 +86,10 @@ export const fullPageEnterprise = {
     Type: "SystemEnumeration",
     Value: "ItemHorizontalLocation.Right",
   },
+  SlaveItemsWidth: {
+    Type: "SystemEnumeration",
+    Value: "ChildFormItemsWidth.LeftNarrowest",
+  },
   Group: {
     Type: "SystemEnumeration",
     Value: "ChildFormItemsGroup.AlwaysHorizontal",
@@ -110,7 +116,7 @@ export const fullPageEnterprise = {
   },
   ...fullFormGroupEnterpriseCommonFixture,
 } satisfies Required<
-  Omit<PageEnterprise, "ChildItemsVerticalAlign" | "ShowTitle" | "SlaveItemsWidth" | "VerticalScrollOnReduceSize">
+  Omit<PageEnterprise, "ChildItemsVerticalAlign" | "ShowTitle" | "VerticalScrollOnReduceSize">
 >
 
 export const minimalPage: Page = {

--- a/packages/core/metadata/forms/elements/page/__fixtures__/full.xml
+++ b/packages/core/metadata/forms/elements/page/__fixtures__/full.xml
@@ -38,6 +38,7 @@
 	<HorizontalSpacing>OneAndHalf</HorizontalSpacing>
 	<VerticalSpacing>Double</VerticalSpacing>
 	<HorizontalAlign>Right</HorizontalAlign>
+	<ChildItemsWidth>LeftNarrowest</ChildItemsWidth>
 	<VerticalAlign>Bottom</VerticalAlign>
 	<Format>
 		<v8:item>

--- a/packages/core/metadata/forms/elements/page/rules.ts
+++ b/packages/core/metadata/forms/elements/page/rules.ts
@@ -61,6 +61,7 @@ export const PageRules = {
     showTitle: { yaml: "ОтображатьЗаголовок", type: "boolean" },
     slaveItemsWidth: {
       yaml: "ШиринаПодчиненныхЭлементов",
+      xml: "ChildItemsWidth",
       type: "SystemEnumeration",
       typeSE: "ChildFormItemsWidth",
     },

--- a/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/data.ts
+++ b/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/data.ts
@@ -37,6 +37,8 @@ export const fullSingleSearchStringAddition: SingleSearchStringAddition = {
   },
   verticalAlignInGroup: "Top",
   visible: true,
+  autoMaxWidth: false,
+  maxWidth: 20,
   width: 300,
   contextMenu: {
     itemType: "ContextMenu",
@@ -60,6 +62,8 @@ export const fullSingleSearchStringAdditionYAML: SingleSearchStringAdditionYAML 
   Подсказка: "Подсказка",
   РазрешитьИспользование: { Администратор: "Истина" },
   РастягиватьПоГоризонтали: "Истина",
+  АвтоМаксимальнаяШирина: "Ложь",
+  МаксимальнаяШирина: 20,
   ЦветРамки: "Черный",
   ЦветТекста: "Черный",
   ЦветФона: "Белый",

--- a/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml
+++ b/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml
@@ -40,5 +40,7 @@
 		<xr:Value name="Role.Администратор">true</xr:Value>
 	</UserVisible>
 	<Visible>true</Visible>
+	<AutoMaxWidth>false</AutoMaxWidth>
+	<MaxWidth>20</MaxWidth>
 	<Width>300</Width>
 </SearchStringAddition>

--- a/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml
+++ b/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/full.xml
@@ -3,6 +3,7 @@
 		<Item>КакойТоЭлемент</Item>
 		<Type>SearchStringRepresentation</Type>
 	</AdditionSource>
+	<AutoMaxWidth>false</AutoMaxWidth>
 	<BackColor>web:White</BackColor>
 	<BorderColor>web:Black</BorderColor>
 	<ContextMenu name="КакойТоЭлементСтрокаПоискаКонтекстноеМеню" id="2">
@@ -21,6 +22,7 @@
 	<GroupHorizontalAlign>Left</GroupHorizontalAlign>
 	<GroupVerticalAlign>Top</GroupVerticalAlign>
 	<HorizontalStretch>true</HorizontalStretch>
+	<MaxWidth>20</MaxWidth>
 	<TextColor>web:Black</TextColor>
 	<Title>
 		<v8:item>
@@ -40,7 +42,5 @@
 		<xr:Value name="Role.Администратор">true</xr:Value>
 	</UserVisible>
 	<Visible>true</Visible>
-	<AutoMaxWidth>false</AutoMaxWidth>
-	<MaxWidth>20</MaxWidth>
 	<Width>300</Width>
 </SearchStringAddition>

--- a/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml
+++ b/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml
@@ -40,5 +40,7 @@
 		<xr:Value name="Role.Администратор">true</xr:Value>
 	</UserVisible>
 	<Visible>true</Visible>
+	<AutoMaxWidth>false</AutoMaxWidth>
+	<MaxWidth>20</MaxWidth>
 	<Width>300</Width>
 </SearchStringAddition>

--- a/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml
+++ b/packages/core/metadata/forms/elements/searchStringAddition/__fixtures__/fullSingle.xml
@@ -3,6 +3,7 @@
 		<Item>КакойТоЭлемент</Item>
 		<Type>SearchStringRepresentation</Type>
 	</AdditionSource>
+	<AutoMaxWidth>false</AutoMaxWidth>
 	<BackColor>web:White</BackColor>
 	<BorderColor>web:Black</BorderColor>
 	<ContextMenu name="КакойТоЭлементСтрокаПоискаКонтекстноеМеню" id="2">
@@ -21,6 +22,7 @@
 	<GroupHorizontalAlign>Left</GroupHorizontalAlign>
 	<GroupVerticalAlign>Top</GroupVerticalAlign>
 	<HorizontalStretch>true</HorizontalStretch>
+	<MaxWidth>20</MaxWidth>
 	<TextColor>web:Black</TextColor>
 	<Title>
 		<v8:item>
@@ -40,7 +42,5 @@
 		<xr:Value name="Role.Администратор">true</xr:Value>
 	</UserVisible>
 	<Visible>true</Visible>
-	<AutoMaxWidth>false</AutoMaxWidth>
-	<MaxWidth>20</MaxWidth>
 	<Width>300</Width>
 </SearchStringAddition>

--- a/packages/core/metadata/forms/elements/searchStringAddition/rules.ts
+++ b/packages/core/metadata/forms/elements/searchStringAddition/rules.ts
@@ -8,13 +8,13 @@ import { getSearchStringAdditionName } from "./helper"
 export type { ElementRule, PropertyRule }
 
 const commonProperties = {
+  autoMaxWidth: { yaml: "АвтоМаксимальнаяШирина", type: "boolean" },
   backColor: { yaml: "ЦветФона", type: "Color" },
   borderColor: { yaml: "ЦветРамки", type: "Color" },
   font: { yaml: "Шрифт", type: "Font" },
   horizontalStretch: { yaml: "РастягиватьПоГоризонтали", type: "boolean" },
-  autoMaxWidth: { yaml: "АвтоМаксимальнаяШирина", type: "boolean" },
-  textColor: { yaml: "ЦветТекста", type: "Color" },
   maxWidth: { yaml: "МаксимальнаяШирина", type: "number" },
+  textColor: { yaml: "ЦветТекста", type: "Color" },
   width: { yaml: "Ширина", type: "number" },
   contextMenu: { yaml: "КонтекстноеМеню", type: "ContextMenu" },
   displayImportance: {

--- a/packages/core/metadata/forms/elements/searchStringAddition/rules.ts
+++ b/packages/core/metadata/forms/elements/searchStringAddition/rules.ts
@@ -12,7 +12,9 @@ const commonProperties = {
   borderColor: { yaml: "ЦветРамки", type: "Color" },
   font: { yaml: "Шрифт", type: "Font" },
   horizontalStretch: { yaml: "РастягиватьПоГоризонтали", type: "boolean" },
+  autoMaxWidth: { yaml: "АвтоМаксимальнаяШирина", type: "boolean" },
   textColor: { yaml: "ЦветТекста", type: "Color" },
+  maxWidth: { yaml: "МаксимальнаяШирина", type: "number" },
   width: { yaml: "Ширина", type: "number" },
   contextMenu: { yaml: "КонтекстноеМеню", type: "ContextMenu" },
   displayImportance: {

--- a/packages/core/metadata/forms/elements/searchStringAddition/types.ts
+++ b/packages/core/metadata/forms/elements/searchStringAddition/types.ts
@@ -17,6 +17,8 @@ export type SingleSearchStringAddition = FormTypeByRule<typeof SingleSearchStrin
 export interface SearchStringAdditionYAML {
   Источник?: string
   РастягиватьПоГоризонтали?: StringboolYAML
+  АвтоМаксимальнаяШирина?: StringboolYAML
+  МаксимальнаяШирина?: number
   ЦветРамки?: ColorYAML
   ЦветТекста?: ColorYAML
   ЦветФона?: ColorYAML


### PR DESCRIPTION
## Что сделано
- Добавлен XML-маппинг ChildItemsWidth для Page.slaveItemsWidth.
- Добавлены AutoMaxWidth и MaxWidth для SearchStringAddition и SingleSearchStringAddition.
- Обновлены XML/TS/YAML fixture'ы и документация с планом.

## Проверки
- pnpm --filter nkdk-language langium:generate
- pnpm --filter '@nakidka/core' exec vitest run metadata/forms/elements/__tests__/fromXML.test.ts metadata/forms/elements/__tests__/toXML.test.ts metadata/forms/elements/__tests__/fromYAML.test.ts metadata/forms/elements/__tests__/toYAML.test.ts metadata/forms/elements/__tests__/toEnterprise.test.ts
- pnpm test
- round-trip-xml: diff_count уменьшился с 26 до 22, прежние пункты Page/SearchStringAddition ушли