### PR TITLE
Исправить пачку round-trip XML расхождений

### DIFF
--- a/docs/superpowers/plans/2026-05-14-round-trip-xml-next-5.md
+++ b/docs/superpowers/plans/2026-05-14-round-trip-xml-next-5.md
@@ -2,641 +2,964 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Fix the accepted short round-trip XML differences for `UserVisible`, DCS `attributeUseRestriction`, and empty form `ExtendedPresentation`.
+**Goal:** Исправить четыре согласованные причины round-trip XML расхождений и разблокировать следующий triage-прогон.
 
-**Architecture:** Keep fixes local to existing metadata rules and type handlers. Do not introduce new shared abstractions: `UserVisible` keeps a canonical platform reference string, `attributeUseRestriction` reuses `CalculatedFieldUseRestriction`, and form `ExtendedPresentation` uses existing empty XML defaults.
+**Architecture:** Все изменения остаются в metadata-слое и используют существующие `rules.ts`/type-rule механизмы. XML-цикл имеет приоритет: сначала точечные XML-тесты, затем минимальная реализация, затем YAML-поведение только для явной формы `dcscor:Field`.
 
-**Tech Stack:** TypeScript, Vitest, pnpm, existing `packages/core/metadata` orchestration rules.
+**Tech Stack:** TypeScript, Vitest, `pnpm`, `fast-xml-parser`, существующая orchestration property-система.
 
 ---
 
+## Source Spec
+
+- `docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md`
+
 ## File Structure
 
-- Modify `packages/core/metadata/commonObjects/userVisible/fromXML.ts`: preserve `xr:Value` `_name` exactly.
-- Modify `packages/core/metadata/commonObjects/userVisible/toXML.ts`: export `_name` exactly from `item.name`.
-- Modify `packages/core/metadata/commonObjects/userVisible/fromYAML.ts`: preserve YAML keys exactly.
-- Modify `packages/core/metadata/commonObjects/userVisible/toYAML.ts`: existing output already uses `item.name`; keep it and add coverage.
-- Modify `packages/core/tests/fixtures/userVisible/withMultipleValues.ts`: update model fixture names to match XML canonical names.
-- Modify `packages/core/tests/fixtures/userVisible/withSingleValue.ts`: update model fixture name to match XML canonical name.
-- Modify `packages/core/metadata/commonObjects/userVisible/fromXML.test.ts`: add UUID preservation coverage.
-- Modify `packages/core/metadata/commonObjects/userVisible/toXML.test.ts`: add UUID preservation coverage.
-- Modify `packages/core/metadata/commonObjects/userVisible/fromYAML.test.ts`: expect `Role.*` keys to remain `Role.*`.
-- Modify `packages/core/metadata/commonObjects/userVisible/toYAML.test.ts`: cover canonical `Role.*` keys and UUID keys.
-- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/rules.ts`: change `attributeUseRestriction` type.
-- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/fromXML.test.ts`: add inline XML round-trip for `attributeUseRestriction`.
-- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/fromYAML.test.ts`: add YAML import coverage for `attributeUseRestriction`.
-- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/toYAML.test.ts`: add YAML export coverage for `attributeUseRestriction`.
-- Modify `packages/core/metadata/forms/clientApplicationForm/rules.ts`: add empty XML defaults for `extendedPresentation`.
-- Modify `packages/core/metadata/forms/clientApplicationForm/fromXML.test.ts`: verify empty metadata `ExtendedPresentation` imports as empty `I8nText`.
-- Modify `packages/core/metadata/forms/clientApplicationForm/toXML.test.ts`: verify reference-only empty `ExtendedPresentation` is preserved and absent references still omit it.
+- Modify `packages/core/metadata/commonObjects/metadataAttribute/rules.ts`
+  - Add `defaultValueXMLRaw: ""` to `commonAttributeProperties.type`.
+- Modify `packages/core/metadata/commonObjects/metadataAttribute/toXML.test.ts`
+  - Add an inline XML test proving an empty `Type` property exports as `<Type/>`.
+- Modify `packages/core/metadata/commonObjects/typeDescription/types.ts`
+  - Add a property-rule extension for local type namespace declaration.
+  - Add the `dcsset` namespace to known `dcsset` type rules so export code has a source of truth.
+- Modify `packages/core/metadata/commonObjects/typeDescription/toXML.ts`
+  - Use the new property-rule flag to add `_xmlns:<prefix>` only when a property asks for it.
+- Modify `packages/core/metadata/commonObjects/typeDescription/toXML.test.ts`
+  - Add paired tests: one with local namespace requested, one without.
+- Modify `packages/core/metadata/appliedObjects/metadataDataProcessor/rules.ts`
+  - Override DataProcessor attribute type rules so `TypeDescription` locally declares the type namespace.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts`
+  - Extend YAML schema/types for explicit DCS text values.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts`
+  - Import `dcscor:Field` as `{ type: "Field", value }` when it appears under `DesignTimeValue`.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.ts`
+  - Parse explicit YAML form `{ Тип: Поле, Значение: ... }` into `{ type: "Field", value }`.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toYAML.ts`
+  - Export explicit field values to the explicit YAML form for `DesignTimeValue`.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts`
+  - Add inline fixture entries for XML/YAML typed field behavior.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts`
+  - Covered via fixture table.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.test.ts`
+  - Covered via fixture table.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.test.ts`
+  - Covered via fixture table.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toYAML.test.ts`
+  - Covered via fixture table.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts`
+  - Allow `undefined` as XML import/export result and allow reference-only `v8:Type`.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.ts`
+  - Import valid `v8:Type *:Undefined` as `undefined`, but preserve the raw object during reference import.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts`
+  - Restore valid reference `v8:Type *:Undefined` when model value is empty.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.test.ts`
+  - Add tests for normal import and reference import.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts`
+  - Add tests for restoration and invalid reference rejection.
 
-Before editing `packages/core/metadata/**`, read these project rules in the implementation session:
-
-```bash
-sed -n '1,220p' .agents/knowledge/metadata/INDEX.md
-sed -n '1,220p' .agents/knowledge/metadata/sources-of-truth.md
-sed -n '1,220p' .agents/knowledge/metadata/round-trip-cycle.md
-sed -n '1,220p' .agents/knowledge/metadata/metadata-item-implementation.md
-sed -n '1,220p' .agents/knowledge/metadata/registries.md
-```
-
-## Task 1: Preserve UserVisible Reference Names
+## Task 1: Preserve Empty MetadataAttribute Type
 
 **Files:**
-- Modify: `packages/core/metadata/commonObjects/userVisible/fromXML.ts`
-- Modify: `packages/core/metadata/commonObjects/userVisible/toXML.ts`
-- Modify: `packages/core/metadata/commonObjects/userVisible/fromYAML.ts`
-- Modify: `packages/core/metadata/commonObjects/userVisible/toYAML.ts`
-- Modify: `packages/core/tests/fixtures/userVisible/withMultipleValues.ts`
-- Modify: `packages/core/tests/fixtures/userVisible/withSingleValue.ts`
-- Test: `packages/core/metadata/commonObjects/userVisible/fromXML.test.ts`
-- Test: `packages/core/metadata/commonObjects/userVisible/toXML.test.ts`
-- Test: `packages/core/metadata/commonObjects/userVisible/fromYAML.test.ts`
-- Test: `packages/core/metadata/commonObjects/userVisible/toYAML.test.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataAttribute/rules.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataAttribute/toXML.test.ts`
 
-- [ ] **Step 1: Update UserVisible model fixtures to canonical XML names**
+- [ ] **Step 1: Write the failing test**
 
-In `packages/core/tests/fixtures/userVisible/withMultipleValues.ts`, replace the exported object with:
+Add this test inside `describe("export MetadataAttributes to XML", () => { ... })` in `packages/core/metadata/commonObjects/metadataAttribute/toXML.test.ts`:
 
 ```ts
-import { UserVisible } from "~/metadata/commonObjects/userVisible/types"
+  it("exports empty Type tag when attribute type is missing", () => {
+    const { result } = testExportPropertyToXML({
+      rule: MetadataAttributeRules.properties.type,
+      value: undefined,
+      xmlRootTag: "Type",
+    })
 
-export const withMultipleValuesUserVisible: UserVisible = {
-  common: true,
-  values: [
-    {
-      name: "Role.Администратор",
-      value: true,
-    },
-    {
-      name: "Role.Пользователь",
-      value: false,
-    },
-  ],
+    expect(result).toBe("<Type/>")
+  })
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/metadataAttribute/toXML.test.ts -t "exports empty Type tag when attribute type is missing"
+```
+
+Expected result before implementation:
+
+```text
+FAIL metadata/commonObjects/metadataAttribute/toXML.test.ts
+expected '<Type></Type>' or '<Type>undefined</Type>' or '' to be '<Type/>'
+```
+
+The exact XML serialization may differ, but the test must fail because `MetadataAttributeRules.properties.type` has no raw empty XML value yet.
+
+- [ ] **Step 3: Implement the minimal rule change**
+
+In `packages/core/metadata/commonObjects/metadataAttribute/rules.ts`, change `commonAttributeProperties.type` to:
+
+```ts
+  type: {
+    yaml: "Тип",
+    type: "TypeDescription",
+    xml: "Type",
+    useAsShortValueYAML: true,
+    xmlParents: ["Properties"],
+    order: 4,
+    defaultValueXMLRaw: "",
+  },
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/metadataAttribute/toXML.test.ts -t "exports empty Type tag when attribute type is missing"
+```
+
+Expected:
+
+```text
+PASS metadata/commonObjects/metadataAttribute/toXML.test.ts
+```
+
+- [ ] **Step 5: Run the metadataAttribute suite**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/metadataAttribute/toXML.test.ts metadata/commonObjects/metadataAttribute/fromXML.test.ts
+```
+
+Expected:
+
+```text
+PASS metadata/commonObjects/metadataAttribute/toXML.test.ts
+PASS metadata/commonObjects/metadataAttribute/fromXML.test.ts
+```
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/metadataAttribute/rules.ts packages/core/metadata/commonObjects/metadataAttribute/toXML.test.ts
+git commit -m "fix: :bug: сохранять пустой Type реквизита"
+```
+
+## Task 2: Add Contextual TypeDescription Namespace Declaration
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/typeDescription/types.ts`
+- Modify: `packages/core/metadata/commonObjects/typeDescription/toXML.ts`
+- Modify: `packages/core/metadata/commonObjects/typeDescription/toXML.test.ts`
+
+- [ ] **Step 1: Write failing TypeDescription tests**
+
+In `packages/core/metadata/commonObjects/typeDescription/toXML.test.ts`, add these tests after the existing generated platform type test:
+
+```ts
+  it("exports local type namespace when rule requests it", () => {
+    const resultXml = exportTypeDescriptionToXML(
+      mockContext,
+      { ...mockRule, declareTypeNamespaceXML: true },
+      { type: ["SettingsComposer"] }
+    )
+
+    const result = xmlExport({ TypeDescription: resultXml }, false)
+
+    expect(result).toEqual(
+      '<TypeDescription>\n\t<v8:Type xmlns:dcsset="http://v8.1c.ru/8.1/data-composition-system/settings">dcsset:SettingsComposer</v8:Type>\n</TypeDescription>'
+    )
+  })
+
+  it("does not export local type namespace by default", () => {
+    const resultXml = exportTypeDescriptionToXML(mockContext, mockRule, { type: ["SettingsComposer"] })
+
+    const result = xmlExport({ TypeDescription: resultXml }, false)
+
+    expect(result).toEqual("<TypeDescription>\n\t<v8:Type>dcsset:SettingsComposer</v8:Type>\n</TypeDescription>")
+  })
+```
+
+- [ ] **Step 2: Run tests and verify the new namespace test fails**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/typeDescription/toXML.test.ts -t "local type namespace"
+```
+
+Expected:
+
+```text
+FAIL metadata/commonObjects/typeDescription/toXML.test.ts
+```
+
+The default test should already pass; the requested namespace test should fail because `declareTypeNamespaceXML` is not implemented.
+
+- [ ] **Step 3: Add the property-rule extension and namespace source**
+
+In `packages/core/metadata/commonObjects/typeDescription/types.ts`, add the import near the top:
+
+```ts
+import type { BasePropertyRule } from "~/metadata/orchestration"
+```
+
+Add this exported type after `TypeDescriptionRule`:
+
+```ts
+export type TypeDescriptionPropertyRule = BasePropertyRule & {
+  type: "TypeDescription"
+  declareTypeNamespaceXML?: boolean
 }
 ```
 
-In `packages/core/tests/fixtures/userVisible/withSingleValue.ts`, replace the exported object with:
+Change these three `dcsset` rules so the namespace is available to the exporter:
 
 ```ts
-import { UserVisible } from "~/metadata/commonObjects/userVisible/types"
+  SettingsComposer: {
+    enterprise: "КомпоновщикНастроекКомпоновкиДанных",
+    prefix: "dcsset",
+    namespace: "http://v8.1c.ru/8.1/data-composition-system/settings",
+  },
+  Filter: {
+    enterprise: "Отбор",
+    prefix: "dcsset",
+    namespace: "http://v8.1c.ru/8.1/data-composition-system/settings",
+  },
+  DataCompositionComparisonType: {
+    enterprise: "DataCompositionComparisonType",
+    prefix: "dcsset",
+    namespace: "http://v8.1c.ru/8.1/data-composition-system/settings",
+  },
+```
 
