### PR TITLE
Поддержать ent-перечисления DCS

### DIFF
--- a/docs/superpowers/plans/2026-05-14-dcs-ent-system-enumeration.md
+++ b/docs/superpowers/plans/2026-05-14-dcs-ent-system-enumeration.md
@@ -1,0 +1,203 @@
+# DCS ent:* System Enumeration Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Round-trip known `ent:*` system enumeration values in DCS metadata values without changing the public value model.
+
+**Architecture:** Add a narrow import fallback in `dcsMetadataValue/fromXML.ts` after primitive parsing and before the unsupported-type error. For `DCSParameter` export, infer the same known `ent:*` type from the parameter `valueType` and use a temporary `SystemEnumeration` rule for the `value` field only.
+
+**Tech Stack:** TypeScript, Vitest, existing metadata orchestration helpers.
+
+---
+
+### Task 1: Add Import Coverage
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts`
+- Create: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/system-enumeration-accumulation-record-type.xml`
+- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts`
+
+- [ ] **Step 1: Add the fixture data entry**
+
+Add a fixture to `dcsMetadataValueXMLFixtures`:
+
+```ts
+{
+  id: "systemEnumerationAccumulationRecordTypeInferred",
+  title: "SystemEnumeration inferred from ent:AccumulationRecordType",
+  rule: { type: "MetadataDcsMetadataValue", valueType: "Primitive", yaml: "value" },
+  value: "Expense",
+  yaml: "Expense",
+  xml: "system-enumeration-accumulation-record-type.xml",
+}
+```
+
+- [ ] **Step 2: Add the XML fixture**
+
+Create `system-enumeration-accumulation-record-type.xml`:
+
+```xml
+<dcscor:value xsi:type="ent:AccumulationRecordType">Expense</dcscor:value>
+```
+
+- [ ] **Step 3: Run the red test**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts -t "SystemEnumeration inferred from ent:AccumulationRecordType"
+```
+
+Expected: FAIL with `DCS MetadataValue: unsupported xsi:type ent:AccumulationRecordType`.
+
+### Task 2: Implement Known ent:* Fallback
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts`
+- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts`
+
+- [ ] **Step 1: Import the system enumeration type map as a runtime value**
+
+Change the system enumeration imports so exported `*ToYAML` maps can be checked at runtime:
+
+```ts
+import * as SystemEnumerations from "~/metadata/systemEnumerations/types"
+import type { SystemEnumerationPropertyRule, SystemEnumerationTypeMap } from "~/metadata/systemEnumerations/types"
+```
+
+- [ ] **Step 2: Add a helper for known ent:* type names**
+
+Add near `hasSystemEnumeration`:
+
+```ts
+const inferEntSystemEnumerationType = (xsi: string | undefined): keyof SystemEnumerationTypeMap | undefined => {
+  if (xsi === undefined || !xsi.startsWith("ent:")) return undefined
+
+  const typeName = xsi.slice("ent:".length)
+  const yamlMapName = `${typeName}ToYAML`
+  return Object.prototype.hasOwnProperty.call(SystemEnumerations, yamlMapName)
+    ? (typeName as keyof SystemEnumerationTypeMap)
+    : undefined
+}
+```
+
+- [ ] **Step 3: Delegate inferred values to the existing importer**
+
+Add after the explicit `hasSystemEnumeration(rule)` branch, before the unsupported error:
+
+```ts
+const inferredTypeSE = inferEntSystemEnumerationType(xsi)
+if (inferredTypeSE !== undefined) {
+  return importSystemEnumerationFromDcsXML(
+    context,
+    { type: "SystemEnumeration", typeSE: inferredTypeSE } as SystemEnumerationPropertyRule,
+    xml as SystemEnumerationDcsValueRootXML
+  )
+}
+```
+
+- [ ] **Step 4: Run the green test**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts -t "SystemEnumeration inferred from ent:AccumulationRecordType"
+```
+
+Expected: PASS.
+
+### Task 3: Verify Nearby Behavior
+
+**Files:**
+- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts`
+- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.test.ts`
+
+- [ ] **Step 1: Run DCS metadata value XML tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.test.ts
+```
+
+Expected: PASS.
+
+### Task 4: Export DCS Parameter ent:* Values From valueType
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts`
+- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts`
+
+- [ ] **Step 1: Add a red import+export test**
+
+Add a DCS parameter XML fixture inline in `fromXML.test.ts`:
+
+```xml
+<Settings>
+	<Parameter>
+		<dcssch:name>ВидДвижения</dcssch:name>
+		<dcssch:valueType>
+			<v8:Type>ent:AccumulationRecordType</v8:Type>
+		</dcssch:valueType>
+		<dcssch:value xsi:type="ent:AccumulationRecordType">Expense</dcssch:value>
+		<dcssch:useRestriction>true</dcssch:useRestriction>
+	</Parameter>
+</Settings>
+```
+
+Assert that import returns `valueType: { type: ["AccumulationRecordType"] }` and `value: "Expense"`,
+then assert export contains:
+
+```xml
+<dcssch:value xsi:type="ent:AccumulationRecordType">Expense</dcssch:value>
+```
+
+- [ ] **Step 2: Run the red test**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts -t "imports and exports ent system enumeration value"
+```
+
+Expected: FAIL with `MetadataValue: неподдерживаемый тип для экспорта в XML: undefined`.
+
+- [ ] **Step 3: Add dynamic export rule selection**
+
+In `dcsParameter/toXML.ts`, infer a known `ent:*` system enumeration from `item.valueType`. When it
+matches, pass `exportMetadataItemToXML` a copy of `DCSParameterRules` where only the `value` property
+uses:
+
+```ts
+{
+  ...DCSParameterRules.properties.value,
+  valueType: "SystemEnumeration",
+  typeSE,
+}
+```
+
+- [ ] **Step 4: Run the green test**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts -t "imports and exports ent system enumeration value"
+```
+
+Expected: PASS.
+
+### Task 5: Final Round-Trip Check
+
+**Files:**
+- Test: `.agents/skills/round-trip-xml/round-trip.sh`
+
+- [ ] **Step 1: Re-run round-trip triage**
+
+Run:
+
+```bash
+./.agents/skills/round-trip-xml/round-trip.sh --triage --batch-size 5
+```
+
+Expected: the previous `ent:AccumulationRecordType` exception is gone. The command may now either print the next diff batch or reveal the next independent blocker.

