### PR TITLE
fix: исправить round-trip XML acc diffs

### DIFF
--- a/docs/superpowers/plans/2026-05-18-dcs-available-fields-item-order.md
+++ b/docs/superpowers/plans/2026-05-18-dcs-available-fields-item-order.md
@@ -1,0 +1,168 @@
+# DCS AvailableFields Item Order Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve 1C XML order for object-form `AvailableFields` items by exporting `dcsset:use` before `dcsset:field`.
+
+**Architecture:** The model shape stays unchanged: `AvailableFieldItem` already stores `field`, optional `use`, and optional presentation fields. `fromXML` remains order-insensitive; only the local expected XML fixture and `toXML` object construction order change.
+
+**Tech Stack:** TypeScript, Vitest, existing `@nakidka/core` metadata XML round-trip fixtures.
+
+---
+
+## File Structure
+
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/__fixtures__/selected-item.xml`
+  - Responsibility: expected XML for object-form `AvailableFields` items.
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/toXML.ts`
+  - Responsibility: export `AvailableFieldItem` values to XML object keys in stable order.
+
+No type changes are needed.
+
+---
+
+### Task 1: Correct Selected Item Fixture Order
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/__fixtures__/selected-item.xml`
+
+- [ ] **Step 1: Move `dcsset:use` before `dcsset:field` in the first object item**
+
+Change the first `dcsset:item` from:
+
+```xml
+<dcsset:item>
+	<dcsset:field>Документ</dcsset:field>
+	<dcsset:use>true</dcsset:use>
+	<dcsset:title>
+```
+
+to:
+
+```xml
+<dcsset:item>
+	<dcsset:use>true</dcsset:use>
+	<dcsset:field>Документ</dcsset:field>
+	<dcsset:title>
+```
+
+- [ ] **Step 2: Move `dcsset:use` before `dcsset:field` in the second object item**
+
+Change the second `dcsset:item` from:
+
+```xml
+<dcsset:item>
+	<dcsset:field>Документ</dcsset:field>
+	<dcsset:use>false</dcsset:use>
+	<dcsset:lwsTitle>
+```
+
+to:
+
+```xml
+<dcsset:item>
+	<dcsset:use>false</dcsset:use>
+	<dcsset:field>Документ</dcsset:field>
+	<dcsset:lwsTitle>
+```
+
+- [ ] **Step 3: Run focused tests and record the expected red state**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/availableFields/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/availableFields/toXML.test.ts
+```
+
+Expected:
+
+- `fromXML.test.ts` remains green because import does not depend on child-node order.
+- `toXML.test.ts` fails for the selected-item fixture because `toXML.ts` still exports `field` before `use`.
+
+- [ ] **Step 4: Do not commit**
+
+Leave the fixture change unstaged for the next task.
+
+---
+
+### Task 2: Export Object AvailableFields Items In 1C Order
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/toXML.ts`
+- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/fromXML.test.ts`
+- Test: `packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/toXML.test.ts`
+
+- [ ] **Step 1: Update object-form export order**
+
+In `exportItem`, keep the string branch unchanged:
+
+```ts
+if (typeof item === "string") return { "dcsset:field": item }
+```
+
+For object items, replace the returned object with this order:
+
+```ts
+return {
+  ...(item.use !== undefined ? { "dcsset:use": item.use } : {}),
+  "dcsset:field": item.field,
+  ...(item.title !== undefined
+    ? { "dcsset:title": exportI8nTextToXML(context, { type: "I8nText" }, item.title) }
+    : {}),
+  ...(item.lwsTitle !== undefined
+    ? { "dcsset:lwsTitle": exportI8nTextToXML(context, { type: "I8nText" }, item.lwsTitle) }
+    : {}),
+  ...(item.viewMode !== undefined ? { "dcsset:viewMode": item.viewMode } : {}),
+}
+```
+
+- [ ] **Step 2: Run focused tests and confirm green state**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/availableFields/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/availableFields/toXML.test.ts
+```
+
+Expected: all tests in both files pass.
+
+- [ ] **Step 3: Inspect the diff**
+
+Run:
+
+```bash
+git diff -- packages/core/metadata/commonObjects/dataCompositionSystem/availableFields
+```
+
+Expected:
+
+- `selected-item.xml` has `dcsset:use` before `dcsset:field` in both object-form items.
+- `toXML.ts` emits `dcsset:use` before `dcsset:field` only for object-form items.
+- No unrelated files changed.
+
+- [ ] **Step 4: Commit the implementation**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/dataCompositionSystem/availableFields
+git commit -m "fix: :bug: сохранить порядок AvailableFields"
+```
+
+---
+
+## Final Verification
+
+After both tasks and reviews complete, run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/availableFields
+```
+
+Expected: the full `availableFields` test directory passes.
+
+Before closing the whole round-trip discrepancy series, run full project verification from the repository root:
+
+```bash
+pnpm test
+```

--- a/docs/superpowers/plans/2026-05-18-dcs-ent-system-enumeration-round-trip.md
+++ b/docs/superpowers/plans/2026-05-18-dcs-ent-system-enumeration-round-trip.md
@@ -1,0 +1,234 @@
+# DCS Ent System Enumeration Round-trip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve inferred `ent:*` DCS system enumeration type information through XML import and export.
+
+**Architecture:** Add a typed system-enumeration value shape to `MetadataDcsMetadataSingleValue`. `fromXML` will return that shape only for inferred `ent:*` values under non-system-enumeration rules, and `toXML` will detect that shape before switching on `rule.valueType`.
+
+**Tech Stack:** TypeScript, Vitest, existing DCS metadata value helpers.
+
+---
+
+### File Map
+
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts`
+  - Add a typed system-enumeration value shape to `MetadataDcsMetadataSingleValue`.
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts`
+  - Return `{ type: "SystemEnumeration", typeSE, value }` for inferred `ent:*`.
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.ts`
+  - Export the typed shape through `exportSystemEnumerationToDcsXML`.
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts`
+  - Change the inferred fixture expected value to the typed shape.
+  - Include the inferred fixture in XML export fixtures.
+
+### Task 1: Add Failing Fixture Expectations
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts`
+
+- [ ] **Step 1: Add a typed value alias after `fixtureHorizontalAlign`**
+
+```ts
+export const fixtureAccumulationRecordType = {
+  type: "SystemEnumeration",
+  typeSE: "AccumulationRecordType",
+  value: "Expense",
+} as const
+```
+
+- [ ] **Step 2: Update `inferredAccumulationRecordTypeFixture.value`**
+
+Replace:
+
+```ts
+  value: "Expense",
+```
+
+with:
+
+```ts
+  value: fixtureAccumulationRecordType,
+```
+
+- [ ] **Step 3: Add the inferred fixture to export fixtures**
+
+Replace:
+
+```ts
+export const dcsMetadataValueXMLFixtures: DcsMetadataValueFixture[] = [
+  ...dcsMetadataValueFixtures,
+  emptyLocalStringFixture,
+  nilFixture,
+  primitiveTypeRefFixture,
+  primitiveUuidFixture,
+]
+```
+
+with:
+
+```ts
+export const dcsMetadataValueXMLFixtures: DcsMetadataValueFixture[] = [
+  ...dcsMetadataValueFixtures,
+  emptyLocalStringFixture,
+  nilFixture,
+  primitiveTypeRefFixture,
+  primitiveUuidFixture,
+  inferredAccumulationRecordTypeFixture,
+]
+```
+
+- [ ] **Step 4: Run focused tests and verify failure**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.test.ts
+```
+
+Expected: import fails because it returns `"Expense"` instead of typed shape; export fails because the typed shape is not yet supported.
+
+### Task 2: Implement Typed Ent System Enumeration Import And Export
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.ts`
+
+- [ ] **Step 1: Add the typed value to `types.ts`**
+
+Insert before `export type MetadataDcsMetadataSingleValue`:
+
+```ts
+export type MetadataDcsSystemEnumerationValue = {
+  type: "SystemEnumeration"
+  typeSE: keyof SystemEnumerationTypeMap
+  value: string
+}
+```
+
+Add `MetadataDcsSystemEnumerationValue` to the `MetadataDcsMetadataSingleValue` union before `string`.
+
+- [ ] **Step 2: Return typed value for inferred ent system enumeration in `fromXML.ts`**
+
+Replace:
+
+```ts
+  const inferredTypeSE = inferEntSystemEnumerationType(xsi)
+  if (inferredTypeSE !== undefined) {
+    return importSystemEnumerationFromDcsXML(
+      context,
+      { type: "SystemEnumeration", typeSE: inferredTypeSE } as SystemEnumerationPropertyRule,
+      xml as SystemEnumerationDcsValueRootXML
+    )
+  }
+```
+
+with:
+
+```ts
+  const inferredTypeSE = inferEntSystemEnumerationType(xsi)
+  if (inferredTypeSE !== undefined) {
+    const value = importSystemEnumerationFromDcsXML(
+      context,
+      { type: "SystemEnumeration", typeSE: inferredTypeSE } as SystemEnumerationPropertyRule,
+      xml as SystemEnumerationDcsValueRootXML
+    )
+    return { type: "SystemEnumeration", typeSE: inferredTypeSE, value }
+  }
+```
+
+- [ ] **Step 3: Add a type guard in `toXML.ts`**
+
+Add `MetadataDcsSystemEnumerationValue` to the type imports from `./types`.
+
+Insert after `isExplicitTextValue`:
+
+```ts
+const isDcsSystemEnumerationValue = (
+  data: MetadataDcsMetadataValue
+): data is MetadataDcsSystemEnumerationValue =>
+  data !== null &&
+  typeof data === "object" &&
+  !Array.isArray(data) &&
+  "type" in data &&
+  "typeSE" in data &&
+  "value" in data &&
+  data.type === "SystemEnumeration" &&
+  typeof data.value === "string"
+```
+
+- [ ] **Step 4: Export typed system enumeration before the `rule.valueType` switch in `toXML.ts`**
+
+Insert after the explicit text branch:
+
+```ts
+  if (isDcsSystemEnumerationValue(data)) {
+    const out = exportSystemEnumerationToDcsXML(
+      context,
+      { type: "SystemEnumeration", typeSE: data.typeSE } as SystemEnumerationPropertyRule,
+      data.value
+    )
+    if (!out) {
+      throw new Error("DCS MetadataValue: cannot export empty inferred system enumeration")
+    }
+    return out
+  }
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.test.ts
+```
+
+Expected: all DCS metadata value import/export XML tests pass.
+
+### Task 3: Verify And Commit DCS Ent System Enumeration Fix
+
+**Files:**
+- Verify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts`
+- Verify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts`
+- Verify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.ts`
+- Verify: `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts`
+
+- [ ] **Step 1: Run the focused tests again**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.test.ts metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Check diff**
+
+Run:
+
+```bash
+git diff -- packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue
+```
+
+Expected: only typed inferred system enumeration support and fixture expectations changed.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue
+git commit -m "fix: :bug: сохранить ent system enumeration в DCS"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Self-Review
+
+- Spec coverage: inferred `ent:*` import, export through `exportSystemEnumerationToDcsXML`, explicit `valueType: "SystemEnumeration"` unchanged.
+- Placeholder scan: no placeholders remain.
+- Type consistency: the typed shape is named `MetadataDcsSystemEnumerationValue` and uses `typeSE` consistently.

--- a/docs/superpowers/plans/2026-05-18-raw-picture-load-transparent.md
+++ b/docs/superpowers/plans/2026-05-18-raw-picture-load-transparent.md
@@ -1,0 +1,305 @@
+# Raw Picture LoadTransparent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve `xr:LoadTransparent` and `xr:TransparentPixel` for raw `Picture` refs during XML round-trip.
+
+**Architecture:** Extend only the raw picture branch in `packages/core/metadata/commonObjects/picture`. Linked pictures keep their current model and export path; raw refs gain optional XML-only fields that are copied through import/export without guessing defaults.
+
+**Tech Stack:** TypeScript, Vitest, existing metadata type-rule registration.
+
+---
+
+### File Map
+
+- Modify: `packages/core/metadata/commonObjects/picture/types.ts`
+  - Add optional `loadTransparent` and `transparentPixel` to `RawPictureRef`.
+- Modify: `packages/core/metadata/commonObjects/picture/fromXML.ts`
+  - Parse raw `xr:LoadTransparent` only when the XML node exists.
+  - Parse raw `xr:TransparentPixel` the same way linked pictures do.
+- Modify: `packages/core/metadata/commonObjects/picture/toXML.ts`
+  - Export raw `xr:LoadTransparent` and `xr:TransparentPixel` only when present in the model.
+- Modify: `packages/core/metadata/commonObjects/picture/fromXML.test.ts`
+  - Add import tests for raw refs with `false`, `true`, and transparent pixel.
+- Modify: `packages/core/metadata/commonObjects/picture/toXML.test.ts`
+  - Add export tests for raw refs with `false`, `true`, and transparent pixel.
+
+### Task 1: Add Failing Raw Picture XML Import Tests
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/picture/fromXML.test.ts`
+
+- [ ] **Step 1: Add tests after `should import empty raw ref from XML`**
+
+```ts
+  it("should import raw ref with LoadTransparent=false from XML", () => {
+    const rawRef = "0:ca5b178d-2d5a-4cf7-b88e-6fbdb2e56065"
+    const result = importPictureFromXML(mockContextFromXML(), mockRule, {
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": false,
+    })
+
+    expect(result).toEqual({ rawRef, loadTransparent: false })
+  })
+
+  it("should import raw ref with LoadTransparent=true from XML", () => {
+    const rawRef = "0:ca5b178d-2d5a-4cf7-b88e-6fbdb2e56065"
+    const result = importPictureFromXML(mockContextFromXML(), mockRule, {
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": true,
+    })
+
+    expect(result).toEqual({ rawRef, loadTransparent: true })
+  })
+
+  it("should import raw ref with transparent pixel from XML", () => {
+    const rawRef = "0"
+    const result = importPictureFromXML(mockContextFromXML(), mockRule, {
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": true,
+      "xr:TransparentPixel": { _x: "12", _y: "2" },
+    })
+
+    expect(result).toEqual({
+      rawRef,
+      loadTransparent: true,
+      transparentPixel: { x: 12, y: 2 },
+    })
+  })
+```
+
+- [ ] **Step 2: Run import tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/commonObjects/picture/fromXML.test.ts
+```
+
+Expected: the new raw ref tests fail because `importPictureFromXML` currently returns only `{ rawRef }`.
+
+### Task 2: Add Failing Raw Picture XML Export Tests
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/picture/toXML.test.ts`
+
+- [ ] **Step 1: Add tests after `should export empty raw ref to XML`**
+
+```ts
+  it("should export raw ref with LoadTransparent=false to XML", () => {
+    const rawRef = "0:ca5b178d-2d5a-4cf7-b88e-6fbdb2e56065"
+    const result = exportPictureToXML(mockContext, mockRule, { rawRef, loadTransparent: false })
+
+    expect(result).toEqual({
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": false,
+    })
+  })
+
+  it("should export raw ref with LoadTransparent=true to XML", () => {
+    const rawRef = "0:ca5b178d-2d5a-4cf7-b88e-6fbdb2e56065"
+    const result = exportPictureToXML(mockContext, mockRule, { rawRef, loadTransparent: true })
+
+    expect(result).toEqual({
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": true,
+    })
+  })
+
+  it("should export raw ref with transparent pixel to XML", () => {
+    const rawRef = "0"
+    const result = exportPictureToXML(mockContext, mockRule, {
+      rawRef,
+      loadTransparent: true,
+      transparentPixel: { x: 12, y: 2 },
+    })
+
+    expect(result).toEqual({
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": true,
+      "xr:TransparentPixel": { _x: 12, _y: 2 },
+    })
+  })
+```
+
+- [ ] **Step 2: Run export tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/commonObjects/picture/toXML.test.ts
+```
+
+Expected: the new export tests fail because `exportPictureToXML` currently drops raw ref transparency fields.
+
+### Task 3: Preserve Raw Picture Transparency Fields
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/picture/types.ts`
+- Modify: `packages/core/metadata/commonObjects/picture/fromXML.ts`
+- Modify: `packages/core/metadata/commonObjects/picture/toXML.ts`
+
+- [ ] **Step 1: Extend `RawPictureRef` in `types.ts`**
+
+Replace:
+
+```ts
+export type RawPictureRef = { rawRef: string }
+```
+
+with:
+
+```ts
+export type RawPictureRef = {
+  rawRef: string
+  loadTransparent?: boolean
+  transparentPixel?: {
+    x: number
+    y: number
+  }
+}
+```
+
+- [ ] **Step 2: Add a shared transparent pixel reader in `fromXML.ts`**
+
+Insert above `importPictureFromXML`:
+
+```ts
+const importTransparentPixel = (
+  transparentPixel: PictureXML["xr:TransparentPixel"] | undefined
+): { x: number; y: number } | undefined => {
+  if (!transparentPixel) return undefined
+
+  return {
+    x: Number.parseInt(String(transparentPixel._x)),
+    y: Number.parseInt(String(transparentPixel._y)),
+  }
+}
+```
+
+- [ ] **Step 3: Preserve raw ref fields in `fromXML.ts`**
+
+Replace the raw ref branch:
+
+```ts
+  if (xmlRef && isRawPictureRefValue(xmlRef)) {
+    return { rawRef: xmlRef }
+  }
+```
+
+with:
+
+```ts
+  if (xmlRef && isRawPictureRefValue(xmlRef)) {
+    return {
+      rawRef: xmlRef,
+      ...(xml["xr:LoadTransparent"] !== undefined
+        ? { loadTransparent: importBooleanFromXML(context, undefined, xml["xr:LoadTransparent"]) }
+        : {}),
+      ...(xml["xr:TransparentPixel"] !== undefined
+        ? { transparentPixel: importTransparentPixel(xml["xr:TransparentPixel"]) }
+        : {}),
+    }
+  }
+```
+
+- [ ] **Step 4: Reuse the helper for linked pictures in `fromXML.ts`**
+
+Replace:
+
+```ts
+  const transparentPixel = xml["xr:TransparentPixel"]
+    ? {
+        x: Number.parseInt(String(xml["xr:TransparentPixel"]._x)),
+        y: Number.parseInt(String(xml["xr:TransparentPixel"]._y)),
+      }
+    : undefined
+```
+
+with:
+
+```ts
+  const transparentPixel = importTransparentPixel(xml["xr:TransparentPixel"])
+```
+
+- [ ] **Step 5: Preserve raw ref fields in `toXML.ts`**
+
+Replace:
+
+```ts
+  if (isRawPictureRef(picture)) {
+    return { "xr:Ref": picture.rawRef }
+  }
+```
+
+with:
+
+```ts
+  if (isRawPictureRef(picture)) {
+    return {
+      "xr:Ref": picture.rawRef,
+      ...(picture.loadTransparent !== undefined ? { "xr:LoadTransparent": picture.loadTransparent } : {}),
+      ...(picture.transparentPixel
+        ? { "xr:TransparentPixel": { _x: picture.transparentPixel.x, _y: picture.transparentPixel.y } }
+        : {}),
+    }
+  }
+```
+
+- [ ] **Step 6: Run focused picture tests**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/commonObjects/picture/fromXML.test.ts packages/core/metadata/commonObjects/picture/toXML.test.ts
+```
+
+Expected: all picture import/export XML tests pass.
+
+### Task 4: Verify And Commit Raw Picture Fix
+
+**Files:**
+- Verify: `packages/core/metadata/commonObjects/picture/fromXML.test.ts`
+- Verify: `packages/core/metadata/commonObjects/picture/toXML.test.ts`
+- Verify: `packages/core/metadata/commonObjects/picture/types.ts`
+- Verify: `packages/core/metadata/commonObjects/picture/fromXML.ts`
+- Verify: `packages/core/metadata/commonObjects/picture/toXML.ts`
+
+- [ ] **Step 1: Run the focused tests again**
+
+Run:
+
+```bash
+pnpm --filter '@nakidka/core' exec vitest run packages/core/metadata/commonObjects/picture/fromXML.test.ts packages/core/metadata/commonObjects/picture/toXML.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Check the diff**
+
+Run:
+
+```bash
+git diff -- packages/core/metadata/commonObjects/picture/types.ts packages/core/metadata/commonObjects/picture/fromXML.ts packages/core/metadata/commonObjects/picture/toXML.ts packages/core/metadata/commonObjects/picture/fromXML.test.ts packages/core/metadata/commonObjects/picture/toXML.test.ts
+```
+
+Expected: only raw picture transparency support and tests are changed.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/picture/types.ts packages/core/metadata/commonObjects/picture/fromXML.ts packages/core/metadata/commonObjects/picture/toXML.ts packages/core/metadata/commonObjects/picture/fromXML.test.ts packages/core/metadata/commonObjects/picture/toXML.test.ts
+git commit -m "fix: :bug: сохранить прозрачность raw Picture"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Self-Review
+
+- Spec coverage: `LoadTransparent=false`, `LoadTransparent=true`, raw `0` with `TransparentPixel`, no heuristic defaults, and no linked-picture changes are covered.
+- Placeholder scan: no placeholders remain.
+- Type consistency: `RawPictureRef.loadTransparent` and `RawPictureRef.transparentPixel` are used consistently across import, export, and tests.