-export const withSingleValueUserVisible: UserVisible = {
-  common: true,
-  values: [
-    {
-      name: "Role.Менеджер",
-      value: true,
+- [ ] **Step 4: Implement conditional namespace export**
+
+In `packages/core/metadata/commonObjects/typeDescription/toXML.ts`, update imports:
+
+```ts
+import { TypeDescription, TypeDescriptionPropertyRule, TypeDescriptionXML, TypeDescriptionXMLType } from "./types"
+```
+
+Change the function signature:
+
+```ts
+export const exportTypeDescriptionToXML = (
+  _context: ConfigurationContext,
+  rule: PropertyRule | undefined,
+  typeDescription: TypeDescription | undefined
+): TypeDescriptionXML | undefined => {
+```
+
+Inside the function, replace:
+
+```ts
+  const typesXML = getTypesXML(typeDescription)
+```
+
+with:
+
+```ts
+  const typesXML = getTypesXML(typeDescription, shouldDeclareTypeNamespace(rule))
+```
+
+Add this helper before `getTypesXML`:
+
+```ts
+const shouldDeclareTypeNamespace = (rule: PropertyRule | undefined): boolean =>
+  Boolean((rule as TypeDescriptionPropertyRule | undefined)?.declareTypeNamespaceXML)
+```
+
+Change `getTypesXML` signature:
+
+```ts
+const getTypesXML = (
+  typeDescription: TypeDescription,
+  declareTypeNamespace: boolean
+): {
+```
+
+Inside `getTypesXML`, replace the `item` construction with:
+
+```ts
+    const item =
+      declareTypeNamespace && rule.namespace
+        ? {
+            [`_xmlns:${rule.prefix}`]: rule.namespace,
+            "#text": typeXML,
+          }
+        : typeXML
+```
+
+- [ ] **Step 5: Run TypeDescription tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/typeDescription/toXML.test.ts
+```
+
+Expected:
+
+```text
+PASS metadata/commonObjects/typeDescription/toXML.test.ts
+```
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/typeDescription/types.ts packages/core/metadata/commonObjects/typeDescription/toXML.ts packages/core/metadata/commonObjects/typeDescription/toXML.test.ts
+git commit -m "fix: :bug: добавить локальный namespace TypeDescription"
+```
+
+## Task 3: Enable Local Type Namespace for DataProcessor Attributes
+
+**Files:**
+- Modify: `packages/core/metadata/appliedObjects/metadataDataProcessor/rules.ts`
+- Modify: `packages/core/metadata/appliedObjects/metadataDataProcessor/toXML.test.ts`
+
+- [ ] **Step 1: Write the failing DataProcessor export test**
+
+In `packages/core/metadata/appliedObjects/metadataDataProcessor/toXML.test.ts`, import `testExportPropertyToXML` and `MetadataDataProcessorRules` if they are not already imported:
+
+```ts
+import { testExportPropertyToXML } from "~/tests/property/exportPropertyToXML"
+import { MetadataDataProcessorRules } from "./rules"
+```
+
+Add this test:
+
+```ts
+  it("exports attribute SettingsComposer type with local dcsset namespace", () => {
+    const { result } = testExportPropertyToXML({
+      rule: MetadataDataProcessorRules.properties.attributes,
+      value: [
+        {
+          uuid: "8a57d427-a34e-4121-84e6-1a86a9f9092d",
+          name: "КомпоновщикОтбораВсехДокументов",
+          synonym: { items: { ru: "Компоновщик отбора всех документов" } },
+          type: { type: ["SettingsComposer"] },
+        },
+      ],
+      xmlRootTag: "Attribute",
+    })
+
+    expect(result).toContain(
+      '<v8:Type xmlns:dcsset="http://v8.1c.ru/8.1/data-composition-system/settings">dcsset:SettingsComposer</v8:Type>'
+    )
+  })
+```
+
+- [ ] **Step 2: Run the focused DataProcessor test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/appliedObjects/metadataDataProcessor/toXML.test.ts -t "exports attribute SettingsComposer type with local dcsset namespace"
+```
+
+Expected:
+
+```text
+FAIL metadata/appliedObjects/metadataDataProcessor/toXML.test.ts
+```
+
+- [ ] **Step 3: Override DataProcessor attribute rules**
+
+In `packages/core/metadata/appliedObjects/metadataDataProcessor/rules.ts`, add imports:
+
+```ts
+import { MetadataAttributeRules } from "~/metadata/commonObjects/metadataAttribute/rules"
+```
+
+Add this constant before `export const MetadataDataProcessorRules`:
+
+```ts
+const MetadataDataProcessorAttributeRules = {
+  ...MetadataAttributeRules,
+  properties: {
+    ...MetadataAttributeRules.properties,
+    type: {
+      ...MetadataAttributeRules.properties.type,
+      declareTypeNamespaceXML: true,
     },
-  ],
+  },
+} as const satisfies MetadataItemRule
+```
+
+Change the `attributes` property from:
+
+```ts
+    attributes: {
+      yaml: "Реквизиты",
+      type: "MetadataAttributes",
+      xmlParents: childObjects,
+      xml: "Attribute",
+    },
+```
+
+to:
+
+```ts
+    attributes: {
+      yaml: "Реквизиты",
+      type: "MetadataAttributes",
+      itemRule: MetadataDataProcessorAttributeRules,
+      xmlParents: childObjects,
+      xml: "Attribute",
+    },
+```
+
+- [ ] **Step 4: Run DataProcessor and TypeDescription tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/appliedObjects/metadataDataProcessor/toXML.test.ts metadata/commonObjects/typeDescription/toXML.test.ts
+```
+
+Expected:
+
+```text
+PASS metadata/appliedObjects/metadataDataProcessor/toXML.test.ts
+PASS metadata/commonObjects/typeDescription/toXML.test.ts
+```
+
+- [ ] **Step 5: Run form attribute guard tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/forms/commonObjects/formAttribute/toXML.test.ts metadata/commonObjects/typeDescription/toXML.test.ts -t "does not export local type namespace by default"
+```
+
+Expected:
+
+```text
+PASS
+```
+
+This verifies the namespace flag is not global.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add packages/core/metadata/appliedObjects/metadataDataProcessor/rules.ts packages/core/metadata/appliedObjects/metadataDataProcessor/toXML.test.ts
+git commit -m "fix: :bug: объявлять dcsset для реквизитов обработки"
+```
+
+## Task 4: Preserve dcscor:Field and Add Explicit YAML Form
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts`
+- Existing fixture-table tests cover:
+  - `fromXML.test.ts`
+  - `toXML.test.ts`
+  - `fromYAML.test.ts`
+  - `toYAML.test.ts`
+
+- [ ] **Step 1: Add fixture cases that fail**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts`, add these exports near other fixture constants:
+
+```ts
+export const fixtureDesignTimeFieldPath = "Сертификаты.СертификатПредставление"
+export const yamlDesignTimeFieldExplicit = {
+  Тип: "Поле",
+  Значение: fixtureDesignTimeFieldPath,
+} as const
+```
+
+Add this fixture before `export const dcsMetadataValueFixtures`:
+
+```ts
+const designTimeFieldFixture: DcsMetadataValueFixture = {
+  id: "designTimeField",
+  title: "DesignTimeValue explicit Field",
+  rule: { type: "MetadataDcsMetadataValue", valueType: "DesignTimeValue", yaml: "value" },
+  value: {
+    type: "Field",
+    value: fixtureDesignTimeFieldPath,
+  },
+  yaml: yamlDesignTimeFieldExplicit,
+  xml: "design-time-field.xml",
 }
 ```
 
-- [ ] **Step 2: Add a failing XML import test for mixed Role and UUID names**
+Add `designTimeFieldFixture` to both `dcsMetadataValueXMLFixtures` and `dcsMetadataValueFromXMLFixtures`.
 
-Append this test to `describe("importUserVisibleFromXML", ...)` in `packages/core/metadata/commonObjects/userVisible/fromXML.test.ts`:
+Create `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/design-time-field.xml` with:
 
-```ts
-  it("preserves Role-prefixed names and UUID names exactly", () => {
-    const result = importUserVisibleFromXML(mockContextFromXML(), mockRule, {
-      "xr:Common": "false",
-      "xr:Value": [
-        { _name: "Role.ПолныеПрава", "#text": "true" },
-        { _name: "b1d9c8b4-d05c-45c7-8db2-abc84e597700", "#text": "true" },
-      ],
-    })
-
-    expect(result).toEqual({
-      common: false,
-      values: [
-        { name: "Role.ПолныеПрава", value: true },
-        { name: "b1d9c8b4-d05c-45c7-8db2-abc84e597700", value: true },
-      ],
-    })
-  })
+```xml
+<dcscor:value xsi:type="dcscor:Field">Сертификаты.СертификатПредставление</dcscor:value>
 ```
 
-- [ ] **Step 3: Add a failing XML export test for mixed Role and UUID names**
-
-Append this test to `describe("exportUserVisibleToXML", ...)` in `packages/core/metadata/commonObjects/userVisible/toXML.test.ts`:
-
-```ts
-  it("exports Role-prefixed names and UUID names exactly", () => {
-    const mockUserVisible: UserVisible = {
-      common: false,
-      values: [
-        { name: "Role.ПолныеПрава", value: true },
-        { name: "b1d9c8b4-d05c-45c7-8db2-abc84e597700", value: true },
-      ],
-    }
-
-    const exported = exportUserVisibleToXML(mockContext, mockRule, mockUserVisible)
-    const xmlString = xmlExport({ UserVisible: exported }, false)
-
-    expect(xmlString).toEqual(`<UserVisible>
-	<xr:Common>false</xr:Common>
-	<xr:Value name="Role.ПолныеПрава">true</xr:Value>
-	<xr:Value name="b1d9c8b4-d05c-45c7-8db2-abc84e597700">true</xr:Value>
-</UserVisible>`)
-  })
-```
-
-- [ ] **Step 4: Update YAML import tests to preserve technical keys**
-
-In `packages/core/metadata/commonObjects/userVisible/fromYAML.test.ts`, change both expected arrays from:
-
-```ts
-      values: [
-        { name: "Администратор", value: true },
-        { name: "Пользователь", value: false },
-      ],
-```
-
-to:
-
-```ts
-      values: [
-        { name: "Role.Администратор", value: true },
-        { name: "Role.Пользователь", value: false },
-      ],
-```
-
-Then append this UUID test:
-
-```ts
-  it("preserves UUID YAML keys", () => {
-    const mock = {
-      "b1d9c8b4-d05c-45c7-8db2-abc84e597700": "Истина" as const,
-    }
-
-    const result = importUserVisibleFromYAMLDeprecated(mockContext, mockRule, mock, undefined)
-
-    expect(result).toEqual({
-      common: true,
-      values: [{ name: "b1d9c8b4-d05c-45c7-8db2-abc84e597700", value: true }],
-    })
-  })
-```
-
-- [ ] **Step 5: Update YAML export tests to use canonical keys**
-
-In `packages/core/metadata/commonObjects/userVisible/toYAML.test.ts`, change both test input values from:
-
-```ts
-        { name: "Администратор", value: true },
-        { name: "Пользователь", value: false },
-```
-
-to:
-
-```ts
-        { name: "Role.Администратор", value: true },
-        { name: "Role.Пользователь", value: false },
-```
-
-Change both expected YAML maps from:
-
-```ts
-        Администратор: "Истина",
-        Пользователь: "Ложь",
-```
-
-to:
-
-```ts
-        "Role.Администратор": "Истина",
-        "Role.Пользователь": "Ложь",
-```
-
-Then append this UUID test:
-
-```ts
-  it("preserves UUID YAML keys", () => {
-    const use: UserVisible = {
-      common: true,
-      values: [{ name: "b1d9c8b4-d05c-45c7-8db2-abc84e597700", value: true }],
-    }
-
-    const result = exportUserVisibleToYAMLDeprecated(mockContext, mockRule, use, {
-      allow: UserVisibleKeysYAML.Allow,
-      deny: UserVisibleKeysYAML.Deny,
-    })
-
-    expect(result).toEqual({
-      РазрешитьИспользование: {
-        "b1d9c8b4-d05c-45c7-8db2-abc84e597700": "Истина",
-      },
-    })
-  })
-```
-
-- [ ] **Step 6: Run UserVisible tests and verify they fail for the expected reason**
+- [ ] **Step 2: Run focused DCS value tests and verify failures**
 
 Run:
 
 ```bash
-pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/userVisible
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toYAML.test.ts -t "DesignTimeValue explicit Field"
 ```
 
-Expected: tests fail because implementation strips `Role.` on import/YAML import and adds `Role.` on XML export.
+Expected:
 
-- [ ] **Step 7: Implement minimal UserVisible preservation**
+```text
+FAIL
+```
 
-In `packages/core/metadata/commonObjects/userVisible/fromXML.ts`, replace:
+The XML import currently returns a string, and YAML explicit form is not supported.
+
+- [ ] **Step 3: Extend DCS metadata value YAML types**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts`, add:
 
 ```ts
-        name: item["_name"].replace(/^Role\./, ""),
+export type MetadataDcsExplicitTextValueYAML =
+  | {
+      Тип: "Поле"
+      Значение: string
+    }
+  | {
+      Тип: "ЗначениеВремениПроектирования"
+      Значение: string
+    }
+```
+
+Add `MetadataDcsExplicitTextValueYAML` to `MetadataDcsMetadataSingleValueYAML`:
+
+```ts
+export type MetadataDcsMetadataSingleValueYAML =
+  | null
+  | MetadataDcsExplicitTextValueYAML
+  | ColorYAML
+  | MetadataFieldYAML
+  | ChoiceParametersYAML
+  | I8nTextYAML
+  | MetadataValueYAML
+  | TypeLinkYAML
+  | ChoiceParameterLinksYAML
+  | FontYAML
+  | string
+```
+
+- [ ] **Step 4: Preserve dcscor:Field on XML import for DesignTimeValue**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts`, replace:
+
+```ts
+  if (xsi === "dcscor:Field") {
+    return textNode(root as string | { "#text"?: string })
+  }
 ```
 
 with:
 
 ```ts
-        name: item["_name"],
+  if (xsi === "dcscor:Field") {
+    const value = textNode(root as string | { "#text"?: string })
+    return rule.valueType === "DesignTimeValue" ? { type: "Field", value } : value
+  }
 ```
 
-In `packages/core/metadata/commonObjects/userVisible/toXML.ts`, replace:
+- [ ] **Step 5: Parse explicit YAML form**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.ts`, add this helper after `isEnterpriseDesignTimeValue`:
 
 ```ts
-      _name: `Role.${item.name}`,
+const importExplicitTextValueFromYAML = (data: unknown): MetadataDcsMetadataValue | undefined => {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return undefined
+  const record = data as Record<string, unknown>
+  if (record["Тип"] === "Поле" && typeof record["Значение"] === "string") {
+    return { type: "Field", value: record["Значение"] }
+  }
+  if (record["Тип"] === "ЗначениеВремениПроектирования" && typeof record["Значение"] === "string") {
+    return { type: "DesignTimeValue", value: record["Значение"] }
+  }
+  return undefined
+}
 ```
 
-with:
+In the `case "DesignTimeValue":` branch, add this as the first statement:
 
 ```ts
-      _name: item.name,
+      const explicitTextValue = importExplicitTextValueFromYAML(data)
+      if (explicitTextValue !== undefined) return explicitTextValue
 ```
 
-In `packages/core/metadata/commonObjects/userVisible/fromYAML.ts`, replace both occurrences of:
+- [ ] **Step 6: Export explicit YAML form**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toYAML.ts`, replace the `isExplicitTextValue(data)` branch with:
 
 ```ts
-    const name = key.replace(/^Role\./, "")
+  if (isExplicitTextValue(data)) {
+    if (rule.valueType === "DesignTimeValue") {
+      return {
+        Тип: data.type === "Field" ? "Поле" : "ЗначениеВремениПроектирования",
+        Значение: data.value,
+      } as MetadataDcsMetadataValueYAML
+    }
+
+    if (data.type === "DesignTimeValue") {
+      return (exportMetadataValueStringToYAML(context, undefined, data.value) ?? data.value) as MetadataDcsMetadataValueYAML
+    }
+
+    return (exportMetadataFieldStringToYAML(context, undefined, data.value) ?? data.value) as MetadataDcsMetadataValueYAML
+  }
 ```
 
-with:
-
-```ts
-    const name = key
-```
-
-No change is needed in `packages/core/metadata/commonObjects/userVisible/toYAML.ts` because it already uses `values[item.name]`.
-
-- [ ] **Step 8: Run UserVisible tests and verify they pass**
+- [ ] **Step 7: Run focused DCS value tests**
 
 Run:
 
 ```bash
-pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/userVisible
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toYAML.test.ts -t "DesignTimeValue explicit Field"
 ```
 
-Expected: all `userVisible` tests pass.
+Expected:
 
-- [ ] **Step 9: Commit Task 1**
+```text
+PASS
+```
+
+- [ ] **Step 8: Run full DCS value tests**
 
 Run:
 
 ```bash
-git add packages/core/metadata/commonObjects/userVisible/fromXML.ts packages/core/metadata/commonObjects/userVisible/toXML.ts packages/core/metadata/commonObjects/userVisible/fromYAML.ts packages/core/metadata/commonObjects/userVisible/toYAML.test.ts packages/core/metadata/commonObjects/userVisible/fromYAML.test.ts packages/core/metadata/commonObjects/userVisible/fromXML.test.ts packages/core/metadata/commonObjects/userVisible/toXML.test.ts packages/core/tests/fixtures/userVisible/withMultipleValues.ts packages/core/tests/fixtures/userVisible/withSingleValue.ts
-git commit -m "fix: :bug: сохранить имена UserVisible"
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/dataCompositionSystem/dcsMetadataValue
 ```
 
-## Task 2: Preserve DCS attributeUseRestriction
+Expected:
+
+```text
+PASS
+```
+
+- [ ] **Step 9: Commit Task 4**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue
+git commit -m "fix: :bug: сохранять DCS Field в DesignTimeValue"
+```
+
+## Task 5: Restore DcsMetadataTypedValue v8:Type Undefined From Reference
 
 **Files:**
-- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/rules.ts`
-- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/fromXML.test.ts`
-- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/fromYAML.test.ts`
-- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/toYAML.test.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.test.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts`
 
-- [ ] **Step 1: Add a failing XML round-trip test for attributeUseRestriction**
+- [ ] **Step 1: Write failing import tests**
 
-In `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/fromXML.test.ts`, add this constant after `xmlWithStringTitle`:
-
-```ts
-const xmlWithAttributeUseRestriction = `<Field xsi:type="dcssch:DataSetFieldField">
-	<dcssch:dataPath>МЧД</dcssch:dataPath>
-	<dcssch:field>МЧД</dcssch:field>
-	<dcssch:attributeUseRestriction>
-		<dcssch:field>true</dcssch:field>
-		<dcssch:condition>true</dcssch:condition>
-		<dcssch:group>true</dcssch:group>
-		<dcssch:order>true</dcssch:order>
-	</dcssch:attributeUseRestriction>
-</Field>`
-```
-
-Append this test to `describe("import DataCompositionSchemaDataSetField from XML", ...)`:
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.test.ts`, add:
 
 ```ts
-  it("round-trips attributeUseRestriction", () => {
+  it("imports v8 Type Undefined as missing value", () => {
     const result = testImportPropertyFromXML({
       rule,
-      xmlString: xmlWithAttributeUseRestriction,
-      xmlRootTag: "Field",
+      xmlRootTag: "value",
+      xmlString:
+        '<value xmlns:d8p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d8p1:Undefined</value>',
     })
 
-    expect(result).toEqual({
-      itemType: "DataCompositionSchemaDataSetField",
-      kind: "ПолеНабораДанныхСхемыКомпоновкиДанных",
-      dataPath: "МЧД",
-      field: "МЧД",
-      attributeUseRestriction: {
-        itemType: "CalculatedFieldUseRestriction",
-        field: true,
-        condition: true,
-        group: true,
-        order: true,
-      },
-    })
-
-    const exported = exportDataCompositionSchemaDataSetField(result)
-
-    expect(exported).toEqual(xmlWithAttributeUseRestriction)
+    expect(result).toBeUndefined()
   })
-```
 
-- [ ] **Step 2: Add failing YAML import coverage**
-
-Append this test to `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/fromYAML.test.ts`:
-
-```ts
-  it("imports attribute use restriction", () => {
-    const result = testImportPropertyFromYAML({
-      rule: { type: "DataCompositionSchemaDataSetField" },
-      value: {
-        Вид: "ПолеНабораДанныхСхемыКомпоновкиДанных",
-        ПутьКДанным: "МЧД",
-        Поле: "МЧД",
-        ОграничениеИспользованияРеквизитов: {
-          Поле: "Истина",
-          Условие: "Истина",
-          Группировка: "Истина",
-          Порядок: "Истина",
-        },
-      },
+  it("imports reference v8 Type Undefined as raw XML", () => {
+    const result = testImportPropertyFromXML({
+      rule,
+      xmlRootTag: "value",
+      xmlString:
+        '<value xmlns:d8p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d8p1:Undefined</value>',
+      forReference: true,
     })
 
     expect(result).toEqual({
-      itemType: "DataCompositionSchemaDataSetField",
-      kind: "ПолеНабораДанныхСхемыКомпоновкиДанных",
-      dataPath: "МЧД",
-      field: "МЧД",
-      attributeUseRestriction: {
-        itemType: "CalculatedFieldUseRestriction",
-        field: true,
-        condition: true,
-        group: true,
-        order: true,
-      },
+      "_xmlns:d8p1": "http://v8.1c.ru/8.2/data/types",
+      "_xsi:type": "v8:Type",
+      "#text": "d8p1:Undefined",
     })
   })
 ```
 
-- [ ] **Step 3: Add failing YAML export coverage**
+- [ ] **Step 2: Write failing export tests**
 
-Append this test to `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/toYAML.test.ts`:
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts`, add:
 
 ```ts
-  it("exports attribute use restriction", () => {
-    const result = testExportPropertyToYAML({
-      rule: { type: "DataCompositionSchemaDataSetField", yaml: "ПолеНабораДанныхСхемыКомпоновкиДанных" },
-      value: {
-        itemType: "DataCompositionSchemaDataSetField",
-        kind: "ПолеНабораДанныхСхемыКомпоновкиДанных",
-        dataPath: "МЧД",
-        field: "МЧД",
-        attributeUseRestriction: {
-          itemType: "CalculatedFieldUseRestriction",
-          field: true,
-          condition: true,
-          group: true,
-          order: true,
-        },
-      },
+const undefinedTypeReferenceValue = {
+  "_xmlns:d8p1": "http://v8.1c.ru/8.2/data/types",
+  "_xsi:type": "v8:Type",
+  "#text": "d8p1:Undefined",
+}
+```
+
+Add tests inside `describe("export DcsMetadataTypedValue to XML", () => { ... })`:
+
+```ts
+  it("exports missing value from reference v8 Type Undefined", () => {
+    const { result } = testExportPropertyToXML({
+      rule,
+      value: undefined,
+      referenceMetadata: undefinedTypeReferenceValue,
+      xmlRootTag: "value",
     })
 
-    expect(result).toEqual({
-      ПолеНабораДанныхСхемыКомпоновкиДанных: {
-        Вид: "ПолеНабораДанныхСхемыКомпоновкиДанных",
-        ПутьКДанным: "МЧД",
-        Поле: "МЧД",
-        ОграничениеИспользованияРеквизитов: {
-          Поле: "Истина",
-          Условие: "Истина",
-          Группировка: "Истина",
-          Порядок: "Истина",
-        },
-      },
-    })
-  })
-```
-
-- [ ] **Step 4: Run DataCompositionSchemaDataSetField tests and verify they fail**
-
-Run:
-
-```bash
-pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField
-```
-
-Expected: new tests fail because `attributeUseRestriction` is currently handled as `string`.
-
-- [ ] **Step 5: Implement the rule change**
-
-In `packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/rules.ts`, replace:
-
-```ts
-    attributeUseRestriction: {
-      type: "string",
-      xml: "dcssch:attributeUseRestriction",
-      yaml: "ОграничениеИспользованияРеквизитов",
-      toXML: isField,
-      order: 6,
-    },
-```
-
-with:
-
-```ts
-    attributeUseRestriction: {
-      type: "CalculatedFieldUseRestriction",
-      xml: "dcssch:attributeUseRestriction",
-      yaml: "ОграничениеИспользованияРеквизитов",
-      toXML: isField,
-      order: 6,
-    },
-```
-
-- [ ] **Step 6: Run DataCompositionSchemaDataSetField tests and verify they pass**
-
-Run:
-
-```bash
-pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField
-```
-
-Expected: all `dataCompositionSchemaDataSetField` tests pass.
-
-- [ ] **Step 7: Commit Task 2**
-
-Run:
-
-```bash
-git add packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/rules.ts packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/fromXML.test.ts packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/fromYAML.test.ts packages/core/metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField/toYAML.test.ts
-git commit -m "fix: :bug: сохранить attributeUseRestriction"
-```
-
-## Task 3: Preserve Empty Form ExtendedPresentation From Reference
-
-**Files:**
-- Modify: `packages/core/metadata/forms/clientApplicationForm/rules.ts`
-- Test: `packages/core/metadata/forms/clientApplicationForm/fromXML.test.ts`
-- Test: `packages/core/metadata/forms/clientApplicationForm/toXML.test.ts`
-
-- [ ] **Step 1: Add a failing import test for empty ExtendedPresentation**
-
-In `packages/core/metadata/forms/clientApplicationForm/fromXML.test.ts`, append this test to `describe("importClientApplicationFormFromXML", ...)`:
-
-```ts
-  it("imports explicit empty ExtendedPresentation from metadata XML", () => {
-    const xmlData = readAndParseXMLFixture<{ Form: ClientApplicationFormXML }>(import.meta.url, "minimal.xml")
-    const xmlMetadata = readAndParseXMLFixture<{ MetaDataObject: FormMetadataXML }>(
-      import.meta.url,
-      "minimalMetadata.xml"
+    expect(result).toEqual(
+      '<value xmlns:d8p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d8p1:Undefined</value>'
     )
-    xmlMetadata.MetaDataObject.Form.Properties.ExtendedPresentation = ""
+  })
 
-    const result = importClientApplicationFormFromXML({
-      context: mockContextFromXML(),
-      xml: xmlData.Form,
-      xmlMetadata: xmlMetadata.MetaDataObject,
+  it("does not export invalid reference v8 Type value", () => {
+    const { result } = testExportPropertyToXML({
+      rule,
+      value: undefined,
+      referenceMetadata: {
+        ...undefinedTypeReferenceValue,
+        "#text": "d8p1:String",
+      },
+      xmlRootTag: "value",
     })
 
-    expect(result.extendedPresentation).toEqual({ items: {} })
+    expect(result).toEqual("<value/>")
   })
 ```
 
-- [ ] **Step 2: Add a failing export test for reference-only empty ExtendedPresentation**
-
-In `packages/core/metadata/forms/clientApplicationForm/toXML.test.ts`, append this test inside `describe("exportFormMetadataToXML", ...)`:
-
-```ts
-    it("preserves empty ExtendedPresentation when it exists in reference metadata", () => {
-      const minimalFormXML = readAndParseXMLFixture<{ Form: ClientApplicationFormXML }>(import.meta.url, "minimal.xml")
-      const minimalMetadataXML = readAndParseXMLFixture<{ MetaDataObject: FormMetadataXML }>(
-        import.meta.url,
-        "minimalMetadata.xml"
-      )
-      minimalMetadataXML.MetaDataObject.Form.Properties.ExtendedPresentation = ""
-      const referenceForm = importClientApplicationFormFromXML({
-        context: mockContextFromXML({ forReference: true }),
-        xml: minimalFormXML.Form,
-        xmlMetadata: minimalMetadataXML.MetaDataObject,
-      })
-
-      const xmlData = exportFormMetadataToXML({
-        context: mockContextToXML(),
-        form: minimalClientApplicationForm,
-        referenceForm,
-        name: "Минимальная",
-      })
-
-      const result = xmlExport({ MetaDataObject: xmlData })
-
-      expect(result).toContain("\n\t\t\t<ExtendedPresentation/>")
-    })
-```
-
-- [ ] **Step 3: Add an explicit absence assertion for metadata without reference tag**
-
-In the existing `it("should export minimal", ...)` test inside `describe("exportFormMetadataToXML", ...)`, add this assertion after `expect(result).toEqual(expectedResult)`:
-
-```ts
-      expect(result).not.toContain("<ExtendedPresentation")
-```
-
-- [ ] **Step 4: Run ClientApplicationForm tests and verify they fail**
+- [ ] **Step 3: Run focused tests and verify failures**
 
 Run:
 
 ```bash
-pnpm --filter @nakidka/core exec vitest run metadata/forms/clientApplicationForm
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts -t "v8 Type"
 ```
 
-Expected: the new empty `ExtendedPresentation` tests fail because the rule does not keep empty `I8nText` XML nodes yet.
+Expected:
 
-- [ ] **Step 5: Implement empty XML defaults for form extendedPresentation**
+```text
+FAIL
+```
 
-In `packages/core/metadata/forms/clientApplicationForm/rules.ts`, replace:
+The import currently throws unsupported `_xsi:type v8:Type`; export currently ignores reference raw XML.
+
+- [ ] **Step 4: Extend typed value XML type**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts`, add this union member to `DcsMetadataTypedValueXML`:
 
 ```ts
-    extendedPresentation: {
-      yaml: "РасширенноеПредставление",
-      type: "I8nText",
-      tag: FormRulesTags.Metadata,
-      xml: "ExtendedPresentation",
-      xmlParents: ["Form", "Properties"],
-    },
+  | {
+      "_xsi:type": "v8:Type"
+      "#text"?: string
+      [key: `_xmlns:${string}`]: string | undefined
+    }
 ```
 
-with:
+- [ ] **Step 5: Implement v8 Type Undefined import**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.ts`, change imports to include `ConfigurationContextFromXML` as already present.
+
+Add helpers above `importSingle`:
 
 ```ts
-    extendedPresentation: {
-      yaml: "РасширенноеПредставление",
-      type: "I8nText",
-      tag: FormRulesTags.Metadata,
-      xml: "ExtendedPresentation",
-      xmlParents: ["Form", "Properties"],
-      defaultValueXMLEmpty: { items: {} },
-      defaultValueXMLRaw: "",
-    },
+const getUndefinedTypePrefix = (xml: DcsMetadataTypedValueXML): string | undefined => {
+  if (xml["_xsi:type"] !== "v8:Type") return undefined
+  const text = "#text" in xml ? xml["#text"] : undefined
+  if (typeof text !== "string") return undefined
+  const parts = text.split(":")
+  if (parts.length !== 2) return undefined
+  const [prefix, name] = parts
+  return prefix !== "" && name === "Undefined" ? prefix : undefined
+}
+
+const asReferenceUndefinedTypeValueXML = (
+  xml: DcsMetadataTypedValueXML,
+  prefix: string
+): DcsMetadataTypedValueXML | undefined => {
+  const namespaceKey = `_xmlns:${prefix}`
+  return typeof (xml as Record<string, unknown>)[namespaceKey] === "string" ? xml : undefined
+}
 ```
 
-- [ ] **Step 6: Run ClientApplicationForm tests and verify they pass**
+Change `importSingle` return type and body:
+
+```ts
+const importSingle = (
+  context: ConfigurationContextFromXML,
+  rule: DcsMetadataTypedValuePropertyRule,
+  xml: DcsMetadataTypedValueXML
+): DcsMetadataTypedValue | undefined => {
+  const undefinedTypePrefix = getUndefinedTypePrefix(xml)
+  if (undefinedTypePrefix !== undefined) {
+    return context.fromXML.forReference ? asReferenceUndefinedTypeValueXML(xml, undefinedTypePrefix) as unknown as DcsMetadataTypedValue : undefined
+  }
+
+  const type = DcsMetadataTypedValueTypeFromXML(xml["_xsi:type"])
+  return DcsMetadataTypedValueRegistry[type].fromXML({ context, rule, xml })
+}
+```
+
+Change `importDcsMetadataTypedValueFromXML` return type and array handling:
+
+```ts
+): DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined => {
+  if (xml === undefined) return undefined
+  if (Array.isArray(xml)) {
+    const values = xml
+      .map((item) => importSingle(context, rule, item))
+      .filter((item): item is DcsMetadataTypedValue => item !== undefined)
+    return values.length > 0 ? values : undefined
+  }
+  return importSingle(context, rule, xml)
+}
+```
+
+- [ ] **Step 6: Implement reference restoration on export**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts`, add helpers above `exportSingle`:
+
+```ts
+type ReferenceUndefinedTypeValueXML = DcsMetadataTypedValueXML & {
+  "_xsi:type": "v8:Type"
+  "#text": string
+}
+
+const getReferenceUndefinedTypeValue = (value: unknown): ReferenceUndefinedTypeValueXML | undefined => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const record = value as Record<string, unknown>
+  if (record["_xsi:type"] !== "v8:Type") return undefined
+  const text = record["#text"]
+  if (typeof text !== "string") return undefined
+  const parts = text.split(":")
+  if (parts.length !== 2) return undefined
+  const [prefix, name] = parts
+  if (prefix === "" || name !== "Undefined") return undefined
+  const namespaceKey = `_xmlns:${prefix}`
+  return typeof record[namespaceKey] === "string" ? (value as ReferenceUndefinedTypeValueXML) : undefined
+}
+```
+
+Change `exportDcsMetadataTypedValueToXML` signature to accept `referenceMetadata`:
+
+```ts
+export const exportDcsMetadataTypedValueToXML = (
+  context: ConfigurationContextWithExportToXML,
+  rule: DcsMetadataTypedValuePropertyRule,
+  value: DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined,
+  referenceMetadata?: unknown
+): DcsMetadataTypedValueXML | DcsMetadataTypedValueXML[] | undefined => {
+  if (value === undefined) return getReferenceUndefinedTypeValue(referenceMetadata)
+  if (Array.isArray(value)) return value.map((item) => exportSingle(context, rule, item))
+  return exportSingle(context, rule, value)
+}
+```
+
+Change the wrapper to pass reference metadata:
+
+```ts
+const exportDcsMetadataTypedValueToXMLForRule = (
+  context: ConfigurationContextWithExportToXML,
+  rule: PropertyRule,
+  value: unknown,
+  referenceMetadata?: unknown
+): DcsMetadataTypedValueXML | DcsMetadataTypedValueXML[] | undefined =>
+  exportDcsMetadataTypedValueToXML(
+    context,
+    rule as DcsMetadataTypedValuePropertyRule,
+    value as DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined,
+    referenceMetadata
+  )
+```
+
+- [ ] **Step 7: Run focused typed value tests**
 
 Run:
 
 ```bash
-pnpm --filter @nakidka/core exec vitest run metadata/forms/clientApplicationForm
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts -t "v8 Type"
 ```
 
-Expected: all `clientApplicationForm` tests pass.
+Expected:
 
-- [ ] **Step 7: Commit Task 3**
+```text
+PASS
+```
+
+- [ ] **Step 8: Run full typed value tests**
 
 Run:
 
 ```bash
-git add packages/core/metadata/forms/clientApplicationForm/rules.ts packages/core/metadata/forms/clientApplicationForm/fromXML.test.ts packages/core/metadata/forms/clientApplicationForm/toXML.test.ts
-git commit -m "fix: :bug: сохранить пустой ExtendedPresentation"
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue
 ```
 
-## Task 4: Verify Integrated Round-Trip Fixes
+Expected:
+
+```text
+PASS
+```
+
+- [ ] **Step 9: Commit Task 5**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue
+git commit -m "fix: :bug: восстанавливать DCS v8 Type Undefined"
+```
+
+## Task 6: Verify Integrated Round-Trip Behavior
 
 **Files:**
-- No code files changed in this task.
+- No new source files.
+- Uses all files changed in Tasks 1-5.
 
-- [ ] **Step 1: Run focused metadata tests for all changed areas**
+- [ ] **Step 1: Run focused metadata suites**
 
 Run:
 
 ```bash
-pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/userVisible metadata/commonObjects/dataCompositionSystem/dataCompositionSchemaDataSetField metadata/forms/clientApplicationForm
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/metadataAttribute metadata/commonObjects/typeDescription metadata/appliedObjects/metadataDataProcessor metadata/commonObjects/dataCompositionSystem/dcsMetadataValue metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue
 ```
 
-Expected: all focused tests pass.
+Expected:
 
-- [ ] **Step 2: Run full project test suite**
+```text
+PASS
+```
 
-Run from repository root:
+- [ ] **Step 2: Run full core tests**
+
+Run:
 
 ```bash
-pnpm test
+pnpm --filter @nakidka/core exec vitest run
 ```
 
-Expected: full project test suite passes.
+Expected:
 
-- [ ] **Step 3: Run short round-trip triage again**
+```text
+PASS
+```
+
+- [ ] **Step 3: Run round-trip triage batch**
 
 Run from repository root:
 
@@ -644,20 +967,39 @@ Run from repository root:
 ./.agents/skills/round-trip-xml/round-trip.sh --triage --batch-size 5
 ```
 
-Expected: the previously accepted diffs are gone or replaced by the next unresolved differences. The run may still stop on unrelated `Type FillChecking not found in TypeDescriptionRules`; if it does, record the exact error and use focused tests as the verification for these three fixes.
+Expected:
 
-- [ ] **Step 4: Commit verification notes only if files changed**
+```text
+[round-trip] ...
+```
+
+The previous blocker `DcsMetadataTypedValue XML: unsupported _xsi:type v8:Type` must not appear. If new diffs remain, record the first five in the final implementation report; do not edit XML fixtures.
+
+- [ ] **Step 4: Run project tests if closing the work**
 
 Run:
 
 ```bash
-git status --short
+pnpm test
 ```
 
-Expected: no uncommitted code changes remain. If generated files changed unexpectedly, inspect them and do not commit unrelated output.
+Expected:
 
-## Self-Review
+```text
+PASS
+```
 
-- Spec coverage: Task 1 covers `UserVisible` XML and YAML name preservation; Task 2 covers DCS `attributeUseRestriction`; Task 3 covers empty form `ExtendedPresentation`; Task 4 covers focused and full verification.
-- Placeholder scan: the plan contains no placeholder markers, no deferred implementation step, and each code-changing step includes the exact code to add or replace.
-- Type consistency: property names match existing code: `extendedPresentation`, `attributeUseRestriction`, `CalculatedFieldUseRestriction`, `defaultValueXMLEmpty`, `defaultValueXMLRaw`, `UserVisibleValue.name`.
+- [ ] **Step 5: Commit verification-only changes if any**
+
+If verification produced no file changes, skip this step. If a tool updated generated files that are tracked and required, review them and run:
+
+```bash
+git add <tracked-generated-file>
+git commit -m "chore: :wrench: обновить проверочные файлы"
+```
+
+## Self-Review Notes
+
+- Spec coverage: Task 1 covers empty `<Type/>`; Tasks 2-3 cover local `xmlns:dcsset`; Task 4 covers XML and YAML behavior for `dcscor:Field`; Task 5 covers `v8:Type *:Undefined`; Task 6 covers focused and round-trip verification.
+- Placeholder scan: no red-flag placeholder text and no vague implementation steps.
+- Type consistency: `declareTypeNamespaceXML` is introduced as a `TypeDescriptionPropertyRule` field and used only by `TypeDescription` export; explicit DCS YAML form uses `Тип`/`Значение` consistently; reference restoration uses the existing `referenceMetadata` parameter shape.

--- a/docs/superpowers/plans/2026-05-14-round-trip-xml-next-5.md
+++ b/docs/superpowers/plans/2026-05-14-round-trip-xml-next-5.md
@@ -998,8 +998,252 @@ git add <tracked-generated-file>
 git commit -m "chore: :wrench: обновить проверочные файлы"
 ```
 
+## Task 7: Add Accumulation Register RecordType Standard Attribute
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/standardAttributeDescription/*`
+- Modify: `packages/core/metadata/appliedObjects/metadataAccumulationRegister/*`
+
+- [x] **Step 1: Add failing XML tests**
+
+Cover `RecordType` export for balance/default accumulation registers and prove `Turnovers` does not receive it.
+
+- [x] **Step 2: Implement contextual standard attributes**
+
+Add `RecordType: "ВидДвижения"` to standard attribute dictionaries and derive XML export order from accumulation register type.
+
+- [x] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/standardAttributeDescription metadata/appliedObjects/metadataAccumulationRegister
+```
+
+Expected: `PASS`.
+
+- [x] **Step 4: Commit**
+
+Committed as:
+
+```text
+fix: :bug: сохранять RecordType регистра накопления
+```
+
+## Task 8: Preserve Root Form Event XML Case
+
+**Files:**
+- Modify: `packages/core/metadata/forms/clientApplicationForm/rules.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/event/toXML.test.ts`
+
+- [x] **Step 1: Add failing event export test**
+
+Export `onUpdateUserSettingSetAtServer` through root form event rules and expect XML `name="OnUpdateUserSettingSetAtServer"`.
+
+- [x] **Step 2: Add event to root form rule**
+
+Add:
+
+```ts
+onUpdateUserSettingSetAtServer: "ПриОбновленииСоставаПользовательскихНастроекНаСервере"
+```
+
+- [x] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/forms/commonObjects/event/toXML.test.ts metadata/forms/clientApplicationForm/toXML.test.ts
+```
+
+Expected: `PASS`.
+
+- [x] **Step 4: Commit**
+
+Committed as:
+
+```text
+fix: :bug: сохранять регистр события формы
+```
+
+## Task 9: Restore CommonAttribute FillValue xsi:nil
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/metadataValue/fromXML.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataValue/toXML.ts`
+- Modify: `packages/core/metadata/orchestration/property/fromXML.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataValue/fromXML.test.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataValue/toXML.test.ts`
+- Modify: `packages/core/metadata/appliedObjects/metadataCommonAttribute/toXML.test.ts`
+
+- [x] **Step 1: Add failing nil tests**
+
+Assert normal import of `{ "_xsi:nil": true }` is `undefined`, reference import preserves the raw marker, and export restores `<FillValue xsi:nil="true"/>` from reference.
+
+- [x] **Step 2: Preserve raw nil marker at XML import boundary**
+
+When an XML key is present but its parsed value is `undefined`, pass `{ "_xsi:nil": true }` to `MetadataValue` import.
+
+- [x] **Step 3: Restore marker during XML export**
+
+If `value` or `referenceMetadata` is the raw nil marker, export it unchanged.
+
+- [x] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/commonObjects/metadataValue metadata/appliedObjects/metadataCommonAttribute
+```
+
+Expected: `PASS`.
+
+- [x] **Step 5: Commit**
+
+Committed as:
+
+```text
+fix: :bug: сохранять nil MetadataValue
+```
+
+## Task 10: Keep GraphicalSchemaField Edit in XML Only
+
+**Files:**
+- Modify: `packages/core/metadata/forms/elements/graphicalSchemaField/rules.ts`
+- Modify: `packages/core/metadata/forms/elements/graphicalSchemaField/toXML.test.ts`
+- Modify: `packages/core/metadata/forms/elements/__fixtures__/data.ts`
+
+- [x] **Step 1: Add failing XML export test**
+
+Export `GraphicalSchemaField` with `edit: false` and expect `<Edit>false</Edit>`.
+
+- [x] **Step 2: Make `edit` XML-only**
+
+Use:
+
+```ts
+edit: { type: "boolean", xml: "Edit", yaml: "Редактирование", toYAML: false, fromYAML: false, toEnterprise: false }
+```
+
+- [x] **Step 3: Keep generic YAML/enterprise fixtures stable**
+
+Remove `edit` from generic full fixture expectations where YAML/enterprise export should not expose it.
+
+- [x] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/forms/elements/graphicalSchemaField metadata/forms/elements
+```
+
+Expected: `PASS`.
+
+- [x] **Step 5: Commit**
+
+Committed as:
+
+```text
+fix: :bug: сохранять Edit графической схемы
+```
+
+## Task 11: Preserve DynamicList KeyField for RowKey
+
+**Files:**
+- Modify: `packages/core/metadata/forms/commonObjects/dynamicList/rules.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/dynamicList/fromXML.test.ts`
+- Modify: `packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts`
+- Modify if needed: `packages/core/metadata/forms/commonObjects/dynamicList/fromYAML.test.ts`
+- Modify if needed: `packages/core/metadata/forms/commonObjects/dynamicList/toYAML.test.ts`
+- Modify if needed: `packages/core/metadata/orchestration/property/toXML.ts`
+
+- [x] **Step 1: Prove direct multi-KeyField XML import/export**
+
+Add a test to `fromXML.test.ts`:
+
+```ts
+  it("imports multiple KeyField nodes as an array", () => {
+    const result = importPropertyFromXML({
+      context: mockContextFromXML(),
+      rule,
+      value: {
+        "_xsi:type": "DynamicList",
+        KeyType: "RowKey",
+        KeyField: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+      },
+    })
+
+    expect(result).toEqual({
+      itemType: "DynamicList",
+      customQuery: false,
+      keyType: "RowKey",
+      keyFields: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+    })
+  })
+```
+
+Add a matching `toXML.test.ts` assertion that exports all three repeated `<KeyField>` nodes from a model value.
+
+- [x] **Step 2: Prove YAML preserves arrays if YAML is the loss point**
+
+If Step 1 passes but round-trip still drops `KeyField`, add YAML tests where `ПоляКлюча` is an array of three strings and assert import/export keeps the array unchanged.
+
+- [x] **Step 3: Implement the minimal fix**
+
+Keep `preserveFromReferenceXML: true` for `DynamicList.keyFields`. If XML/YAML array tests fail, adjust only the narrow string-property import/export path or the `keyFields` rule so repeated `KeyField` stays `string[]`; do not add a new broad conversion for all string fields without tests.
+
+- [x] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/forms/commonObjects/dynamicList/fromXML.test.ts metadata/forms/commonObjects/dynamicList/toXML.test.ts metadata/forms/commonObjects/dynamicList/fromYAML.test.ts metadata/forms/commonObjects/dynamicList/toYAML.test.ts
+```
+
+Expected: `PASS`.
+
+- [ ] **Step 5: Run round-trip triage**
+
+Run:
+
+```bash
+env NKDK_XML_REPO=/Users/nikita/git/round-trip-source NKDK_XML_DIR=/Users/nikita/git/round-trip-source/trade ./.agents/skills/round-trip-xml/round-trip.sh --triage --batch-size 5
+```
+
+Expected: the first diff must no longer be loss of `DynamicList` `KeyField`.
+
+- [x] **Step 6: Commit**
+
+Run:
+
+```bash
+git add packages/core/metadata/forms/commonObjects/dynamicList packages/core/metadata/orchestration/property/toXML.ts docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md docs/superpowers/plans/2026-05-14-round-trip-xml-next-5.md
+git commit -m "fix: :bug: сохранять KeyField динамического списка"
+```
+
+## Task 12: Continue With Next Triage Diff
+
+**Files:**
+- To be selected from the next first unresolved diff after Task 11.
+
+- [ ] **Step 1: Capture the first unresolved diff**
+
+Run the round-trip triage command from Task 11 and copy the first diff class into the spec under `Принятые решения`.
+
+- [ ] **Step 2: Brainstorm the solution**
+
+Compare XML reference, imported model, YAML output, and XML export. Choose the narrowest rule-level fix that does not edit source XML fixtures.
+
+- [ ] **Step 3: Add focused failing tests**
+
+Place tests next to the owning metadata object or common object. The test must fail before implementation and must not depend on external XML fixture mutation.
+
+- [ ] **Step 4: Implement, verify, and commit**
+
+Run focused tests, then round-trip triage. Commit only after the targeted diff class disappears.
+
 ## Self-Review Notes
 
-- Spec coverage: Task 1 covers empty `<Type/>`; Tasks 2-3 cover local `xmlns:dcsset`; Task 4 covers XML and YAML behavior for `dcscor:Field`; Task 5 covers `v8:Type *:Undefined`; Task 6 covers focused and round-trip verification.
-- Placeholder scan: no red-flag placeholder text and no vague implementation steps.
-- Type consistency: `declareTypeNamespaceXML` is introduced as a `TypeDescriptionPropertyRule` field and used only by `TypeDescription` export; explicit DCS YAML form uses `Тип`/`Значение` consistently; reference restoration uses the existing `referenceMetadata` parameter shape.
+- Spec coverage: Tasks 1-6 cover the initial four accepted issues and integrated verification. Tasks 7-11 cover all later accepted decisions currently written in the spec: `RecordType`, form event XML case, `xsi:nil`, `GraphicalSchemaField.Edit`, and `DynamicList.KeyField`.
+- Placeholder scan: the only future-looking task is Task 12, intentionally a triage loop because the exact next diff is discovered by the tool after Task 11.
+- Type consistency: `declareTypeNamespaceXML`, explicit DCS YAML `Тип`/`Значение`, `v8:Type *:Undefined`, `RecordType`, `edit`, and `keyFields` names match the source rules and tests.

--- a/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
+++ b/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
@@ -181,3 +181,26 @@ fromXML/toXML, но отключить `fromYAML`, `toYAML` и `toEnterprise`.
 
 Проверка: точечный тест экспорта `GraphicalSchemaField` с `edit: false` должен содержать
 `<Edit>false</Edit>`.
+
+### DynamicList KeyField при RowKey
+
+Следующий diff показывает потерю повторяющихся `KeyField` у `DynamicList`:
+
+```diff
+- <KeyField>КлючПриглашения</KeyField>
+- <KeyField>Контрагент</KeyField>
+- <KeyField>ИдентификаторОрганизации</KeyField>
+```
+
+Причина: `keyFields` приходит из reference, но текущая модель может содержать ключ
+`keyFields` со значением `undefined`. Общий XML-экспорт считает наличие ключа в модели более
+важным, чем reference, и не восстанавливает XML-only значение.
+
+Решение:
+
+- для `DynamicList.keyFields` включить `preserveFromReferenceXML`;
+- в общем `exportPropertiesToXML` для `preserveFromReferenceXML` брать значение из reference,
+  когда текущее значение равно `undefined`, даже если ключ присутствует в модели.
+
+Проверка: точечный тест `DynamicList` с `keyFields: undefined` в текущей модели и массивом
+`keyFields` в reference должен экспортировать все `KeyField`.

--- a/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
+++ b/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
@@ -164,3 +164,20 @@ reference и отказа от восстановления некорректн
 
 Проверка: точечный тест `MetadataCommonAttributeRules.properties.fillValue` с пустым значением и
 reference `{ "_xsi:nil": true }` должен экспортировать `<FillValue xsi:nil="true"/>`.
+
+### GraphicalSchemaField Edit=false
+
+Следующий diff показывает потерю XML-поля у графической схемы формы:
+
+```diff
+- <Edit>false</Edit>
+```
+
+Оба первых случая относятся к `GraphicalSchemaField`. В правилах этого элемента свойство `edit`
+помечено `runtimeOnly`, поэтому оно не импортируется и не экспортируется в XML.
+
+Решение: сделать `edit` XML-only, а не runtime-only: оставить тип `boolean`, разрешить
+fromXML/toXML, но отключить `fromYAML`, `toYAML` и `toEnterprise`.
+
+Проверка: точечный тест экспорта `GraphicalSchemaField` с `edit: false` должен содержать
+`<Edit>false</Edit>`.

--- a/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
+++ b/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
@@ -88,3 +88,32 @@ XML-тип `dcscor:Field` должен сохраняться без угады�
 
 Проверка: добавить тесты для обычного импорта, reference-импорта, экспорта пустого значения с
 reference и отказа от восстановления некорректного reference.
+
+### StandardAttribute RecordType у регистров накопления
+
+Следующий triage после снятия DCS-блокеров показал однотипное расхождение в первых пяти файлах:
+у balance-регистров накопления удаляется стандартный реквизит `RecordType`.
+
+По XML-источнику `HEAD` все 69 регистров накопления в текущем наборе имеют
+`<RegisterType>Balance</RegisterType>` и блок:
+
+```xml
+<xr:StandardAttribute name="RecordType">
+```
+
+Причина: `MetadataAccumulationRegisterStandardAttributeNames` не содержит `RecordType`, а экспорт
+`StandardAttributeDescriptions` разворачивает секцию только по списку стандартных реквизитов из
+правила.
+
+Решение:
+
+- добавить `RecordType: "ВидДвижения"` в общий словарь стандартных реквизитов;
+- добавить `RecordType: "ВидДвижения"` в YAML/graph-словарь стандартных реквизитов
+  `MetadataAccumulationRegister`;
+- для XML-экспорта сделать список стандартных реквизитов контекстным: при
+  `registerType === "Turnovers"` не добавлять `RecordType`, во всех остальных случаях считать
+  регистр balance/default и ставить `RecordType` перед `Active`.
+
+Проверка: точечный тест `StandardAttributeDescriptions` должен подтверждать экспорт и порядок
+`RecordType` перед `Active`; тест накопительного регистра должен подтверждать, что `Turnovers`
+не получает `RecordType`, а `Balance` получает; затем повторить round-trip triage.

--- a/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
+++ b/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
@@ -117,3 +117,24 @@ reference и отказа от восстановления некорректн
 Проверка: точечный тест `StandardAttributeDescriptions` должен подтверждать экспорт и порядок
 `RecordType` перед `Active`; тест накопительного регистра должен подтверждать, что `Turnovers`
 не получает `RecordType`, а `Balance` получает; затем повторить round-trip triage.
+
+### Событие формы OnUpdateUserSettingSetAtServer
+
+После исправления `RecordType` следующий triage показал смену регистра XML-имени события формы:
+
+```diff
+- <Event name="OnUpdateUserSettingSetAtServer">
++ <Event name="onUpdateUserSettingSetAtServer">
+```
+
+Причина: XML-импорт нормализует имя события в ключ модели с маленькой первой буквой, а XML-экспорт
+возвращает canonical XML-case только для событий, известных правилу. Событие
+`onUpdateUserSettingSetAtServer` уже есть у элемента `Table`, но отсутствует в списке событий
+корневой формы.
+
+Решение: добавить `onUpdateUserSettingSetAtServer:
+"ПриОбновленииСоставаПользовательскихНастроекНаСервере"` в
+`MetadataClientApplicationFormRules.properties.events.items`.
+
+Проверка: точечный тест экспорта `Events` по правилу корневой формы должен выдавать
+`name="OnUpdateUserSettingSetAtServer"`.

--- a/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
+++ b/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
@@ -138,3 +138,29 @@ reference и отказа от восстановления некорректн
 
 Проверка: точечный тест экспорта `Events` по правилу корневой формы должен выдавать
 `name="OnUpdateUserSettingSetAtServer"`.
+
+### CommonAttribute FillValue xsi:nil
+
+Следующий diff показывает потерю raw-формы пустого значения заполнения общего реквизита:
+
+```diff
+- <FillValue xsi:nil="true"/>
++ <FillValue xsi:type="xs:string"/>
+```
+
+Модельно это по-прежнему отсутствующее значение, а не строка и не отдельный тип. Поэтому свежий
+экспорт без reference должен сохранить существующее поведение `defaultValueXMLRaw:
+{ "_xsi:type": "xs:string" }`, но round-trip из XML должен восстановить `xsi:nil`, если такая
+форма была в reference.
+
+Решение:
+
+- при XML-импорте `MetadataValue`, если XML-ключ присутствует, но парсер вернул `undefined`
+  из-за `xsi:nil`, передавать в импортёр raw-маркер `{ "_xsi:nil": true }`;
+- обычный импорт читает этот маркер как `undefined`;
+- reference-импорт сохраняет маркер;
+- XML-экспорт восстанавливает `{ "_xsi:nil": true }`, если маркер пришёл как `value` или
+  `referenceMetadata`.
+
+Проверка: точечный тест `MetadataCommonAttributeRules.properties.fillValue` с пустым значением и
+reference `{ "_xsi:nil": true }` должен экспортировать `<FillValue xsi:nil="true"/>`.

--- a/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
+++ b/docs/superpowers/specs/2026-05-14-round-trip-xml-next-5-design.md
@@ -1,0 +1,90 @@
+# Round-Trip XML: следующие расхождения
+
+## Контекст
+
+`round-trip.sh --triage --batch-size 5` для XML-каталога `/Users/nikita/git/round-trip-source/acc`
+остановился на `DocumentJournals/Взаимодействия/ФормаСписка` из-за
+`DcsMetadataTypedValue XML: unsupported _xsi:type v8:Type`.
+
+До остановки были видны три группы расхождений:
+
+- пустой `<Type/>` у `MetadataAttribute` пропадает при экспорте;
+- локальный `xmlns:dcsset` у `v8:Type` теряется в `DataProcessor`;
+- `dcscor:Field` внутри DCS-значений экспортируется как `xs:string`.
+
+Отдельно включаем блокер `v8:Type`, чтобы следующий triage мог пройти дальше.
+
+## Принятые решения
+
+### Пустой Type у MetadataAttribute
+
+Пустой XML-узел `<Type/>` должен сохраняться в XML round-trip для `MetadataAttribute`.
+Решение: локально для свойства `type` в `MetadataAttributeRules` использовать существующий
+механизм пустого XML-значения, например `defaultValueXMLRaw: ""`.
+
+Не менять общий экспорт `TypeDescription`: это затронуло бы все места, где отсутствие типа
+сейчас корректно означает отсутствие XML-узла.
+
+Проверка: добавить точечный тест на round-trip пустого `Type` без изменения XML-фикстур.
+
+### Namespace для dcsset TypeDescription в DataProcessor
+
+Не добавлять namespace глобально в `TypeDescriptionRules.SettingsComposer`: в формах `dcsset`
+обычно уже объявлен на корневом `<Form>`, и локальный `xmlns:dcsset` на каждом `v8:Type`
+стал бы лишним.
+
+Решение: добавить в правила свойства `TypeDescription` явный XML-флаг, который говорит
+экспорту объявлять namespace типа локально на `v8:Type`. Включить этот флаг для атрибутов
+`DataProcessor`, где `MetaDataObject` не объявляет `dcsset` на корне и эталонный XML содержит
+локальное объявление:
+
+```xml
+<v8:Type xmlns:dcsset="http://v8.1c.ru/8.1/data-composition-system/settings">dcsset:SettingsComposer</v8:Type>
+```
+
+Проверка: один тест для `DataProcessor`/`MetaDataObject`-стиля с локальным `xmlns:dcsset`,
+один тест для form-стиля без локального `xmlns`, чтобы не добавить лишний namespace в формы.
+
+### DCS Field внутри DesignTimeValue
+
+XML-тип `dcscor:Field` должен сохраняться без угадывания:
+
+- XML -> модель: `xsi:type="dcscor:Field"` импортируется как явное значение `{ type: "Field", value }`;
+- модель -> XML: явное значение `{ type: "Field", value }` экспортируется как `dcscor:Field`;
+- YAML -> модель: не угадывать поле по строке, потому что строка с точкой может быть буквальным текстом;
+- для YAML добавить явную форму, например:
+
+```yaml
+Текст:
+  Тип: Поле
+  Значение: Сертификаты.СертификатПредставление
+```
+
+Краткая YAML-строка остаётся строкой и не превращается в `dcscor:Field` эвристически.
+
+### DcsMetadataTypedValue v8:Type Undefined
+
+`DcsMetadataTypedValue` с XML-формой:
+
+```xml
+<dcsset:right xmlns:d8p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d8p1:Undefined</dcsset:right>
+```
+
+не должен становиться отдельным смысловым значением модели. Это явный XML-способ представить
+отсутствующее значение.
+
+Решение:
+
+- обычный XML-импорт читает `v8:Type` со значением `*:Undefined` как `undefined`;
+- reference XML-импорт сохраняет исходный объект с `_xsi:type`, `#text` и `_xmlns:<prefix>`;
+- XML-экспорт при пустом значении использует reference-объект, если он был именно валидным
+  `v8:Type *:Undefined`;
+- если reference содержит другой `v8:Type`, значение без namespace или не `Undefined`, оно не
+  восстанавливается автоматически.
+
+Это повторяет уже существующий паттерн для `DCSParameter.value`, где `dcssch:value`
+`v8:Type Undefined` импортируется как отсутствующее значение, но сохраняется из reference при
+обратном XML-экспорте.
+
+Проверка: добавить тесты для обычного импорта, reference-импорта, экспорта пустого значения с
+reference и отказа от восстановления некорректного reference.

--- a/packages/core/metadata/appliedObjects/metadataAccumulationRegister/rules.ts
+++ b/packages/core/metadata/appliedObjects/metadataAccumulationRegister/rules.ts
@@ -6,11 +6,25 @@ const properties = ["Properties"]
 const childObjects = ["ChildObjects"]
 
 export const MetadataAccumulationRegisterStandardAttributeNames: Record<string, string> = {
+  RecordType: "ВидДвижения",
   Active: "Активность",
   LineNumber: "НомерСтроки",
   Recorder: "Регистратор",
   Period: "Период",
 }
+
+const MetadataAccumulationRegisterTurnoverStandardAttributeNames: Record<string, string> = {
+  Active: "Активность",
+  LineNumber: "НомерСтроки",
+  Recorder: "Регистратор",
+  Period: "Период",
+}
+
+const isTurnoverAccumulationRegister = (metadataItem: unknown): boolean =>
+  typeof metadataItem === "object" &&
+  metadataItem !== null &&
+  "registerType" in metadataItem &&
+  metadataItem.registerType === "Turnovers"
 
 const MetadataAccumulationRegisterCommandRules = {
   ...MetadataCommandRules,
@@ -113,6 +127,10 @@ export const MetadataAccumulationRegisterRules = {
       yaml: "СтандартныеРеквизиты",
       type: "StandardAttributeDescriptions",
       standartAttributeNames: MetadataAccumulationRegisterStandardAttributeNames,
+      standartAttributeNamesXML: (metadataItem) =>
+        isTurnoverAccumulationRegister(metadataItem)
+          ? MetadataAccumulationRegisterTurnoverStandardAttributeNames
+          : MetadataAccumulationRegisterStandardAttributeNames,
       xmlParents: properties,
     },
     dataLockControlMode: {

--- a/packages/core/metadata/appliedObjects/metadataAccumulationRegister/toXML.test.ts
+++ b/packages/core/metadata/appliedObjects/metadataAccumulationRegister/toXML.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest"
+import { exportMetadataItemToXML } from "~/metadata/orchestration"
 import { testExportAppliedObjectToXML, testImportAppliedObjectFromXML } from "~/tests/appliedObject"
+import { mockContextToXML } from "~/tests/mockContext"
+import { xmlExport } from "~/xml/export/exporter"
 import { MetadataAccumulationRegisterRules } from "./rules"
 import { MetadataAccumulationRegister } from "./types"
 
@@ -19,5 +22,28 @@ describe("export MetadataAccumulationRegister to XML", () => {
       data: data!,
     })
     expect(normalizeLineEndings(result)).toEqual(normalizeLineEndings(expected))
+  })
+
+  it("exports RecordType for balance registers", () => {
+    const data = testImportAppliedObjectFromXML<MetadataAccumulationRegister>({
+      rule: MetadataAccumulationRegisterRules,
+      importMetaUrl: import.meta.url,
+      fixture: "minimal.xml",
+    })!
+
+    const xmlData = exportMetadataItemToXML({
+      context: mockContextToXML(),
+      data: {
+        ...data,
+        registerType: "Balance",
+        standardAttributes: [{ itemType: "StandardAttributeDescription", name: "Active", comment: "changed" }],
+      },
+      rule: MetadataAccumulationRegisterRules,
+    })
+    const result = xmlExport(xmlData!)
+
+    expect(result).toContain('<xr:StandardAttribute name="RecordType">')
+    expect(result).toContain('<xr:StandardAttribute name="Active">')
+    expect(result.indexOf('name="RecordType"')).toBeLessThan(result.indexOf('name="Active"'))
   })
 })

--- a/packages/core/metadata/appliedObjects/metadataDataProcessor/rules.ts
+++ b/packages/core/metadata/appliedObjects/metadataDataProcessor/rules.ts
@@ -1,5 +1,10 @@
 import { V8_MDCLASSES_ROOT } from "~/metadata/orchestration/appliedObject/presets"
-import { MetadataItemRule } from "~/metadata/orchestration/property/types"
+import { exportMetadataCollectionToXML } from "~/metadata/orchestration/metadataCollection/toXML"
+import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
+import { ExportToXMLFunctionNew } from "~/metadata/orchestration/property/fn"
+import { MetadataItemRule, PropertyRule } from "~/metadata/orchestration/property/types"
+import "~/metadata/commonObjects/metadataAttribute/register"
+import { MetadataAttributeRules } from "~/metadata/commonObjects/metadataAttribute/rules"
 import { MetadataCommandRules } from "../metadataCommand/rules"
 
 const properties = ["Properties"]
@@ -16,6 +21,38 @@ const MetadataDataProcessorCommandRules = {
     },
   },
 } as const satisfies MetadataItemRule
+
+const MetadataDataProcessorAttributeRules = {
+  ...MetadataAttributeRules,
+  properties: {
+    ...MetadataAttributeRules.properties,
+    type: {
+      ...MetadataAttributeRules.properties.type,
+      declareTypeNamespaceXML: true,
+    },
+  },
+} as const satisfies MetadataItemRule
+
+const getMetadataAttributeItemRule = (rule: PropertyRule | undefined): MetadataItemRule => {
+  if (rule && "itemRule" in rule && rule.itemRule !== undefined) return rule.itemRule as MetadataItemRule
+  return MetadataAttributeRules
+}
+
+const exportMetadataAttributesToXML: ExportToXMLFunctionNew = (params) => {
+  const effectiveXmlElement = params.rule.xml === "Attribute" ? undefined : "Attribute"
+
+  return exportMetadataCollectionToXML({
+    context: params.context,
+    rule: params.rule,
+    data: params.value,
+    referenceData: params.referenceMetadata,
+    itemRule: getMetadataAttributeItemRule(params.rule),
+    xmlElement: effectiveXmlElement,
+    keyField: "name",
+  })
+}
+
+registerTypeRule("MetadataAttributes", "exportToXML", exportMetadataAttributesToXML)
 
 export const MetadataDataProcessorRules = {
   itemType: "MetadataDataProcessor",
@@ -123,6 +160,7 @@ export const MetadataDataProcessorRules = {
       type: "MetadataAttributes",
       xmlParents: childObjects,
       xml: "Attribute",
+      ...({ itemRule: MetadataDataProcessorAttributeRules } as { itemRule: MetadataItemRule }),
     },
     tabularSections: {
       yaml: "ТабличныеЧасти",

--- a/packages/core/metadata/appliedObjects/metadataDataProcessor/toXML.test.ts
+++ b/packages/core/metadata/appliedObjects/metadataDataProcessor/toXML.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { testExportAppliedObjectToXML } from "~/tests/appliedObject"
+import { testExportPropertyToXML } from "~/tests/property/exportPropertyToXML"
 import { full } from "./__fixtures__/full"
 import { minimal } from "./__fixtures__/minimal"
 import { MetadataDataProcessorRules } from "./rules"
@@ -18,5 +19,26 @@ describe("export MetadataDataProcessor to XML", () => {
       data,
     })
     expect(normalizeLineEndings(result)).toEqual(normalizeLineEndings(expected))
+  })
+})
+
+describe("export MetadataDataProcessor attributes to XML", () => {
+  it("exports attribute SettingsComposer type with local dcsset namespace", () => {
+    const { result } = testExportPropertyToXML({
+      rule: MetadataDataProcessorRules.properties.attributes,
+      value: [
+        {
+          uuid: "8a57d427-a34e-4121-84e6-1a86a9f9092d",
+          name: "КомпоновщикОтбораВсехДокументов",
+          synonym: { items: { ru: "Компоновщик отбора всех документов" } },
+          type: { type: ["SettingsComposer"] },
+        },
+      ],
+      xmlRootTag: "Attribute",
+    })
+
+    expect(result).toContain(
+      '<v8:Type xmlns:dcsset="http://v8.1c.ru/8.1/data-composition-system/settings">dcsset:SettingsComposer</v8:Type>',
+    )
   })
 })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts
@@ -18,6 +18,7 @@ export const fixtureColorWebRed: Color = {
 
 export const fixtureFieldPath = "Реквизит1"
 export const fixtureDesignTimeRefPath = "Перечисление.СтраницыЖурналаОтчетность.ЕГРЮЛ"
+export const fixtureDesignTimeFieldPath = "Сертификаты.СертификатПредставление"
 
 export const fixtureBooleanPrimitive: MetadataTypedPrimitiveValue = {
   type: "boolean",
@@ -71,6 +72,10 @@ export const fixtureChoiceParameterDecimal: ChoiceParameter = {
 
 export const yamlColorWebRed: ColorYAML = "Красный"
 export const yamlFieldPath: MetadataFieldYAML = "Реквизит1"
+export const yamlDesignTimeFieldExplicit = {
+  Тип: "Поле",
+  Значение: fixtureDesignTimeFieldPath,
+} as const
 export const yamlBooleanPrimitive: MetadataValueYAML = "Истина"
 export const yamlLocalStringI8n: I8nTextYAML = "ЧЦ=3; ЧДЦ=2"
 export const yamlHorizontalAlign = "Центр" as const
@@ -109,6 +114,18 @@ const designTimeRefUnderFieldDefaultFixture: DcsMetadataValueFixture = {
   },
   yaml: fixtureDesignTimeRefPath,
   xml: "design-time-ref.xml",
+}
+
+const designTimeFieldFixture: DcsMetadataValueFixture = {
+  id: "designTimeField",
+  title: "DesignTimeValue explicit Field",
+  rule: { type: "MetadataDcsMetadataValue", valueType: "DesignTimeValue", yaml: "value" },
+  value: {
+    type: "Field",
+    value: fixtureDesignTimeFieldPath,
+  },
+  yaml: yamlDesignTimeFieldExplicit,
+  xml: "design-time-field.xml",
 }
 
 const primitiveUuidFixture: DcsMetadataValueFixture = {
@@ -181,6 +198,7 @@ export const dcsMetadataValueFixtures: DcsMetadataValueFixture[] = [
     yaml: yamlLocalStringI8n,
     xml: "design-time-value.xml",
   },
+  designTimeFieldFixture,
   {
     id: "systemEnumerationHorizontalAlign",
     title: "SystemEnumeration (HorizontalAlign)",

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/design-time-field.xml
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/design-time-field.xml
@@ -1,0 +1,1 @@
+<dcscor:value xsi:type="dcscor:Field">Сертификаты.СертификатПредставление</dcscor:value>

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts
@@ -201,7 +201,8 @@ const importDcsMetadataValueFromDcsXMLInternal = (
   }
 
   if (xsi === "dcscor:Field") {
-    return textNode(root as string | { "#text"?: string })
+    const value = textNode(root as string | { "#text"?: string })
+    return rule.valueType === "DesignTimeValue" ? { type: "Field", value } : value
   }
 
   const metadataPrimitive = xsi !== undefined ? MetadataValueTypeFromXML(xsi as MetadataValueTypeXML) : undefined

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.test.ts
@@ -11,4 +11,16 @@ describe("import MetadataDcsMetadataValue from YAML", () => {
       })
     ).toEqual(fixture.value)
   })
+
+  it("rejects invalid explicit text value", () => {
+    expect(() =>
+      testImportPropertyFromYAML({
+        rule: { type: "MetadataDcsMetadataValue", valueType: "DesignTimeValue", yaml: "value" },
+        value: {
+          Тип: "Поле",
+          Значение: 123,
+        },
+      })
+    ).toThrow("MetadataDcsMetadataValue YAML: invalid explicit text value")
+  })
 })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.ts
@@ -27,6 +27,18 @@ const isEnumValueMetadataPath = (value: string | undefined): boolean =>
 const isEnterpriseDesignTimeValue = (value: unknown): value is string =>
   typeof value === "string" && value.startsWith("Перечисление.")
 
+const importExplicitTextValueFromYAML = (data: unknown): MetadataDcsMetadataValue | undefined => {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return undefined
+  const record = data as Record<string, unknown>
+  if (record["Тип"] === "Поле" && typeof record["Значение"] === "string") {
+    return { type: "Field", value: record["Значение"] }
+  }
+  if (record["Тип"] === "ЗначениеВремениПроектирования" && typeof record["Значение"] === "string") {
+    return { type: "DesignTimeValue", value: record["Значение"] }
+  }
+  return undefined
+}
+
 export const importDcsMetadataValueFromYAML = (
   context: ConfigurationContext,
   rule: DcsMetadataValuePropertyRule,
@@ -57,7 +69,11 @@ export const importDcsMetadataValueFromYAML = (
       const list = importChoiceParametersFromYAML(context, undefined, data as ChoiceParametersYAML)
       return list?.[0]
     }
-    case "DesignTimeValue":
+    case "DesignTimeValue": {
+      const explicitTextValue = importExplicitTextValueFromYAML(data)
+      if (explicitTextValue !== undefined) {
+        return explicitTextValue
+      }
       if (typeof data === "string" && /^".*"$/.test(data)) {
         return importMetadataValueFromYAML(context, undefined, data as any) as MetadataDcsMetadataValue
       }
@@ -69,6 +85,7 @@ export const importDcsMetadataValueFromYAML = (
         rule: { type: "I8nText" },
         value: data as I8nTextYAML,
       })!
+    }
     case "Primitive":
       if (isEnterpriseDesignTimeValue(data)) {
         return { type: "DesignTimeValue", value: data }

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.ts
@@ -27,16 +27,18 @@ const isEnumValueMetadataPath = (value: string | undefined): boolean =>
 const isEnterpriseDesignTimeValue = (value: unknown): value is string =>
   typeof value === "string" && value.startsWith("Перечисление.")
 
+const hasExplicitTextType = (data: unknown): data is Record<string, unknown> =>
+  typeof data === "object" && data !== null && !Array.isArray(data) && "Тип" in data
+
 const importExplicitTextValueFromYAML = (data: unknown): MetadataDcsMetadataValue | undefined => {
-  if (typeof data !== "object" || data === null || Array.isArray(data)) return undefined
-  const record = data as Record<string, unknown>
-  if (record["Тип"] === "Поле" && typeof record["Значение"] === "string") {
-    return { type: "Field", value: record["Значение"] }
+  if (!hasExplicitTextType(data)) return undefined
+  if (data["Тип"] === "Поле" && typeof data["Значение"] === "string") {
+    return { type: "Field", value: data["Значение"] }
   }
-  if (record["Тип"] === "ЗначениеВремениПроектирования" && typeof record["Значение"] === "string") {
-    return { type: "DesignTimeValue", value: record["Значение"] }
+  if (data["Тип"] === "ЗначениеВремениПроектирования" && typeof data["Значение"] === "string") {
+    return { type: "DesignTimeValue", value: data["Значение"] }
   }
-  return undefined
+  throw new Error("MetadataDcsMetadataValue YAML: invalid explicit text value")
 }
 
 export const importDcsMetadataValueFromYAML = (

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toYAML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toYAML.ts
@@ -43,6 +43,13 @@ export const exportDcsMetadataValueToYAML = (
   }
 
   if (isExplicitTextValue(data)) {
+    if (rule.valueType === "DesignTimeValue") {
+      return {
+        Тип: data.type === "Field" ? "Поле" : "ЗначениеВремениПроектирования",
+        Значение: data.value,
+      } as MetadataDcsMetadataValueYAML
+    }
+
     if (data.type === "DesignTimeValue") {
       return (exportMetadataValueStringToYAML(context, undefined, data.value) ?? data.value) as MetadataDcsMetadataValueYAML
     }

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts
@@ -41,6 +41,15 @@ export type DcsMetadataValuePropertyRule = DcsMetadataValueBasePropertyRule | Sy
 export type MetadataDcsFieldValue = { type: "Field"; value: string }
 export type MetadataDcsDesignTimeValue = { type: "DesignTimeValue"; value: string }
 export type MetadataDcsExplicitTextValue = MetadataDcsFieldValue | MetadataDcsDesignTimeValue
+export type MetadataDcsExplicitTextValueYAML =
+  | {
+      Тип: "Поле"
+      Значение: string
+    }
+  | {
+      Тип: "ЗначениеВремениПроектирования"
+      Значение: string
+    }
 
 export type MetadataDcsMetadataSingleValue =
   | null
@@ -61,6 +70,7 @@ export type MetadataDcsMetadataSingleValueYAML =
   | null
   | ColorYAML
   | MetadataFieldYAML
+  | MetadataDcsExplicitTextValueYAML
   | ChoiceParametersYAML
   | I8nTextYAML
   | MetadataValueYAML

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.test.ts
@@ -30,6 +30,33 @@ describe("import DcsMetadataTypedValue from XML", () => {
     ).toEqual(emptyValueListTypedValue)
   })
 
+  it("imports v8 Type Undefined as missing value", () => {
+    const result = testImportPropertyFromXML({
+      rule,
+      xmlRootTag: "value",
+      xmlString:
+        '<value xmlns:d8p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d8p1:Undefined</value>',
+    })
+
+    expect(result).toBeUndefined()
+  })
+
+  it("imports reference v8 Type Undefined as raw XML", () => {
+    const result = testImportPropertyFromXML({
+      rule,
+      xmlRootTag: "value",
+      xmlString:
+        '<value xmlns:d8p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d8p1:Undefined</value>',
+      forReference: true,
+    })
+
+    expect(result).toEqual({
+      "_xmlns:d8p1": "http://v8.1c.ru/8.2/data/types",
+      "_xsi:type": "v8:Type",
+      "#text": "d8p1:Undefined",
+    })
+  })
+
   it("rejects non-empty ValueListType", () => {
     expect(() =>
       testImportPropertyFromXML({

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.ts
@@ -2,13 +2,46 @@ import { ConfigurationContextFromXML } from "~/metadata/context/types"
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { PropertyRule } from "~/metadata/orchestration/property/types"
 import { DcsMetadataTypedValueRegistry, DcsMetadataTypedValueTypeFromXML } from "./rules"
-import { DcsMetadataTypedValue, DcsMetadataTypedValuePropertyRule, DcsMetadataTypedValueXML } from "./types"
+import {
+  DcsMetadataTypedValuePropertyRule,
+  DcsMetadataTypedValueReference,
+  DcsMetadataTypedValueUndefinedTypeXML,
+  DcsMetadataTypedValueXML,
+} from "./types"
+
+const DATA_TYPES_NAMESPACE = "http://v8.1c.ru/8.2/data/types"
+
+const getUndefinedTypePrefix = (xml: DcsMetadataTypedValueXML): string | undefined => {
+  if (xml["_xsi:type"] !== "v8:Type") return undefined
+
+  const text = "#text" in xml ? xml["#text"] : undefined
+  if (typeof text !== "string") return undefined
+
+  const parts = text.split(":")
+  if (parts.length !== 2) return undefined
+
+  const [prefix, name] = parts
+  if (prefix === "" || name !== "Undefined") return undefined
+
+  return prefix
+}
+
+const isUndefinedTypeXML = (xml: DcsMetadataTypedValueXML): xml is DcsMetadataTypedValueUndefinedTypeXML => {
+  const prefix = getUndefinedTypePrefix(xml)
+  if (prefix === undefined) return false
+
+  return (xml as Record<`_xmlns:${string}`, unknown>)[`_xmlns:${prefix}`] === DATA_TYPES_NAMESPACE
+}
 
 const importSingle = (
   context: ConfigurationContextFromXML,
   rule: DcsMetadataTypedValuePropertyRule,
   xml: DcsMetadataTypedValueXML
-): DcsMetadataTypedValue => {
+): DcsMetadataTypedValueReference | undefined => {
+  if (isUndefinedTypeXML(xml)) {
+    return context.fromXML.forReference ? xml : undefined
+  }
+
   const type = DcsMetadataTypedValueTypeFromXML(xml["_xsi:type"])
   return DcsMetadataTypedValueRegistry[type].fromXML({ context, rule, xml })
 }
@@ -17,9 +50,14 @@ export const importDcsMetadataTypedValueFromXML = (
   context: ConfigurationContextFromXML,
   rule: DcsMetadataTypedValuePropertyRule,
   xml: DcsMetadataTypedValueXML | DcsMetadataTypedValueXML[] | undefined
-): DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined => {
+): DcsMetadataTypedValueReference | DcsMetadataTypedValueReference[] | undefined => {
   if (xml === undefined) return undefined
-  if (Array.isArray(xml)) return xml.map((item) => importSingle(context, rule, item))
+  if (Array.isArray(xml)) {
+    const items = xml
+      .map((item) => importSingle(context, rule, item))
+      .filter((item): item is DcsMetadataTypedValueReference => item !== undefined)
+    return items.length > 0 ? items : undefined
+  }
   return importSingle(context, rule, xml)
 }
 
@@ -27,7 +65,7 @@ const importDcsMetadataTypedValueFromXMLForRule = (
   context: ConfigurationContextFromXML,
   rule: PropertyRule,
   value: unknown
-): DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined =>
+): DcsMetadataTypedValueReference | DcsMetadataTypedValueReference[] | undefined =>
   importDcsMetadataTypedValueFromXML(
     context,
     rule as DcsMetadataTypedValuePropertyRule,

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts
@@ -51,13 +51,24 @@ describe("export DcsMetadataTypedValue to XML", () => {
   })
 
   it("does not export invalid reference v8 Type value", () => {
+    expect(() =>
+      testExportPropertyToXML({
+        rule,
+        value: undefined,
+        referenceMetadata: {
+          ...undefinedTypeReferenceValue,
+          "#text": "d8p1:String",
+        },
+        xmlRootTag: "value",
+      })
+    ).toThrow("DcsMetadataTypedValue XML: unsupported reference v8:Type")
+  })
+
+  it("does not restore unrelated reference metadata", () => {
     const { result } = testExportPropertyToXML({
       rule,
       value: undefined,
-      referenceMetadata: {
-        ...undefinedTypeReferenceValue,
-        "#text": "d8p1:String",
-      },
+      referenceMetadata: { "_xsi:type": "xs:string", "#text": "x" },
       xmlRootTag: "value",
     })
 

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts
@@ -50,6 +50,19 @@ describe("export DcsMetadataTypedValue to XML", () => {
     )
   })
 
+  it("exports reference-only v8 Type Undefined when passed as value", () => {
+    const { result } = testExportPropertyToXML({
+      rule,
+      value: undefinedTypeReferenceValue,
+      referenceMetadata: undefinedTypeReferenceValue,
+      xmlRootTag: "value",
+    })
+
+    expect(result).toEqual(
+      '<value xmlns:d8p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d8p1:Undefined</value>'
+    )
+  })
+
   it("does not export invalid reference v8 Type value", () => {
     expect(() =>
       testExportPropertyToXML({

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts
@@ -63,6 +63,20 @@ describe("export DcsMetadataTypedValue to XML", () => {
     )
   })
 
+  it("exports reference-only v8 Type Undefined inside value array", () => {
+    const { result } = testExportPropertyToXML({
+      rule,
+      value: [{ type: "string", value: "x" }, undefinedTypeReferenceValue],
+      referenceMetadata: [{ type: "string", value: "x" }, undefinedTypeReferenceValue],
+      xmlRootTag: "value",
+    })
+
+    expect(result).toEqual(
+      '<value xsi:type="xs:string">x</value>\n' +
+        '<value xmlns:d8p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d8p1:Undefined</value>'
+    )
+  })
+
   it("does not export invalid reference v8 Type value", () => {
     expect(() =>
       testExportPropertyToXML({

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts
@@ -8,6 +8,12 @@ const rule: PropertyRule = {
   yaml: "value",
 }
 
+const undefinedTypeReferenceValue = {
+  "_xmlns:d8p1": "http://v8.1c.ru/8.2/data/types",
+  "_xsi:type": "v8:Type",
+  "#text": "d8p1:Undefined",
+}
+
 describe("export DcsMetadataTypedValue to XML", () => {
   it.each(dcsMetadataTypedValueFixtures)("exports $name", (fixture) => {
     const { result } = testExportPropertyToXML({
@@ -29,5 +35,32 @@ describe("export DcsMetadataTypedValue to XML", () => {
     })
 
     expect(result).toEqual(expectedResult)
+  })
+
+  it("exports missing value from reference v8 Type Undefined", () => {
+    const { result } = testExportPropertyToXML({
+      rule,
+      value: undefined,
+      referenceMetadata: undefinedTypeReferenceValue,
+      xmlRootTag: "value",
+    })
+
+    expect(result).toEqual(
+      '<value xmlns:d8p1="http://v8.1c.ru/8.2/data/types" xsi:type="v8:Type">d8p1:Undefined</value>'
+    )
+  })
+
+  it("does not export invalid reference v8 Type value", () => {
+    const { result } = testExportPropertyToXML({
+      rule,
+      value: undefined,
+      referenceMetadata: {
+        ...undefinedTypeReferenceValue,
+        "#text": "d8p1:String",
+      },
+      xmlRootTag: "value",
+    })
+
+    expect(result).toEqual("<value/>")
   })
 })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts
@@ -2,7 +2,38 @@ import { ConfigurationContextWithExportToXML } from "~/metadata/context/types"
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { PropertyRule } from "~/metadata/orchestration/property/types"
 import { DcsMetadataTypedValueRegistry } from "./rules"
-import { DcsMetadataTypedValue, DcsMetadataTypedValuePropertyRule, DcsMetadataTypedValueXML } from "./types"
+import {
+  DcsMetadataTypedValue,
+  DcsMetadataTypedValuePropertyRule,
+  DcsMetadataTypedValueUndefinedTypeXML,
+  DcsMetadataTypedValueXML,
+} from "./types"
+
+const DATA_TYPES_NAMESPACE = "http://v8.1c.ru/8.2/data/types"
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isReferenceTypeValue = (value: unknown): value is Record<string, unknown> =>
+  isObject(value) && value["_xsi:type"] === "v8:Type"
+
+const getReferenceUndefinedTypeValue = (value: unknown): DcsMetadataTypedValueUndefinedTypeXML | undefined => {
+  if (!isReferenceTypeValue(value)) return undefined
+
+  const text = value["#text"]
+  if (typeof text !== "string") return undefined
+
+  const parts = text.split(":")
+  if (parts.length !== 2) return undefined
+
+  const [prefix, name] = parts
+  if (prefix === "" || name !== "Undefined") return undefined
+
+  const namespaceKey = `_xmlns:${prefix}`
+  if (value[namespaceKey] !== DATA_TYPES_NAMESPACE) return undefined
+
+  return value as DcsMetadataTypedValueUndefinedTypeXML
+}
 
 const exportSingle = (
   context: ConfigurationContextWithExportToXML,
@@ -14,9 +45,15 @@ const exportSingle = (
 export const exportDcsMetadataTypedValueToXML = (
   context: ConfigurationContextWithExportToXML,
   rule: DcsMetadataTypedValuePropertyRule,
-  value: DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined
+  value: DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined,
+  referenceMetadata?: unknown
 ): DcsMetadataTypedValueXML | DcsMetadataTypedValueXML[] | undefined => {
-  if (value === undefined) return undefined
+  if (value === undefined) {
+    const referenceUndefinedValue = getReferenceUndefinedTypeValue(referenceMetadata)
+    if (referenceUndefinedValue !== undefined) return referenceUndefinedValue
+    if (isReferenceTypeValue(referenceMetadata)) return {} as DcsMetadataTypedValueXML
+    return undefined
+  }
   if (Array.isArray(value)) return value.map((item) => exportSingle(context, rule, item))
   return exportSingle(context, rule, value)
 }
@@ -24,12 +61,14 @@ export const exportDcsMetadataTypedValueToXML = (
 const exportDcsMetadataTypedValueToXMLForRule = (
   context: ConfigurationContextWithExportToXML,
   rule: PropertyRule,
-  value: unknown
+  value: unknown,
+  referenceMetadata?: unknown
 ): DcsMetadataTypedValueXML | DcsMetadataTypedValueXML[] | undefined =>
   exportDcsMetadataTypedValueToXML(
     context,
     rule as DcsMetadataTypedValuePropertyRule,
-    value as DcsMetadataTypedValue | DcsMetadataTypedValue[]
+    value as DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined,
+    referenceMetadata
   )
 
 registerTypeRule("DcsMetadataTypedValue", "exportToXML", exportDcsMetadataTypedValueToXMLForRule)

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts
@@ -59,6 +59,11 @@ export const exportDcsMetadataTypedValueToXML = (
     if (isObject(referenceMetadata)) return {}
     return undefined
   }
+  const valueUndefinedType = getReferenceUndefinedTypeValue(value)
+  if (valueUndefinedType !== undefined) return valueUndefinedType
+  if (isReferenceTypeValue(value)) {
+    throw new Error("DcsMetadataTypedValue XML: unsupported reference v8:Type")
+  }
   if (Array.isArray(value)) return value.map((item) => exportSingle(context, rule, item))
   return exportSingle(context, rule, value)
 }

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts
@@ -11,6 +11,8 @@ import {
 
 const DATA_TYPES_NAMESPACE = "http://v8.1c.ru/8.2/data/types"
 
+type DcsMetadataTypedValueEmptyXML = Record<string, never>
+
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
 
@@ -47,11 +49,14 @@ export const exportDcsMetadataTypedValueToXML = (
   rule: DcsMetadataTypedValuePropertyRule,
   value: DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined,
   referenceMetadata?: unknown
-): DcsMetadataTypedValueXML | DcsMetadataTypedValueXML[] | undefined => {
+): DcsMetadataTypedValueXML | DcsMetadataTypedValueEmptyXML | DcsMetadataTypedValueXML[] | undefined => {
   if (value === undefined) {
     const referenceUndefinedValue = getReferenceUndefinedTypeValue(referenceMetadata)
     if (referenceUndefinedValue !== undefined) return referenceUndefinedValue
-    if (isReferenceTypeValue(referenceMetadata)) return {} as DcsMetadataTypedValueXML
+    if (isReferenceTypeValue(referenceMetadata)) {
+      throw new Error("DcsMetadataTypedValue XML: unsupported reference v8:Type")
+    }
+    if (isObject(referenceMetadata)) return {}
     return undefined
   }
   if (Array.isArray(value)) return value.map((item) => exportSingle(context, rule, item))
@@ -63,7 +68,7 @@ const exportDcsMetadataTypedValueToXMLForRule = (
   rule: PropertyRule,
   value: unknown,
   referenceMetadata?: unknown
-): DcsMetadataTypedValueXML | DcsMetadataTypedValueXML[] | undefined =>
+): DcsMetadataTypedValueXML | DcsMetadataTypedValueEmptyXML | DcsMetadataTypedValueXML[] | undefined =>
   exportDcsMetadataTypedValueToXML(
     context,
     rule as DcsMetadataTypedValuePropertyRule,

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.ts
@@ -12,6 +12,7 @@ import {
 const DATA_TYPES_NAMESPACE = "http://v8.1c.ru/8.2/data/types"
 
 type DcsMetadataTypedValueEmptyXML = Record<string, never>
+type ExportableDcsMetadataTypedValue = DcsMetadataTypedValue | DcsMetadataTypedValueUndefinedTypeXML
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
@@ -37,17 +38,30 @@ const getReferenceUndefinedTypeValue = (value: unknown): DcsMetadataTypedValueUn
   return value as DcsMetadataTypedValueUndefinedTypeXML
 }
 
+const isDcsMetadataTypedValue = (value: ExportableDcsMetadataTypedValue): value is DcsMetadataTypedValue =>
+  isObject(value) && typeof (value as { type?: unknown }).type === "string"
+
 const exportSingle = (
   context: ConfigurationContextWithExportToXML,
   rule: DcsMetadataTypedValuePropertyRule,
-  value: DcsMetadataTypedValue
-): DcsMetadataTypedValueXML =>
-  DcsMetadataTypedValueRegistry[value.type].toXML({ context, rule, item: value })
+  value: ExportableDcsMetadataTypedValue
+): DcsMetadataTypedValueXML => {
+  const valueUndefinedType = getReferenceUndefinedTypeValue(value)
+  if (valueUndefinedType !== undefined) return valueUndefinedType
+  if (isReferenceTypeValue(value)) {
+    throw new Error("DcsMetadataTypedValue XML: unsupported reference v8:Type")
+  }
+  if (!isDcsMetadataTypedValue(value)) {
+    throw new Error("DcsMetadataTypedValue XML: unsupported typed value")
+  }
+  const modelValue = value as DcsMetadataTypedValue
+  return DcsMetadataTypedValueRegistry[modelValue.type].toXML({ context, rule, item: modelValue })
+}
 
 export const exportDcsMetadataTypedValueToXML = (
   context: ConfigurationContextWithExportToXML,
   rule: DcsMetadataTypedValuePropertyRule,
-  value: DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined,
+  value: ExportableDcsMetadataTypedValue | ExportableDcsMetadataTypedValue[] | undefined,
   referenceMetadata?: unknown
 ): DcsMetadataTypedValueXML | DcsMetadataTypedValueEmptyXML | DcsMetadataTypedValueXML[] | undefined => {
   if (value === undefined) {
@@ -58,11 +72,6 @@ export const exportDcsMetadataTypedValueToXML = (
     }
     if (isObject(referenceMetadata)) return {}
     return undefined
-  }
-  const valueUndefinedType = getReferenceUndefinedTypeValue(value)
-  if (valueUndefinedType !== undefined) return valueUndefinedType
-  if (isReferenceTypeValue(value)) {
-    throw new Error("DcsMetadataTypedValue XML: unsupported reference v8:Type")
   }
   if (Array.isArray(value)) return value.map((item) => exportSingle(context, rule, item))
   return exportSingle(context, rule, value)
@@ -77,7 +86,7 @@ const exportDcsMetadataTypedValueToXMLForRule = (
   exportDcsMetadataTypedValueToXML(
     context,
     rule as DcsMetadataTypedValuePropertyRule,
-    value as DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined,
+    value as ExportableDcsMetadataTypedValue | ExportableDcsMetadataTypedValue[] | undefined,
     referenceMetadata
   )
 

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts
@@ -57,6 +57,14 @@ export const DcsMetadataTypedValueJSONSchema = Type.Union([
 
 export type DcsMetadataTypedValueYAML = Static<typeof DcsMetadataTypedValueJSONSchema>
 
+export type DcsMetadataTypedValueUndefinedTypeXML = {
+  "_xsi:type": "v8:Type"
+  "#text"?: string
+  [key: `_xmlns:${string}`]: string | undefined
+}
+
+export type DcsMetadataTypedValueReference = DcsMetadataTypedValue | DcsMetadataTypedValueUndefinedTypeXML
+
 export type DcsMetadataTypedValueXML =
   | {
       "_xsi:type": "dcscor:Field"
@@ -93,4 +101,5 @@ export type DcsMetadataTypedValueXML =
   | {
       "_xsi:type": "dcsset:Order"
     }
+  | DcsMetadataTypedValueUndefinedTypeXML
   | StandartBeginningDateXML

--- a/packages/core/metadata/commonObjects/metadataAttribute/rules.ts
+++ b/packages/core/metadata/commonObjects/metadataAttribute/rules.ts
@@ -41,6 +41,7 @@ const commonAttributeProperties = {
     useAsShortValueYAML: true,
     xmlParents: ["Properties"],
     order: 4,
+    defaultValueXMLRaw: "",
   },
   passwordMode: {
     yaml: "РежимПароля",

--- a/packages/core/metadata/commonObjects/metadataAttribute/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataAttribute/toXML.test.ts
@@ -76,4 +76,14 @@ describe("export MetadataAttributes to XML", () => {
 
     expect(result).toBe('<MinValue xsi:type="xs:string">1</MinValue>')
   })
+
+  it("exports empty Type tag when attribute type is missing", () => {
+    const { result } = testExportPropertyToXML({
+      rule: MetadataAttributeRules.properties.type,
+      value: undefined,
+      xmlRootTag: "Type",
+    })
+
+    expect(result).toBe("<Type/>")
+  })
 })

--- a/packages/core/metadata/commonObjects/metadataValue/fromXML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/fromXML.test.ts
@@ -44,6 +44,28 @@ describe("importMetadataValueFromXML", () => {
     expect(result).toEqual({ type: "DataCompositionComparisonType", value: "Equal" })
   })
 
+  it("imports xsi:nil as undefined", () => {
+    const xmlValue = parseValue('<Value xsi:nil="true"/>')
+    const result = importMetadataValueFromXML({
+      context: mockContextFromXML(),
+      rule: undefined,
+      value: xmlValue,
+    })
+
+    expect(result).toBeUndefined()
+  })
+
+  it("keeps xsi:nil for reference import", () => {
+    const xmlValue = parseValue('<Value xsi:nil="true"/>') ?? { "_xsi:nil": true }
+    const result = importMetadataValueFromXML({
+      context: mockContextFromXML({ forReference: true }),
+      rule: undefined,
+      value: xmlValue,
+    })
+
+    expect(result).toEqual({ "_xsi:nil": true })
+  })
+
   describe("строгая валидация valueType", () => {
     it("должен бросить при valueType: [string] и фактическом boolean", () => {
       const xml = '<Value xsi:type="xs:boolean">true</Value>'

--- a/packages/core/metadata/commonObjects/metadataValue/fromXML.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/fromXML.ts
@@ -43,6 +43,9 @@ export const importMetadataValueFromXML = (params: {
 }): MetadataTypedValue | undefined => {
   const { context, value: data, type } = params
   if (!data) return undefined
+  if (data["_xsi:nil"] === true) {
+    return context.fromXML.forReference ? (data as any) : undefined
+  }
 
   const resultedType: MetadataValueType | undefined = type ?? MetadataValueTypeFromXML(data["_xsi:type"] as MetadataValueTypeXML)
   if (!resultedType) throw new Error(`MetadataValue: не распознан тип: ${data["_xsi:type"]}`)

--- a/packages/core/metadata/commonObjects/metadataValue/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/toXML.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
+import { MetadataCommonAttributeRules } from "~/metadata/appliedObjects/metadataCommonAttribute/rules"
 import { metadataValueFixtures } from "~/metadata/commonObjects/metadataValue/__fixtures__/data"
 import { mockContext } from "~/tests/mockContext"
+import { testExportPropertyToXML } from "~/tests/property/exportPropertyToXML"
 import { xmlExport } from "~/xml/export/exporter"
 import { exportMetadataValueToXML } from "./toXML"
 
@@ -31,6 +33,28 @@ describe("exportMetadataValueToXML", () => {
     const result = xmlExport({ Value: xmlData }, false)
 
     expect(result).toEqual('<Value xsi:type="dcsset:DataCompositionComparisonType">Equal</Value>')
+  })
+
+  it("preserves reference xsi:nil for missing value", () => {
+    const { result } = testExportPropertyToXML({
+      rule: MetadataCommonAttributeRules.properties.fillValue,
+      value: undefined,
+      referenceMetadata: { "_xsi:nil": true },
+      xmlRootTag: "FillValue",
+    })
+
+    expect(result).toBe('<FillValue xsi:nil="true"/>')
+  })
+
+  it("exports reference-only xsi:nil when passed as value", () => {
+    const { result } = testExportPropertyToXML({
+      rule: MetadataCommonAttributeRules.properties.fillValue,
+      value: { "_xsi:nil": true },
+      referenceMetadata: { "_xsi:nil": true },
+      xmlRootTag: "FillValue",
+    })
+
+    expect(result).toBe('<FillValue xsi:nil="true"/>')
   })
 
   describe("строгая валидация valueType", () => {

--- a/packages/core/metadata/commonObjects/metadataValue/toXML.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/toXML.ts
@@ -30,17 +30,27 @@ const PRIMITIVE_TYPES: readonly MetadataPrimitiveValueType[] = [
   "DataCompositionComparisonType",
 ]
 
+const isNilMetadataValueXML = (value: unknown): value is { "_xsi:nil": true } =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  (value as Record<string, unknown>)["_xsi:nil"] === true
+
 /**
  * Экспортирует MetadataValue в XML. Принимает тегированную форму {type, value}.
  */
 export const exportMetadataValueToXML = (params: {
   context: ConfigurationContext
   rule: MetadataValuePropertyRule
-  value: MetadataTypedValue | undefined
+  value: MetadataTypedValue | { "_xsi:nil": true } | undefined
+  referenceMetadata?: unknown
 }): any => {
-  const { rule, value } = params
+  const { rule, value, referenceMetadata } = params
+
+  if (isNilMetadataValueXML(value)) return { "_xsi:nil": true }
 
   if (value === undefined) {
+    if (isNilMetadataValueXML(referenceMetadata)) return { "_xsi:nil": true }
     if (rule.exportNilValue) return { "_xsi:nil": true }
     if (rule.valueType !== undefined && rule.valueType.length > 0) {
       const firstType = rule.valueType[0]

--- a/packages/core/metadata/commonObjects/standardAttributeDescription/registerCollectionRule.ts
+++ b/packages/core/metadata/commonObjects/standardAttributeDescription/registerCollectionRule.ts
@@ -167,7 +167,9 @@ function exportStandardAttributeDescriptionsToXML(p: {
   if (!isGroupChanged) return undefined
 
   // Expand to full canonical list from standartAttributeNames
-  const standartAttributeNames: Record<string, string> = (p.rule as any).standartAttributeNames ?? {}
+  const stdAttrRule = p.rule as StandardAttributeDescriptionsPropertyRule
+  const standartAttributeNames: Record<string, string> =
+    stdAttrRule.standartAttributeNamesXML?.(p.metadataItem) ?? stdAttrRule.standartAttributeNames ?? {}
   const explicitByName = new Map<string, StandardAttributeDescription>()
   for (const item of items) {
     if (item.name) explicitByName.set(item.name as string, item)

--- a/packages/core/metadata/commonObjects/standardAttributeDescription/standartAttributeNames.ts
+++ b/packages/core/metadata/commonObjects/standardAttributeDescription/standartAttributeNames.ts
@@ -10,6 +10,7 @@ export const StandartAttributeNameToYAML = {
   IsFolder: "ЭтоГруппа",
   LineNumber: "НомерСтроки",
   Active: "Активность",
+  RecordType: "ВидДвижения",
   Recorder: "Регистратор",
   Period: "Период",
   Date: "Дата",

--- a/packages/core/metadata/commonObjects/standardAttributeDescription/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/standardAttributeDescription/toXML.test.ts
@@ -62,6 +62,25 @@ describe("exportStandardAttributeDescriptionsToXML", () => {
     expect(result).toEqual(expectedResult)
   })
 
+  it("exports RecordType when it is part of standard attribute names", () => {
+    const rule: PropertyRule = {
+      type: "StandardAttributeDescriptions",
+      standartAttributeNames: {
+        RecordType: "ВидДвижения",
+        Active: "Активность",
+      },
+    }
+    const { result } = testExportPropertyToXML({
+      rule,
+      value: [{ itemType: "StandardAttributeDescription", name: "Active", comment: "changed" }],
+      xmlRootTag: "StandardAttributes",
+    })
+
+    expect(result).toContain('<xr:StandardAttribute name="RecordType">')
+    expect(result).toContain('<xr:StandardAttribute name="Active">')
+    expect(result.indexOf('name="RecordType"')).toBeLessThan(result.indexOf('name="Active"'))
+  })
+
   it("exports undefined", () => {
     const rule: PropertyRule = {
       type: "StandardAttributeDescriptions",

--- a/packages/core/metadata/commonObjects/typeDescription/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/typeDescription/toXML.test.ts
@@ -4,6 +4,12 @@ import { xmlExport } from "~/xml/export/exporter"
 import { typeFixturesTable } from "./__fixtures__/data"
 import { exportTypeDescriptionToXML } from "./toXML"
 
+const typeDescriptionRule = { type: "TypeDescription" } as const
+const typeDescriptionRuleWithLocalNamespace = {
+  type: "TypeDescription",
+  declareTypeNamespaceXML: true,
+} as const
+
 describe("exportTypeDescriptionToXML", () => {
   it("should export undefined type description to XML", () => {
     const result = exportTypeDescriptionToXML(mockContext, mockRule, undefined)
@@ -41,7 +47,7 @@ describe("exportTypeDescriptionToXML", () => {
   it("exports local type namespace when rule requests it", () => {
     const resultXml = exportTypeDescriptionToXML(
       mockContext,
-      { ...mockRule, declareTypeNamespaceXML: true },
+      typeDescriptionRuleWithLocalNamespace,
       { type: ["SettingsComposer"] }
     )
 
@@ -53,7 +59,7 @@ describe("exportTypeDescriptionToXML", () => {
   })
 
   it("does not export local type namespace by default", () => {
-    const resultXml = exportTypeDescriptionToXML(mockContext, mockRule, { type: ["SettingsComposer"] })
+    const resultXml = exportTypeDescriptionToXML(mockContext, typeDescriptionRule, { type: ["SettingsComposer"] })
 
     const result = xmlExport({ TypeDescription: resultXml }, false)
 

--- a/packages/core/metadata/commonObjects/typeDescription/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/typeDescription/toXML.test.ts
@@ -38,6 +38,28 @@ describe("exportTypeDescriptionToXML", () => {
     expect(result).toEqual(`<TypeDescription>\n\t<v8:Type>${xmlType}</v8:Type>\n</TypeDescription>`)
   })
 
+  it("exports local type namespace when rule requests it", () => {
+    const resultXml = exportTypeDescriptionToXML(
+      mockContext,
+      { ...mockRule, declareTypeNamespaceXML: true },
+      { type: ["SettingsComposer"] }
+    )
+
+    const result = xmlExport({ TypeDescription: resultXml }, false)
+
+    expect(result).toEqual(
+      '<TypeDescription>\n\t<v8:Type xmlns:dcsset="http://v8.1c.ru/8.1/data-composition-system/settings">dcsset:SettingsComposer</v8:Type>\n</TypeDescription>'
+    )
+  })
+
+  it("does not export local type namespace by default", () => {
+    const resultXml = exportTypeDescriptionToXML(mockContext, mockRule, { type: ["SettingsComposer"] })
+
+    const result = xmlExport({ TypeDescription: resultXml }, false)
+
+    expect(result).toEqual("<TypeDescription>\n\t<v8:Type>dcsset:SettingsComposer</v8:Type>\n</TypeDescription>")
+  })
+
   it("should export known system enumeration type to XML with v8 prefix", () => {
     const resultXml = exportTypeDescriptionToXML(mockContext, mockRule, { type: ["FillChecking"] })
 

--- a/packages/core/metadata/commonObjects/typeDescription/toXML.ts
+++ b/packages/core/metadata/commonObjects/typeDescription/toXML.ts
@@ -3,7 +3,6 @@ import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { ConfigurationContext } from "../../context/types"
 import { getSystemEnumerationTypeDescriptionRule, getTypeDescriptionRule } from "./helper"
 import { TypeDescription, TypeDescriptionXML, TypeDescriptionXMLType } from "./types"
-import type { TypeDescriptionPropertyRule } from "./types"
 
 export const exportTypeDescriptionToXML = (
   _context: ConfigurationContext,
@@ -30,7 +29,7 @@ export const exportTypeDescriptionToXML = (
 }
 
 const shouldDeclareTypeNamespace = (rule: PropertyRule | undefined): boolean =>
-  Boolean((rule as TypeDescriptionPropertyRule | undefined)?.declareTypeNamespaceXML)
+  Boolean(rule && "declareTypeNamespaceXML" in rule && rule.declareTypeNamespaceXML)
 
 const getTypesXML = (
   typeDescription: TypeDescription,

--- a/packages/core/metadata/commonObjects/typeDescription/toXML.ts
+++ b/packages/core/metadata/commonObjects/typeDescription/toXML.ts
@@ -3,6 +3,7 @@ import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { ConfigurationContext } from "../../context/types"
 import { getSystemEnumerationTypeDescriptionRule, getTypeDescriptionRule } from "./helper"
 import { TypeDescription, TypeDescriptionXML, TypeDescriptionXMLType } from "./types"
+import type { TypeDescriptionPropertyRule } from "./types"
 
 export const exportTypeDescriptionToXML = (
   _context: ConfigurationContext,
@@ -14,7 +15,7 @@ export const exportTypeDescriptionToXML = (
   const numberQualifiers = getNumberQualifiers(typeDescription)
   const dateQualifiers = getDateQualifiers(typeDescription)
 
-  const typesXML = getTypesXML(typeDescription)
+  const typesXML = getTypesXML(typeDescription, shouldDeclareTypeNamespace(_rule))
   const typeIdXML = getTypeIdXML(typeDescription)
 
   const result = {
@@ -28,8 +29,12 @@ export const exportTypeDescriptionToXML = (
   return result
 }
 
+const shouldDeclareTypeNamespace = (rule: PropertyRule | undefined): boolean =>
+  Boolean((rule as TypeDescriptionPropertyRule | undefined)?.declareTypeNamespaceXML)
+
 const getTypesXML = (
-  typeDescription: TypeDescription
+  typeDescription: TypeDescription,
+  declareTypeNamespace: boolean
 ): {
   "v8:Type"?: TypeDescriptionXMLType[] | TypeDescriptionXMLType
   "v8:TypeSet"?: TypeDescriptionXMLType[] | TypeDescriptionXMLType
@@ -48,7 +53,7 @@ const getTypesXML = (
     if (!rule) throw new Error(`Type ${type} not found in TypeDescriptionRules`)
 
     const typeXML = `${rule.prefix}:${type}`
-    const item = rule.namespace
+    const item = shouldExportTypeNamespace(rule, declareTypeNamespace)
       ? {
           [`_xmlns:${rule.prefix}`]: rule.namespace,
           "#text": typeXML,
@@ -67,6 +72,12 @@ const getTypesXML = (
     ...(typeSetXML.length > 0 ? { "v8:TypeSet": typeSetXML.length === 1 ? typeSetXML[0] : typeSetXML } : undefined),
   }
 }
+
+const shouldExportTypeNamespace = (
+  rule: ReturnType<typeof getTypeDescriptionRule>,
+  declareTypeNamespace: boolean
+): rule is NonNullable<typeof rule> & { namespace: string } =>
+  Boolean(rule?.namespace && (declareTypeNamespace || rule.prefix !== "dcsset"))
 
 const getTypeIdXML = (typeDescription: TypeDescription): TypeDescriptionXML["v8:TypeId"] | undefined => {
   if (typeDescription.typeId === undefined || typeDescription.typeId.length === 0) return undefined

--- a/packages/core/metadata/commonObjects/typeDescription/types.ts
+++ b/packages/core/metadata/commonObjects/typeDescription/types.ts
@@ -1,4 +1,5 @@
 import { Static, Type } from "@sinclair/typebox"
+import type { BasePropertyRule } from "~/metadata/orchestration"
 
 export type TypeModifier = "complex" | "typeset" | "alwaysType"
 
@@ -8,6 +9,11 @@ export interface TypeDescriptionRule {
   namespace?: string
   modifier?: TypeModifier
   ignoreInEnterprise?: boolean
+}
+
+export type TypeDescriptionPropertyRule = BasePropertyRule & {
+  type: "TypeDescription"
+  declareTypeNamespaceXML?: boolean
 }
 
 export const TypeDescriptionRules: Record<string, TypeDescriptionRule> = {
@@ -209,14 +215,17 @@ export const TypeDescriptionRules: Record<string, TypeDescriptionRule> = {
   SettingsComposer: {
     enterprise: "КомпоновщикНастроекКомпоновкиДанных",
     prefix: "dcsset",
+    namespace: "http://v8.1c.ru/8.1/data-composition-system/settings",
   },
   Filter: {
     enterprise: "Отбор",
     prefix: "dcsset",
+    namespace: "http://v8.1c.ru/8.1/data-composition-system/settings",
   },
   DataCompositionComparisonType: {
     enterprise: "DataCompositionComparisonType",
     prefix: "dcsset",
+    namespace: "http://v8.1c.ru/8.1/data-composition-system/settings",
   },
   Field: {
     enterprise: "ПолеКомпоновкиДанных",

--- a/packages/core/metadata/commonObjects/typeDescription/types.ts
+++ b/packages/core/metadata/commonObjects/typeDescription/types.ts
@@ -1,5 +1,4 @@
 import { Static, Type } from "@sinclair/typebox"
-import type { BasePropertyRule } from "~/metadata/orchestration"
 
 export type TypeModifier = "complex" | "typeset" | "alwaysType"
 
@@ -9,11 +8,6 @@ export interface TypeDescriptionRule {
   namespace?: string
   modifier?: TypeModifier
   ignoreInEnterprise?: boolean
-}
-
-export type TypeDescriptionPropertyRule = BasePropertyRule & {
-  type: "TypeDescription"
-  declareTypeNamespaceXML?: boolean
 }
 
 export const TypeDescriptionRules: Record<string, TypeDescriptionRule> = {

--- a/packages/core/metadata/forms/clientApplicationForm/rules.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/rules.ts
@@ -455,6 +455,7 @@ export const ClientApplicationFormRules = {
         onReopen: "ПриПовторномОткрытии",
         onCreateAtServer: "ПриСозданииНаСервере",
         onSaveDataInSettingsAtServer: "ПриСохраненииДанныхВНастройкахНаСервере",
+        onUpdateUserSettingSetAtServer: "ПриОбновленииСоставаПользовательскихНастроекНаСервере",
         onClientApplicationSuspend: "ПриЗасыпанииКлиентскогоПриложения",
         onClientApplicationResume: "ПриПробужденииКлиентскогоПриложения",
 

--- a/packages/core/metadata/forms/commonObjects/dynamicList/fromXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/fromXML.test.ts
@@ -197,6 +197,25 @@ describe("import DynamicList from XML", () => {
     })
   })
 
+  it("imports repeated KeyField nodes as keyFields array", () => {
+    const result = importPropertyFromXML({
+      context: mockContextFromXML(),
+      rule,
+      value: {
+        "_xsi:type": "DynamicList",
+        KeyType: "RowKey",
+        KeyField: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+      },
+    })
+
+    expect(result).toEqual({
+      itemType: "DynamicList",
+      customQuery: false,
+      keyType: "RowKey",
+      keyFields: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+    })
+  })
+
   it("round-trip: queryTextWithManualQueryFalse.xml import -> export", () => {
     const imported = testImportPropertyFromXML({
       rule,

--- a/packages/core/metadata/forms/commonObjects/dynamicList/fromYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/fromYAML.test.ts
@@ -90,4 +90,21 @@ describe("import DynamicList from YAML", () => {
       },
     })
   })
+
+  it("imports ПоляКлюча array as keyFields array", () => {
+    const result = testImportPropertyFromYAML({
+      rule,
+      value: {
+        ВидКлюча: "КлючСтроки",
+        ПоляКлюча: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+      },
+    })
+
+    expect(result).toEqual({
+      itemType: "DynamicList",
+      customQuery: false,
+      keyType: "RowKey",
+      keyFields: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+    })
+  })
 })

--- a/packages/core/metadata/forms/commonObjects/dynamicList/rules.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/rules.ts
@@ -114,6 +114,7 @@ export const DynamicListRules = {
       xml: "KeyField",
       yaml: "ПоляКлюча",
       order: 5,
+      preserveFromReferenceXML: true,
     },
     itemsViewMode: {
       type: "SystemEnumeration",

--- a/packages/core/metadata/forms/commonObjects/dynamicList/rules.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/rules.ts
@@ -110,7 +110,7 @@ export const DynamicListRules = {
       defaultValueYAML: "Auto",
     },
     keyFields: {
-      type: "string",
+      type: "DynamicListKeyFields",
       xml: "KeyField",
       yaml: "ПоляКлюча",
       order: 5,

--- a/packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts
@@ -135,4 +135,22 @@ describe("export DynamicList to XML", () => {
     expect(result).toContain("<KeyField>Контрагент</KeyField>")
     expect(result).toContain("<KeyField>ИдентификаторОрганизации</KeyField>")
   })
+
+  it("exports keyFields array as repeated KeyField nodes", () => {
+    const { result } = testExportPropertyToXML({
+      rule,
+      value: {
+        itemType: "DynamicList",
+        keyType: "RowKey",
+        keyFields: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+      },
+      xmlRootTag: "Settings",
+    })
+
+    expect(result.match(/<KeyField>/g)).toHaveLength(3)
+    expect(result).toContain("<KeyType>RowKey</KeyType>")
+    expect(result).toContain("<KeyField>КлючПриглашения</KeyField>")
+    expect(result).toContain("<KeyField>Контрагент</KeyField>")
+    expect(result).toContain("<KeyField>ИдентификаторОрганизации</KeyField>")
+  })
 })

--- a/packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/toXML.test.ts
@@ -113,4 +113,26 @@ describe("export DynamicList to XML", () => {
     expect(keyFieldIndex).toBeGreaterThan(keyTypeIndex)
     expect(listSettingsIndex).toBeGreaterThan(keyFieldIndex)
   })
+
+  it("preserves reference KeyField when current value is undefined", () => {
+    const { result } = testExportPropertyToXML({
+      rule,
+      value: {
+        itemType: "DynamicList",
+        keyType: "RowKey",
+        keyFields: undefined,
+      },
+      referenceMetadata: {
+        itemType: "DynamicList",
+        keyType: "RowKey",
+        keyFields: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+      },
+      xmlRootTag: "Settings",
+    })
+
+    expect(result).toContain("<KeyType>RowKey</KeyType>")
+    expect(result).toContain("<KeyField>КлючПриглашения</KeyField>")
+    expect(result).toContain("<KeyField>Контрагент</KeyField>")
+    expect(result).toContain("<KeyField>ИдентификаторОрганизации</KeyField>")
+  })
 })

--- a/packages/core/metadata/forms/commonObjects/dynamicList/toYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/toYAML.test.ts
@@ -84,6 +84,25 @@ describe("export DynamicList to YAML", () => {
     })
   })
 
+  it("exports keyFields array as ПоляКлюча array", () => {
+    const result = exportPropertyToYAML({
+      context: mockContextToTypedYAML,
+      rule,
+      value: {
+        itemType: "DynamicList",
+        keyType: "RowKey",
+        keyFields: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+      },
+    })
+
+    expect(result).toEqual({
+      ДинамическийСписок: {
+        ВидКлюча: "КлючСтроки",
+        ПоляКлюча: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+      },
+    })
+  })
+
   it("does not export ManualQuery true when queryText is present and collects query file", () => {
     const externalFilesCollector: { relativePath: string; content: string }[] = []
     const queryText = "ВЫБРАТЬ\n  Справочник1.Ссылка\nИЗ\n  Справочник.Справочник1 КАК Справочник1"

--- a/packages/core/metadata/forms/commonObjects/dynamicList/types.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/types.ts
@@ -14,6 +14,30 @@ export type DynamicListXML = {
   [key: string]: unknown
 }
 
+const importDynamicListKeyFieldsFromXML = (
+  _context: ConfigurationContextFromXML,
+  _rule: PropertyRule,
+  value: unknown
+): string | string[] | undefined => {
+  if (value === undefined) return undefined
+  if (Array.isArray(value)) {
+    const items = value.map(normalizeKeyField).filter((item): item is string => item !== undefined)
+    return items.length > 0 ? items : undefined
+  }
+  return normalizeKeyField(value)
+}
+
+const normalizeKeyField = (value: unknown): string | undefined => {
+  if (typeof value === "string" || typeof value === "number") return value.toString()
+  if (value && typeof value === "object" && "#text" in value) {
+    const text = (value as { "#text"?: unknown })["#text"]
+    return text === undefined ? undefined : String(text)
+  }
+  return undefined
+}
+
+registerTypeRule("DynamicListKeyFields", "importFromXML", importDynamicListKeyFieldsFromXML)
+
 registerMetadataItemRule({
   propertyType: "DynamicList",
   itemRule: DynamicListRules,

--- a/packages/core/metadata/forms/commonObjects/event/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/event/toXML.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { ClientApplicationFormRules } from "~/metadata/forms/clientApplicationForm/rules"
+import { testExportPropertyToXML } from "~/tests/property/exportPropertyToXML"
+
+describe("export Events to XML", () => {
+  it("exports form user settings update event with canonical XML case", () => {
+    const { result } = testExportPropertyToXML({
+      rule: ClientApplicationFormRules.properties.events,
+      value: {
+        onUpdateUserSettingSetAtServer: "ПриОбновленииСоставаПользовательскихНастроекНаСервере",
+      },
+      referenceMetadata: {
+        onUpdateUserSettingSetAtServer: "ПриОбновленииСоставаПользовательскихНастроекНаСервере",
+      },
+      xmlRootTag: "Events",
+    })
+
+    expect(result).toEqual(
+      '<Events>\n' +
+        '\t<Event name="OnUpdateUserSettingSetAtServer">ПриОбновленииСоставаПользовательскихНастроекНаСервере</Event>\n' +
+        "</Events>"
+    )
+  })
+})

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromXML.test.ts
@@ -225,6 +225,35 @@ describe("importFormAttributesFromXML", () => {
     expect(result).toEqual(valueListWithReferenceEmptySettings)
   })
 
+  it("imports DynamicList Settings with repeated KeyField nodes", () => {
+    const result = importFormAttributesFromXML(mockContextFromXML(), mockRule, {
+      Attribute: [{
+        _name: "Список",
+        _id: "1",
+        Settings: {
+          "_xsi:type": "DynamicList",
+          KeyType: "RowKey",
+          KeyField: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+        },
+      }],
+    })
+
+    expect(result).toEqual([
+      {
+        itemType: "FormAttribute",
+        name: "Список",
+        title: { items: { ru: "" } },
+        columns: [],
+        dynamicList: {
+          itemType: "DynamicList",
+          customQuery: false,
+          keyType: "RowKey",
+          keyFields: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+        },
+      },
+    ])
+  })
+
   // it("should throw error when ConditionalAppearance is present in XML", () => {
   //   const xmlData = readAndParseXMLFile<{ Attributes: FormAttributesXML }>("formAttributes/conditionalAppearance.xml")
 

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toXML.test.ts
@@ -10,7 +10,7 @@ import {
   withEmptySettingsFormAttribute,
   withoutTypeFormAttribute,
 } from "~/tests/fixtures/formAttributes/data"
-import { mockContextToXML, mockRule } from "~/tests/mockContext"
+import { mockContextFromXML, mockContextToXML, mockRule } from "~/tests/mockContext"
 import { testExportPropertyToXML } from "~/tests/property/exportPropertyToXML"
 import { testImportPropertyFromXML } from "~/tests/property/importPropertyFromXML"
 import { readXMLFileAsString } from "~/tests/readAndParseXMLFile"
@@ -28,6 +28,7 @@ import { treeWithColumn } from "./__fixtures__/treeWithColumn"
 import { twoTables } from "./__fixtures__/twoTables"
 import { valueListWithReferenceEmptySettings } from "./__fixtures__/valueListWithReferenceEmptySettings"
 import { valueListWithoutSettings } from "./__fixtures__/valueListWithoutSettings"
+import { importFormAttributesFromXML } from "./fromXML"
 import { exportFormAttributesToXML } from "./toXML"
 
 const formAttributesRule = { type: "FormAttributes", xml: "Attribute" } as const
@@ -258,6 +259,34 @@ describe("exportFormAttributesToXML", () => {
     })
 
     expect(result).toEqual(expectedResult)
+  })
+
+  it("round-trip keeps repeated DynamicList KeyField nodes in Settings", () => {
+    const context = mockContextToXML()
+    const value = importFormAttributesFromXML(
+      mockContextFromXML({ forReference: true }),
+      mockRule,
+      {
+        Attribute: [{
+          _name: "Список",
+          _id: "1",
+          Settings: {
+            "_xsi:type": "DynamicList",
+            KeyType: "RowKey",
+            KeyField: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+          },
+        }],
+      }
+    )
+
+    const xmlData = exportFormAttributesToXML(context, mockRule, value, value)
+    const result = xmlExport(xmlData!, false)
+
+    expect(result.match(/<KeyField>/g)).toHaveLength(3)
+    expect(result).toContain("<KeyType>RowKey</KeyType>")
+    expect(result).toContain("<KeyField>КлючПриглашения</KeyField>")
+    expect(result).toContain("<KeyField>Контрагент</KeyField>")
+    expect(result).toContain("<KeyField>ИдентификаторОрганизации</KeyField>")
   })
 
   it("export attributeAnyType", () => {

--- a/packages/core/metadata/forms/elements/graphicalSchemaField/__fixtures__/data.ts
+++ b/packages/core/metadata/forms/elements/graphicalSchemaField/__fixtures__/data.ts
@@ -11,7 +11,7 @@ import {
 } from "~/tests/fixtures/forms/base/formField/rules"
 import { RequiredFieldsElement } from "~/tests/types"
 
-export const fullGraphicalSchemaField: RequiredFieldsElement<GraphicalSchemaField> = {
+export const fullGraphicalSchemaField = {
   itemType: "GraphicalSchemaField",
   name: "ПолеГрафическойСхемы",
   title: {
@@ -36,7 +36,7 @@ export const fullGraphicalSchemaField: RequiredFieldsElement<GraphicalSchemaFiel
     onActivate: "ПроцедураАктивации",
   },
   ...fullFormFieldCommonFixture,
-} satisfies RequiredFieldsElement<GraphicalSchemaField>
+} satisfies Omit<RequiredFieldsElement<GraphicalSchemaField>, "edit">
 
 export const fullGraphicalSchemaFieldEnterprise = {
   ElementType: "FormField",

--- a/packages/core/metadata/forms/elements/graphicalSchemaField/rules.ts
+++ b/packages/core/metadata/forms/elements/graphicalSchemaField/rules.ts
@@ -12,7 +12,7 @@ export const GraphicalSchemaFieldRules = {
     autoMaxHeight: { yaml: "АвтоМаксимальнаяВысота", type: "boolean" },
     autoMaxWidth: { yaml: "АвтоМаксимальнаяШирина", type: "boolean" },
     borderColor: { yaml: "ЦветРамки", type: "Color" },
-    edit: { yaml: "Редактирование", type: "boolean", runtimeOnly: true },
+    edit: { yaml: "Редактирование", type: "boolean", toYAML: false, fromYAML: false, toEnterprise: false },
     height: { yaml: "Высота", type: "number" },
     horizontalStretch: { yaml: "РастягиватьПоГоризонтали", type: "boolean" },
     maxHeight: { yaml: "МаксимальнаяВысота", type: "number" },

--- a/packages/core/metadata/forms/elements/graphicalSchemaField/toXML.test.ts
+++ b/packages/core/metadata/forms/elements/graphicalSchemaField/toXML.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { exportElementToXML } from "~/metadata/orchestration"
+import { mockContextToXML } from "~/tests/mockContext"
+import { xmlExport } from "~/xml/export/exporter"
+import { GraphicalSchemaField } from "./types"
+
+describe("export GraphicalSchemaField to XML", () => {
+  it("exports XML-only Edit value", () => {
+    const element: GraphicalSchemaField = {
+      itemType: "GraphicalSchemaField",
+      name: "Схема",
+      edit: false,
+    }
+
+    const xmlData = exportElementToXML({
+      context: mockContextToXML(),
+      element,
+    })
+    const result = xmlExport({ GraphicalSchemaField: xmlData }, false)
+
+    expect(result).toContain("<Edit>false</Edit>")
+  })
+})

--- a/packages/core/metadata/orchestration/property/fromXML.ts
+++ b/packages/core/metadata/orchestration/property/fromXML.ts
@@ -37,6 +37,9 @@ export function importPropertiesFromXML<Rule extends MetadataItemRule>(
     ) {
       xmlValue = null
     }
+    if (xmlValue === undefined && currentRule.type === "MetadataValue" && isXMLKeyPresent(key, xml, currentRule)) {
+      xmlValue = { "_xsi:nil": true }
+    }
     const shouldImportForReference =
       forReference &&
       currentRule.fromXML === false &&

--- a/packages/core/metadata/orchestration/property/registry.ts
+++ b/packages/core/metadata/orchestration/property/registry.ts
@@ -553,6 +553,10 @@ export type PropertyTypeRegistry = {
     enterprise: string[]
     yaml: FieldsListYAML
   }
+  DynamicListKeyFields: {
+    item: string | string[]
+    yaml: string | string[]
+  }
   FunctionalOptions: {
     item: FunctionalOptions
     enterprise: string[]
@@ -1128,6 +1132,7 @@ export const PropertyRuleTypeKeys = Object.keys({
   ChoiceParameterLinks: "ChoiceParameterLinks",
   ChoiceParameters: "ChoiceParameters",
   FieldsList: "FieldsList",
+  DynamicListKeyFields: "DynamicListKeyFields",
   FunctionalOptions: "FunctionalOptions",
   IndexField: "IndexField",
   MetadataAttribute: "MetadataAttribute",

--- a/packages/core/metadata/orchestration/property/toXML.ts
+++ b/packages/core/metadata/orchestration/property/toXML.ts
@@ -57,10 +57,9 @@ export const exportPropertiesToXML = <Rule extends MetadataItemRule>(params: {
       const value = metadataHasOwnKey ? (metadata as any)[key] : undefined
       const referenceValue = referenceMetadata === undefined ? undefined : (referenceMetadata as any)[key]
 
-      let valueToExport =
-        metadataHasOwnKey && !(ruleProp.preserveFromReferenceXML === true && value === undefined)
-          ? value
-          : referenceValue
+      const shouldUseReferenceForUndefined =
+        ruleProp.preserveFromReferenceXML === true && value === undefined && (ruleProp as any).exportNilValue !== true
+      let valueToExport = metadataHasOwnKey && !shouldUseReferenceForUndefined ? value : referenceValue
 
       // derivedFrom: вычисляем значение из наличия связанного свойства, если в модели нет явного значения
       if ("derivedFrom" in ruleProp && (ruleProp as any).derivedFrom?.externalFile && !metadataHasOwnKey) {

--- a/packages/core/metadata/orchestration/property/toXML.ts
+++ b/packages/core/metadata/orchestration/property/toXML.ts
@@ -57,7 +57,10 @@ export const exportPropertiesToXML = <Rule extends MetadataItemRule>(params: {
       const value = metadataHasOwnKey ? (metadata as any)[key] : undefined
       const referenceValue = referenceMetadata === undefined ? undefined : (referenceMetadata as any)[key]
 
-      let valueToExport = metadataHasOwnKey ? value : referenceValue
+      let valueToExport =
+        metadataHasOwnKey && !(ruleProp.preserveFromReferenceXML === true && value === undefined)
+          ? value
+          : referenceValue
 
       // derivedFrom: вычисляем значение из наличия связанного свойства, если в модели нет явного значения
       if ("derivedFrom" in ruleProp && (ruleProp as any).derivedFrom?.externalFile && !metadataHasOwnKey) {

--- a/packages/core/metadata/orchestration/property/types.ts
+++ b/packages/core/metadata/orchestration/property/types.ts
@@ -198,6 +198,7 @@ export interface StandardAttributeDescriptionPropertyRule extends BasePropertyRu
 export interface StandardAttributeDescriptionsPropertyRule extends BasePropertyRule {
   type: "StandardAttributeDescriptions"
   standartAttributeNames: Record<string, string>
+  standartAttributeNamesXML?: (metadataItem: unknown) => Record<string, string>
 }
 
 export interface EventsPropertyRule extends BasePropertyRule {

--- a/packages/core/metadata/orchestration/property/types.ts
+++ b/packages/core/metadata/orchestration/property/types.ts
@@ -218,6 +218,7 @@ export interface TableAdditionalSourcePropertyRule extends BasePropertyRule {
 export interface TypeDescriptionPropertyRule extends BasePropertyRule {
   type: "TypeDescription"
   addTypeDescriptionAttributeToXML?: true
+  declareTypeNamespaceXML?: boolean
 }
 
 export interface DataPathPropertyRule extends BasePropertyRule {


### PR DESCRIPTION
## Что сделано
- сохранение пустого MetadataAttribute Type и локального namespace TypeDescription
- сохранение DCS Field, v8 Type Undefined и nil MetadataValue
- исправления RecordType, событий формы, GraphicalSchemaField Edit и DynamicList KeyField
- уточнение preserveFromReferenceXML для явного nil DCS параметра

## Проверки
- pnpm --filter @nakidka/core exec vitest run metadata/forms/commonObjects/dynamicList/fromXML.test.ts metadata/forms/commonObjects/dynamicList/toXML.test.ts metadata/forms/commonObjects/dynamicList/fromYAML.test.ts metadata/forms/commonObjects/dynamicList/toYAML.test.ts metadata/forms/commonObjects/formAttribute/fromXML.test.ts metadata/forms/commonObjects/formAttribute/toXML.test.ts
- pnpm --filter @nakidka/core type-check
- env NKDK_XML_REPO=/Users/nikita/git/round-trip-source NKDK_XML_DIR=/Users/nikita/git/round-trip-source/trade ./.agents/skills/round-trip-xml/round-trip.sh --triage --batch-size 5
- pnpm --filter '@nakidka/core' test