--- a/docs/superpowers/specs/2026-05-14-dcs-ent-system-enumeration-design.md
+++ b/docs/superpowers/specs/2026-05-14-dcs-ent-system-enumeration-design.md
@@ -30,17 +30,20 @@ example `"Expense"` or `"Receipt"`.
 
 ## Export
 
-Do not add heuristic export for raw strings. A generic string value does not carry `typeSE`, so
-choosing an `ent:*` type during export would be ambiguous.
+Do not add heuristic export for raw strings in generic `MetadataDcsMetadataValue`. A generic string
+value does not carry `typeSE`, so choosing an `ent:*` type during export would be ambiguous.
 
-Existing export remains the supported path:
+Generic export remains the supported explicit path:
 
 ```ts
 { type: "MetadataDcsMetadataValue", valueType: "SystemEnumeration", typeSE: "AccumulationRecordType" }
 ```
 
-This keeps round-trip behavior explicit on export while unblocking import of real DCS XML where the
-type is already present in `xsi:type`.
+For DCS parameters, export has additional local context: the same item contains `dcssch:valueType`.
+When that `valueType` is a single known `ent:*` system enumeration, `dcsParameter/toXML.ts` should
+export the parameter value through a temporary `SystemEnumeration` rule for that item. This keeps
+the generic value model unchanged while allowing XML -> model -> XML round-trip for parameters like
+`AccumulationRecordType`.
 
 ## Tests
 
@@ -50,6 +53,8 @@ Add a focused XML import fixture for `ent:AccumulationRecordType` under
 Expected behavior:
 
 - `xsi:type="ent:AccumulationRecordType"` imports as `"Expense"`;