--- a/docs/superpowers/specs/2026-05-18-dcs-available-fields-item-order-design.md
+++ b/docs/superpowers/specs/2026-05-18-dcs-available-fields-item-order-design.md
@@ -1,0 +1,79 @@
+# DCS AvailableFields item XML order
+
+## Контекст
+
+Второе расхождение из `acc` находится в форме:
+
+`DataProcessors/СверкаДанныхУчетаНДС/Forms/Форма/Ext/Form.xml`
+
+Исходный XML содержит выбранное поле с `use` перед `field`:
+
+```xml
+<dcsset:item>
+  <dcsset:use>false</dcsset:use>
+  <dcsset:field>ВходящиеРеестрыДатаФормирования</dcsset:field>
+</dcsset:item>
+```
+
+После short round-trip текущий экспорт меняет порядок:
+
+```xml
+<dcsset:item>
+  <dcsset:field>ВходящиеРеестрыДатаФормирования</dcsset:field>
+  <dcsset:use>false</dcsset:use>
+</dcsset:item>
+```
+
+`AvailableFields` уже умеет хранить объектную форму элемента с `field`, `use`, `title`,
+`lwsTitle` и `viewMode`. Проблема осталась только в порядке XML-узлов.
+
+## Цель
+
+Сделать XML-экспорт объектного `AvailableFieldItem` совместимым с исходным XML 1C:
+`dcsset:use` должен идти перед `dcsset:field`.
+
+Границы задачи:
+
+- меняется только порядок XML-узлов в `AvailableFields`;
+- строковая форма элемента остается короткой и экспортируется только как `dcsset:field`;
+- существующая XML-фикстура `selected-item.xml` должна быть исправлена, потому что сейчас она
+  закрепляет неправильный порядок;
+- другие DCS-элементы и правила не меняются.
+
+## Дизайн
+
+В `availableFields/toXML.ts` объектную форму элемента экспортировать в порядке:
+
+1. `dcsset:use`, если поле задано;
+2. `dcsset:field`;
+3. `dcsset:title`, если поле задано;
+4. `dcsset:lwsTitle`, если поле задано;
+5. `dcsset:viewMode`, если поле задано.
+
+Такой порядок согласуется с соседними DCS-элементами, где `use` является первым узлом
+(`OrderItemField`, `GroupItemField`, `FilterItemComparison`), и с реальным XML из `acc`.
+
+## Данные и поток
+
+1. `fromXML` читает `dcsset:item` и сохраняет `{ field, use: false }`.
+2. Модель не меняется.
+3. `toXML` получает объектный `AvailableFieldItem` и строит XML-объект с `use` перед `field`.
+4. Сравнение round-trip больше не видит перестановку узлов.
+
+## Тестирование
+
+Обновить `packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/__fixtures__/selected-item.xml`:
+в обоих объектных элементах `dcsset:use` должен идти перед `dcsset:field`.
+
+Проверки:
+
+- `toXML` для `selectedItemAvailableFields` совпадает с обновленной фикстурой;
+- `fromXML` для той же фикстуры остается зеленым;
+- после реализации запустить узкие тесты `availableFields`;
+- перед закрытием всей серии задач запустить полный `pnpm test` из корня.
+
+## Не входит
+
+- Не менять существующие XML-фикстуры из внешнего XML-репозитория.
+- Не добавлять новые правила fromXML/toXML/fromYAML/toYAML.
+- Не решать здесь `ent:*` и `Picture/xr:LoadTransparent` расхождения.