+- a DCS parameter with `valueType` `ent:AccumulationRecordType` exports the value back as
+  `xsi:type="ent:AccumulationRecordType"`;
 - the existing unsupported-type error still applies to unknown `ent:*` names;
 - export tests continue to cover the explicit `SystemEnumeration` rule path.
 

--- a/docs/superpowers/specs/2026-05-14-dcs-ent-system-enumeration-design.md
+++ b/docs/superpowers/specs/2026-05-14-dcs-ent-system-enumeration-design.md
@@ -1,0 +1,59 @@
+# DCS ent:* system enumeration import
+
+## Context
+
+Short round-trip stops while importing a form DCS value:
+
+```xml
+<dcssch:value xsi:type="ent:AccumulationRecordType">Expense</dcssch:value>
+```
+
+`MetadataDcsMetadataValue` already supports system enumerations when a rule explicitly says
+`valueType: "SystemEnumeration"` and provides `typeSE`. The failing DCS value is parsed through a
+generic `Primitive` rule, so the importer reaches the unsupported `xsi:type` branch before any XML
+diff can be produced.
+
+## Decision
+
+Use approach B1: add a generic import fallback for known `ent:*` system enumerations.
+
+When `dcsMetadataValue/fromXML.ts` sees an unknown `xsi:type` with the `ent:` prefix, it should:
+
+1. extract the type name after `ent:`;
+2. verify that the name exists in `SystemEnumerationTypeMap`;
+3. import the value through the existing `importSystemEnumerationFromDcsXML` helper with
+   `valueType: "SystemEnumeration"` and the inferred `typeSE`;
+4. leave truly unknown `ent:*` values on the current explicit error path.
+
+The model remains unchanged: the imported value is still the raw enumeration value string, for
+example `"Expense"` or `"Receipt"`.
+
+## Export
+
+Do not add heuristic export for raw strings. A generic string value does not carry `typeSE`, so
+choosing an `ent:*` type during export would be ambiguous.
+
+Existing export remains the supported path:
+
+```ts
+{ type: "MetadataDcsMetadataValue", valueType: "SystemEnumeration", typeSE: "AccumulationRecordType" }
+```
+
+This keeps round-trip behavior explicit on export while unblocking import of real DCS XML where the
+type is already present in `xsi:type`.
+
+## Tests
+
+Add a focused XML import fixture for `ent:AccumulationRecordType` under
+`packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue`.
+
+Expected behavior:
+
+- `xsi:type="ent:AccumulationRecordType"` imports as `"Expense"`;
+- the existing unsupported-type error still applies to unknown `ent:*` names;
+- export tests continue to cover the explicit `SystemEnumeration` rule path.
+
+## Scope
+
+This change is limited to DCS metadata values. It does not add YAML behavior, change fixture XML from
+the source repository, or alter broader metadata orchestration rules.

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts
@@ -138,6 +138,15 @@ const nilFixture: DcsMetadataValueFixture = {
   xml: "nil.xml",
 }
 