--- a/docs/superpowers/specs/2026-05-18-dcs-ent-system-enumeration-round-trip-design.md
+++ b/docs/superpowers/specs/2026-05-18-dcs-ent-system-enumeration-round-trip-design.md
@@ -1,0 +1,72 @@
+# DCS ent system enumeration round-trip
+
+## Контекст
+
+Первое расхождение из `acc` находится в форме:
+
+`DataProcessors/ПомощникРасчетаНалогаУСН/Forms/РасшифровкаУменьшенияНалогаИнтеграцияСБанком/Ext/Form.xml`
+
+Исходный XML содержит:
+
+```xml
+<dcscor:value xsi:type="ent:AccumulationRecordType">Receipt</dcscor:value>
+```
+
+После short round-trip значение экспортируется как:
+
+```xml
+<dcscor:value xsi:type="dcscor:Field">Receipt</dcscor:value>
+```
+
+Импорт уже распознает `ent:*` через `inferEntSystemEnumerationType`, но возвращает только строковое значение. Из-за этого модель теряет `typeSE`, а экспорт под правилом `valueType: "Primitive"` не может восстановить исходный `xsi:type`.
+
+## Цель
+
+Сохранить тип неявно распознанной DCS system enumeration в модели и восстановить исходный `ent:AccumulationRecordType` при экспорте.
+
+Границы задачи:
+
+- исправляется только DCS MetadataDcsMetadataValue;
+- первая цель - `ent:AccumulationRecordType`, но решение должно работать для любых поддержанных `ent:*`, которые уже распознаются через `inferEntSystemEnumerationType`;
+- расхождения по порядку `dcsset:use` и `Picture/xr:LoadTransparent` остаются отдельными задачами.
+
+## Дизайн
+
+Добавить в `MetadataDcsMetadataSingleValue` отдельную форму для неявной system enumeration:
+
+```ts
+{
+  type: "SystemEnumeration"
+  typeSE: keyof SystemEnumerationTypeMap
+  value: string
+}
+```
+
+При импорте `ent:*` без явного `valueType: "SystemEnumeration"` возвращать эту форму вместо голой строки. При экспорте сначала распознавать эту форму и передавать ее в существующий `exportSystemEnumerationToDcsXML`.
+
+Правила с явным `valueType: "SystemEnumeration"` остаются без изменений: они по-прежнему принимают строковое значение и используют `rule.typeSE`.
+
+## Данные и поток
+
+1. `fromXML` читает `dcscor:value`.
+2. Если `xsi:type` начинается с `ent:` и найден соответствующий тип в `SystemEnumerations`, модель получает `{ type: "SystemEnumeration", typeSE, value }`.
+3. `toXML` видит эту форму независимо от `rule.valueType` и экспортирует `dcscor:value` через `exportSystemEnumerationToDcsXML`.
+4. XML получает тот же `xsi:type`, например `ent:AccumulationRecordType`.
+
+## Ошибки и ограничения
+
+Если `ent:*` не найден в `SystemEnumerations`, текущее поведение остается прежним: импорт завершится ошибкой `unsupported xsi:type`. Это лучше тихой потери типа.
+
+Эвристика по значениям вроде `Receipt`/`Expense` не используется, потому что строка без `xsi:type` не должна превращаться в system enumeration.
+
+## Тестирование
+
+Добавить точечную фикстуру в `packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__` для `ent:AccumulationRecordType`.
+
+Проверки:
+
+- `fromXML` импортирует XML в новую typed-форму;
+- `toXML` экспортирует эту форму обратно в `xsi:type="ent:AccumulationRecordType"`;
+- существующие фикстуры DCS MetadataDcsMetadataValue остаются зелеными.
+
+После реализации запустить узкие тесты `dcsMetadataValue`, а перед закрытием всей серии задач - полный `pnpm test` из корня.