+const inferredAccumulationRecordTypeFixture: DcsMetadataValueFixture = {
+  id: "systemEnumerationAccumulationRecordTypeInferred",
+  title: "SystemEnumeration inferred from ent:AccumulationRecordType",
+  rule: { type: "MetadataDcsMetadataValue", valueType: "Primitive", yaml: "value" },
+  value: "Expense",
+  yaml: "Expense",
+  xml: "system-enumeration-accumulation-record-type.xml",
+}
+
 export const dcsMetadataValueFixtures: DcsMetadataValueFixture[] = [
   {
     id: "color",
@@ -225,4 +234,9 @@ export const dcsMetadataValueXMLFixtures: DcsMetadataValueFixture[] = [
   nilFixture,
   primitiveTypeRefFixture,
   primitiveUuidFixture,
+]
+
+export const dcsMetadataValueFromXMLFixtures: DcsMetadataValueFixture[] = [
+  ...dcsMetadataValueXMLFixtures,
+  inferredAccumulationRecordTypeFixture,
 ]

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/system-enumeration-accumulation-record-type.xml
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/system-enumeration-accumulation-record-type.xml
@@ -1,0 +1,1 @@
+<dcscor:value xsi:type="ent:AccumulationRecordType">Expense</dcscor:value>

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest"
 import { testImportPropertyFromXML } from "~/tests/property/importPropertyFromXML"
-import { dcsMetadataValueXMLFixtures } from "./__fixtures__/data"
+import { dcsMetadataValueFromXMLFixtures } from "./__fixtures__/data"
 
 describe("import MetadataDcsMetadataValue from XML", () => {
-  it.each(dcsMetadataValueXMLFixtures)("imports $title", (fixture) => {
+  it.each(dcsMetadataValueFromXMLFixtures)("imports $title", (fixture) => {
     expect(
       testImportPropertyFromXML({
         rule: fixture.rule,

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts
@@ -15,7 +15,8 @@ import { PropertyRule } from "~/metadata/forms/elements/calendarField/rules"
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { SystemEnumerationDcsValueRootXML } from "~/metadata/systemEnumerations/dcsTypes"
 import { importSystemEnumerationFromDcsXML } from "~/metadata/systemEnumerations/fromDcsXML"
-import { SystemEnumerationPropertyRule, SystemEnumerationTypeMap } from "~/metadata/systemEnumerations/types"
+import * as SystemEnumerations from "~/metadata/systemEnumerations/types"
+import type { SystemEnumerationPropertyRule, SystemEnumerationTypeMap } from "~/metadata/systemEnumerations/types"
 import { ConfigurationContextFromXML } from "../../../context/types"
 import {
   DcsMetadataValuePropertyRule,
@@ -104,6 +105,16 @@ const hasSystemEnumeration = (
   rule: DcsMetadataValuePropertyRule
 ): rule is DcsMetadataValuePropertyRule & { valueType: "SystemEnumeration"; typeSE: keyof SystemEnumerationTypeMap } =>
   rule.valueType === "SystemEnumeration" && rule.typeSE !== undefined
+
+const inferEntSystemEnumerationType = (xsi: string | undefined): keyof SystemEnumerationTypeMap | undefined => {
+  if (xsi === undefined || !xsi.startsWith("ent:")) return undefined
+
+  const typeName = xsi.slice("ent:".length)
+  const yamlMapName = `${typeName}ToYAML`
+  return Object.prototype.hasOwnProperty.call(SystemEnumerations, yamlMapName)
+    ? (typeName as keyof SystemEnumerationTypeMap)
+    : undefined
+}
 
 const importDcsMetadataValueFromDcsXMLInternal = (
   context: ConfigurationContextFromXML,
@@ -215,6 +226,15 @@ const importDcsMetadataValueFromDcsXMLInternal = (
     return importSystemEnumerationFromDcsXML(
       context,
       { type: "SystemEnumeration", typeSE: rule.typeSE } as SystemEnumerationPropertyRule,
+      xml as SystemEnumerationDcsValueRootXML
+    )
+  }
+
+  const inferredTypeSE = inferEntSystemEnumerationType(xsi)
+  if (inferredTypeSE !== undefined) {
+    return importSystemEnumerationFromDcsXML(
+      context,
+      { type: "SystemEnumeration", typeSE: inferredTypeSE } as SystemEnumerationPropertyRule,
       xml as SystemEnumerationDcsValueRootXML
     )
   }

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts
@@ -46,6 +46,17 @@ const xmlWithMultipleValues = `<Settings>
 	</Parameter>
 </Settings>`
 
+const xmlWithAccumulationRecordTypeValue = `<Settings>
+	<Parameter>
+		<dcssch:name>ВидДвижения</dcssch:name>
+		<dcssch:valueType>
+			<v8:Type>ent:AccumulationRecordType</v8:Type>
+		</dcssch:valueType>
+		<dcssch:value xsi:type="ent:AccumulationRecordType">Expense</dcssch:value>
+		<dcssch:useRestriction>true</dcssch:useRestriction>
+	</Parameter>
+</Settings>`
+
 const exportDCSParameters = (value: unknown, referenceMetadata?: unknown): string => {
   const xmlData = exportPropertyToXML({
     context: mockContextToXML(),
@@ -167,5 +178,27 @@ describe("import DCSParameter from XML", () => {
         ],
       },
     ])
+  })
+
+  it("imports and exports ent system enumeration value", () => {
+    const result = testImportPropertyFromXML({
+      rule,
+      xmlString: xmlWithAccumulationRecordTypeValue,
+      xmlRootTag: "Settings",
+    })
+
+    expect(result).toEqual([
+      {
+        itemType: "DCSParameter",
+        name: "ВидДвижения",
+        valueType: { type: ["AccumulationRecordType"] },
+        value: "Expense",
+        useRestriction: true,
+      },
+    ])
+
+    expect(exportDCSParameters(result)).toContain(
+      '<dcssch:value xsi:type="ent:AccumulationRecordType">Expense</dcssch:value>',
+    )
   })
 })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/toXML.ts
@@ -1,7 +1,11 @@
 import { exportMetadataItemToXML } from "~/metadata/orchestration"
+import type { MetadataItemRule } from "~/metadata/orchestration"
 import type { NamedElementXML } from "~/metadata/orchestration/metadataCollection/types"
 import type { ExportToXMLFunctionNew } from "~/metadata/orchestration/property/fn"
 import type { ItemXML } from "~/metadata/orchestration/property/types"
+import { resolveSystemEnumerationXsiType } from "~/metadata/systemEnumerations/toDcsXML"
+import * as SystemEnumerations from "~/metadata/systemEnumerations/types"
+import type { SystemEnumerationTypeMap } from "~/metadata/systemEnumerations/types"
 
 import { DCSParameterRules } from "./rules"
 import type { DCSParameter, DCSParameters } from "./types"
@@ -58,6 +62,44 @@ const omitValue = (item: DCSParameter): DCSParameter => {
   return itemWithoutValue
 }
 
+const getSingleValueTypeName = (item: DCSParameter): string | undefined => {
+  const valueType = item.valueType
+  if (!isObject(valueType)) return undefined
+
+  const type = valueType.type
+  if (!Array.isArray(type) || type.length !== 1) return undefined
+
+  return typeof type[0] === "string" ? type[0] : undefined
+}
+
+const inferEntSystemEnumerationType = (item: DCSParameter): keyof SystemEnumerationTypeMap | undefined => {
+  const typeName = getSingleValueTypeName(item)
+  if (typeName === undefined) return undefined
+
+  const yamlMapName = `${typeName}ToYAML`
+  if (!Object.prototype.hasOwnProperty.call(SystemEnumerations, yamlMapName)) return undefined
+
+  const typeSE = typeName as keyof SystemEnumerationTypeMap
+  return resolveSystemEnumerationXsiType(typeSE).startsWith("ent:") ? typeSE : undefined
+}
+
+const ruleForItem = (item: DCSParameter): MetadataItemRule => {
+  const typeSE = inferEntSystemEnumerationType(item)
+  if (typeSE === undefined) return DCSParameterRules
+
+  return {
+    ...DCSParameterRules,
+    properties: {
+      ...DCSParameterRules.properties,
+      value: {
+        ...DCSParameterRules.properties.value,
+        valueType: "SystemEnumeration",
+        typeSE,
+      },
+    },
+  } satisfies MetadataItemRule
+}
+
 export const exportDCSParametersToXML: ExportToXMLFunctionNew = (params) => {
   const data = params.value as DCSParameters | undefined
   const referenceData = params.referenceMetadata as DCSParameters | undefined
@@ -94,7 +136,7 @@ export const exportDCSParametersToXML: ExportToXMLFunctionNew = (params) => {
         context: params.context,
         data: item,
         referenceData: referenceForExport,
-        rule: DCSParameterRules,
+        rule: ruleForItem(item),
       }) as NamedElementXML | undefined) ?? {}
 
     if (referenceUndefinedValue !== undefined) {


### PR DESCRIPTION
## Summary
- add inferred import for known ent:* DCS system enumeration values
- export DCSParameter values as system enumerations when valueType provides a known ent:* type
- cover AccumulationRecordType import/export behavior

## Test plan
- pnpm --filter '@nakidka/core' test

## Notes
- round-trip triage no longer stops on ent:AccumulationRecordType; the next independent blocker is FillChecking missing in TypeDescriptionRules