--- a/docs/superpowers/specs/2026-05-18-raw-picture-load-transparent-design.md
+++ b/docs/superpowers/specs/2026-05-18-raw-picture-load-transparent-design.md
@@ -1,0 +1,113 @@
+# Raw Picture LoadTransparent round-trip
+
+## Контекст
+
+Расхождения #3-#5 из `acc` находятся в формах документов:
+
+- `Documents/ПлатежноеПоручение/Forms/ФормаДокумента/Ext/Form.xml`
+- `Documents/ПлатежноеПоручение/Forms/ФормаДокументаНалоговая/Ext/Form.xml`
+- `Documents/ПлатежноеТребование/Forms/ФормаДокумента/Ext/Form.xml`
+
+Во всех случаях исходный XML содержит raw-ссылку на картинку:
+
+```xml
+<Picture>
+  <xr:Ref>0:05f4dd91-2d70-4f80-accc-4f1980cba51a</xr:Ref>
+  <xr:LoadTransparent>false</xr:LoadTransparent>
+</Picture>
+```
+
+или:
+
+```xml
+<Picture>
+  <xr:Ref>0:05f4dd91-2d70-4f80-accc-4f1980cba51a</xr:Ref>
+  <xr:LoadTransparent>true</xr:LoadTransparent>
+</Picture>
+```
+
+После short round-trip `xr:LoadTransparent` пропадает.
+
+## Наблюдения
+
+Для обычных картинок текущая YAML-логика использует дефолты:
+
+- `StandardPicture` -> `loadTransparent=true`;
+- `CommonPicture` и `AbsolutePicture` -> `loadTransparent=false`.
+
+Для XML это значение задано явно. Для raw-ссылок вычислять его из `rawRef` нельзя:
+
+- один и тот же raw ref `0:05f4dd91-2d70-4f80-accc-4f1980cba51a` встречается и с `false`, и с `true`;
+- raw ref `0` встречается с `true` и `xr:TransparentPixel`;
+- raw ref с другим UUID встречается с `false`.
+
+Значит `LoadTransparent` для raw-ссылок является частью XML-состояния, а не выводимым дефолтом.
+
+## Цель
+
+Сохранять `xr:LoadTransparent` и `xr:TransparentPixel` у raw `Picture` при XML round-trip.
+
+Границы задачи:
+
+- меняется только `packages/core/metadata/commonObjects/picture`;
+- обычные `StandardPicture`, `CommonPicture` и `AbsolutePicture` сохраняют текущую модель;
+- raw-ссылка без `LoadTransparent` продолжает round-trip без добавления нового узла;
+- YAML-форма raw-ссылки строкой остается прежней, чтобы не менять существующий YAML без необходимости.
+
+## Дизайн
+
+Расширить `RawPictureRef`:
+
+```ts
+type RawPictureRef = {
+  rawRef: string
+  loadTransparent?: boolean
+  transparentPixel?: {
+    x: number
+    y: number
+  }
+}
+```
+
+`fromXML` для raw-ссылки должен:
+
+1. сохранить `rawRef`;
+2. если `xr:LoadTransparent` задан, сохранить `loadTransparent`;
+3. если `xr:TransparentPixel` задан, сохранить `transparentPixel`.
+
+`toXML` для raw-ссылки должен:
+
+1. всегда писать `xr:Ref`;
+2. писать `xr:LoadTransparent`, только если `loadTransparent` задан;
+3. писать `xr:TransparentPixel`, только если `transparentPixel` задан.
+
+Порядок XML-узлов: `xr:Ref`, затем `xr:LoadTransparent`, затем `xr:TransparentPixel`.
+
+## Данные и поток
+
+1. XML `Picture` с raw `xr:Ref` импортируется в `RawPictureRef`.
+2. Явные настройки прозрачности остаются в модели.
+3. Экспорт raw `Picture` восстанавливает исходные XML-узлы.
+4. Расхождения #3-#5 исчезают одним исправлением.
+
+## Тестирование
+
+Добавить тесты в `picture`:
+
+- импорт raw ref с `xr:LoadTransparent=false`;
+- импорт raw ref с `xr:LoadTransparent=true`;
+- импорт raw ref `0` с `xr:TransparentPixel`;
+- экспорт raw ref с `loadTransparent=false`;
+- экспорт raw ref с `loadTransparent=true`;
+- экспорт raw ref с `transparentPixel`.
+
+Существующие тесты для raw ref без прозрачности должны остаться зелеными.
+
+После реализации запустить узкие тесты `picture`, а перед закрытием всей серии задач - полный
+`pnpm test` из корня.
+
+## Не входит
+
+- Не менять XML-фикстуры внешнего XML-репозитория.
+- Не менять правила или модель обычных linked pictures.
+- Не выводить `LoadTransparent` для raw ref эвристически из значения ссылки.

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/__fixtures__/selected-item.xml
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/__fixtures__/selected-item.xml
@@ -1,7 +1,7 @@
 <dcsset:selection>
 	<dcsset:item>
-		<dcsset:field>Документ</dcsset:field>
 		<dcsset:use>true</dcsset:use>
+		<dcsset:field>Документ</dcsset:field>
 		<dcsset:title>
 			<v8:item>
 				<v8:lang>ru</v8:lang>
@@ -11,8 +11,8 @@
 		<dcsset:viewMode>Normal</dcsset:viewMode>
 	</dcsset:item>
 	<dcsset:item>
-		<dcsset:field>Документ</dcsset:field>
 		<dcsset:use>false</dcsset:use>
+		<dcsset:field>Документ</dcsset:field>
 		<dcsset:lwsTitle>
 			<v8:item>
 				<v8:lang>ru</v8:lang>

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/toXML.ts
@@ -10,8 +10,8 @@ const exportItem = (
   if (typeof item === "string") return { "dcsset:field": item }
 
   return {
-    "dcsset:field": item.field,
     ...(item.use !== undefined ? { "dcsset:use": item.use } : {}),
+    "dcsset:field": item.field,
     ...(item.title !== undefined
       ? { "dcsset:title": exportI8nTextToXML(context, { type: "I8nText" }, item.title) }
       : {}),

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/__fixtures__/data.ts
@@ -43,6 +43,12 @@ export const fixtureLocalStringI8n: I8nText = {
 
 export const fixtureHorizontalAlign = "Center"
 
+export const fixtureAccumulationRecordType = {
+  type: "SystemEnumeration",
+  typeSE: "AccumulationRecordType",
+  value: "Expense",
+} as const
+
 export const fixtureFontStyleExtraLarge: Font = {
   kind: "StyleItem",
   ref: "ExtraLargeTextFont",
@@ -159,7 +165,7 @@ const inferredAccumulationRecordTypeFixture: DcsMetadataValueFixture = {
   id: "systemEnumerationAccumulationRecordTypeInferred",
   title: "SystemEnumeration inferred from ent:AccumulationRecordType",
   rule: { type: "MetadataDcsMetadataValue", valueType: "Primitive", yaml: "value" },
-  value: "Expense",
+  value: fixtureAccumulationRecordType,
   yaml: "Expense",
   xml: "system-enumeration-accumulation-record-type.xml",
 }
@@ -252,9 +258,7 @@ export const dcsMetadataValueXMLFixtures: DcsMetadataValueFixture[] = [
   nilFixture,
   primitiveTypeRefFixture,
   primitiveUuidFixture,
-]
-
-export const dcsMetadataValueFromXMLFixtures: DcsMetadataValueFixture[] = [
-  ...dcsMetadataValueXMLFixtures,
   inferredAccumulationRecordTypeFixture,
 ]
+
+export const dcsMetadataValueFromXMLFixtures: DcsMetadataValueFixture[] = dcsMetadataValueXMLFixtures

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromXML.ts
@@ -233,11 +233,12 @@ const importDcsMetadataValueFromDcsXMLInternal = (
 
   const inferredTypeSE = inferEntSystemEnumerationType(xsi)
   if (inferredTypeSE !== undefined) {
-    return importSystemEnumerationFromDcsXML(
+    const value = importSystemEnumerationFromDcsXML(
       context,
       { type: "SystemEnumeration", typeSE: inferredTypeSE } as SystemEnumerationPropertyRule,
       xml as SystemEnumerationDcsValueRootXML
     )
+    return { type: "SystemEnumeration", typeSE: inferredTypeSE, value }
   }
 
   throw new Error(`DCS MetadataValue: unsupported xsi:type ${String(xsi)} in ${JSON.stringify(root)}`)

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toXML.ts
@@ -22,6 +22,7 @@ import {
   MetadataDcsExplicitTextValue,
   MetadataDcsMetadataValue,
   MetadataDcsMetadataValueDcsRootXML,
+  MetadataDcsSystemEnumerationValue,
 } from "./types"
 
 const isExplicitTextValue = (data: MetadataDcsMetadataValue): data is MetadataDcsExplicitTextValue =>
@@ -30,6 +31,18 @@ const isExplicitTextValue = (data: MetadataDcsMetadataValue): data is MetadataDc
   "type" in data &&
   "value" in data &&
   (data.type === "DesignTimeValue" || data.type === "Field") &&
+  typeof data.value === "string"
+
+const isDcsSystemEnumerationValue = (
+  data: MetadataDcsMetadataValue
+): data is MetadataDcsSystemEnumerationValue =>
+  data !== null &&
+  typeof data === "object" &&
+  !Array.isArray(data) &&
+  "type" in data &&
+  "typeSE" in data &&
+  "value" in data &&
+  data.type === "SystemEnumeration" &&
   typeof data.value === "string"
 
 export const exportDcsMetadataValueToDcsXML = (params: {
@@ -68,6 +81,18 @@ export const exportDcsMetadataValueToDcsXML = (params: {
         "#text": data.value,
       },
     }
+  }
+
+  if (isDcsSystemEnumerationValue(data)) {
+    const out = exportSystemEnumerationToDcsXML(
+      context,
+      { type: "SystemEnumeration", typeSE: data.typeSE } as SystemEnumerationPropertyRule,
+      data.value
+    )
+    if (!out) {
+      throw new Error("DCS MetadataValue: cannot export empty inferred system enumeration")
+    }
+    return out
   }
 
   switch (rule.valueType) {

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/types.ts
@@ -51,6 +51,12 @@ export type MetadataDcsExplicitTextValueYAML =
       Значение: string
     }
 
+export type MetadataDcsSystemEnumerationValue = {
+  type: "SystemEnumeration"
+  typeSE: keyof SystemEnumerationTypeMap
+  value: string
+}
+
 export type MetadataDcsMetadataSingleValue =
   | null
   | Color
@@ -62,6 +68,7 @@ export type MetadataDcsMetadataSingleValue =
   | TypeLink
   | ChoiceParameterLinks
   | Font
+  | MetadataDcsSystemEnumerationValue
   | string
 
 export type MetadataDcsMetadataValue = MetadataDcsMetadataSingleValue | MetadataDcsMetadataSingleValue[]

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsParameter/fromXML.test.ts
@@ -192,7 +192,11 @@ describe("import DCSParameter from XML", () => {
         itemType: "DCSParameter",
         name: "ВидДвижения",
         valueType: { type: ["AccumulationRecordType"] },
-        value: "Expense",
+        value: {
+          type: "SystemEnumeration",
+          typeSE: "AccumulationRecordType",
+          value: "Expense",
+        },
         useRestriction: true,
       },
     ])

--- a/packages/core/metadata/commonObjects/picture/fromXML.test.ts
+++ b/packages/core/metadata/commonObjects/picture/fromXML.test.ts
@@ -33,6 +33,41 @@ describe("importPictureFromXML", () => {
     expect(result).toEqual({ rawRef })
   })
 
+  it("should import raw ref with LoadTransparent=false from XML", () => {
+    const rawRef = "0:ca5b178d-2d5a-4cf7-b88e-6fbdb2e56065"
+    const result = importPictureFromXML(mockContextFromXML(), mockRule, {
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": false,
+    })
+
+    expect(result).toEqual({ rawRef, loadTransparent: false })
+  })
+
+  it("should import raw ref with LoadTransparent=true from XML", () => {
+    const rawRef = "0:ca5b178d-2d5a-4cf7-b88e-6fbdb2e56065"
+    const result = importPictureFromXML(mockContextFromXML(), mockRule, {
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": true,
+    })
+
+    expect(result).toEqual({ rawRef, loadTransparent: true })
+  })
+
+  it("should import raw ref with transparent pixel from XML", () => {
+    const rawRef = "0"
+    const result = importPictureFromXML(mockContextFromXML(), mockRule, {
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": true,
+      "xr:TransparentPixel": { _x: "12", _y: "2" },
+    })
+
+    expect(result).toEqual({
+      rawRef,
+      loadTransparent: true,
+      transparentPixel: { x: 12, y: 2 },
+    })
+  })
+
   it.each(["00", "0:g", "1:ca5b178d-2d5a-4cf7-b88e-6fbdb2e56065"])(
     "should not classify %s as raw ref from XML",
     (ref) => {

--- a/packages/core/metadata/commonObjects/picture/fromXML.ts
+++ b/packages/core/metadata/commonObjects/picture/fromXML.ts
@@ -4,6 +4,17 @@ import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { importBooleanFromXML } from "../boolean/fromXML"
 import { isRawPictureRefValue, Picture, PictureXML } from "./types"
 
+const importTransparentPixel = (
+  transparentPixel: PictureXML["xr:TransparentPixel"] | undefined
+): { x: number; y: number } | undefined => {
+  if (!transparentPixel) return undefined
+
+  return {
+    x: Number.parseInt(String(transparentPixel._x)),
+    y: Number.parseInt(String(transparentPixel._y)),
+  }
+}
+
 export const importPictureFromXML = (
   context: ConfigurationContextFromXML,
   _rule: PropertyRule | undefined,
@@ -13,17 +24,20 @@ export const importPictureFromXML = (
 
   const xmlRef = xml["xr:Ref"]
   if (xmlRef && isRawPictureRefValue(xmlRef)) {
-    return { rawRef: xmlRef }
+    return {
+      rawRef: xmlRef,
+      ...(xml["xr:LoadTransparent"] !== undefined
+        ? { loadTransparent: importBooleanFromXML(context, undefined, xml["xr:LoadTransparent"]) }
+        : {}),
+      ...(xml["xr:TransparentPixel"] !== undefined
+        ? { transparentPixel: importTransparentPixel(xml["xr:TransparentPixel"]) }
+        : {}),
+    }
   }
 
   const loadTransparent = importBooleanFromXML(context, undefined, xml["xr:LoadTransparent"])!
 
-  const transparentPixel = xml["xr:TransparentPixel"]
-    ? {
-        x: Number.parseInt(String(xml["xr:TransparentPixel"]._x)),
-        y: Number.parseInt(String(xml["xr:TransparentPixel"]._y)),
-      }
-    : undefined
+  const transparentPixel = importTransparentPixel(xml["xr:TransparentPixel"])
 
   if (xml["xr:Abs"]) {
     return {

--- a/packages/core/metadata/commonObjects/picture/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/picture/toXML.test.ts
@@ -34,4 +34,39 @@ describe("exportPictureToXML", () => {
 
     expect(result?.["xr:Ref"]).toBe(rawRef)
   })
+
+  it("should export raw ref with LoadTransparent=false to XML", () => {
+    const rawRef = "0:ca5b178d-2d5a-4cf7-b88e-6fbdb2e56065"
+    const result = exportPictureToXML(mockContext, mockRule, { rawRef, loadTransparent: false })
+
+    expect(result).toEqual({
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": false,
+    })
+  })
+
+  it("should export raw ref with LoadTransparent=true to XML", () => {
+    const rawRef = "0:ca5b178d-2d5a-4cf7-b88e-6fbdb2e56065"
+    const result = exportPictureToXML(mockContext, mockRule, { rawRef, loadTransparent: true })
+
+    expect(result).toEqual({
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": true,
+    })
+  })
+
+  it("should export raw ref with transparent pixel to XML", () => {
+    const rawRef = "0"
+    const result = exportPictureToXML(mockContext, mockRule, {
+      rawRef,
+      loadTransparent: true,
+      transparentPixel: { x: 12, y: 2 },
+    })
+
+    expect(result).toEqual({
+      "xr:Ref": rawRef,
+      "xr:LoadTransparent": true,
+      "xr:TransparentPixel": { _x: 12, _y: 2 },
+    })
+  })
 })

--- a/packages/core/metadata/commonObjects/picture/toXML.ts
+++ b/packages/core/metadata/commonObjects/picture/toXML.ts
@@ -11,7 +11,13 @@ export const exportPictureToXML = (
   if (!picture) return undefined
 
   if (isRawPictureRef(picture)) {
-    return { "xr:Ref": picture.rawRef }
+    return {
+      "xr:Ref": picture.rawRef,
+      ...(picture.loadTransparent !== undefined ? { "xr:LoadTransparent": picture.loadTransparent } : {}),
+      ...(picture.transparentPixel
+        ? { "xr:TransparentPixel": { _x: picture.transparentPixel.x, _y: picture.transparentPixel.y } }
+        : {}),
+    }
   }
 
   const result: PictureXML = {}

--- a/packages/core/metadata/commonObjects/picture/types.ts
+++ b/packages/core/metadata/commonObjects/picture/types.ts
@@ -12,7 +12,14 @@ export interface PictureXML {
   }
 }
 
-export type RawPictureRef = { rawRef: string }
+export type RawPictureRef = {
+  rawRef: string
+  loadTransparent?: boolean
+  transparentPixel?: {
+    x: number
+    y: number
+  }
+}
 
 export interface LinkedPicture {
   ref: string | SE.PictureLib


### PR DESCRIPTION
## Что сделано
- сохранён raw Picture xr:LoadTransparent/xr:TransparentPixel
- сохранён inferred ent system enumeration в DCS MetadataValue
- сохранён порядок AvailableFields: dcsset:use перед dcsset:field
- обновлено ожидание DCSParameter для typed SystemEnumeration

## Проверка
- pnpm --filter '@nakidka/core' test