### PR TITLE
Исправить import-блокеры round-trip YAML

### DIFF
--- a/docs/superpowers/plans/2026-05-22-erp-round-trip-yaml-import-blockers.md
+++ b/docs/superpowers/plans/2026-05-22-erp-round-trip-yaml-import-blockers.md
@@ -1,0 +1,1321 @@
+# ERP Round Trip YAML Import Blockers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make full `round-trip-yaml --all-configs` pass the current import blockers in `erp`, `small`, and `trade`.
+
+**Architecture:** Keep XML-specific opaque form bodies outside the semantic form model: managed forms still parse `Ext/Form.xml`, ordinary forms import metadata YAML plus optional `Form.bin`. Extend existing focused value converters for raw `Color`, DCS typed-value nil array positions, and `MetadataValue` `StandardPeriod` without changing XML fixtures.
+
+**Tech Stack:** TypeScript, Vitest, existing metadata orchestration rules, `round-trip-yaml` diagnostic skill.
+
+---
+
+## File Structure
+
+- Modify `packages/core/metadata/forms/clientApplicationForm/convertFromXML.ts`: detect form body kind from `Forms/<name>.xml`, import metadata-only ordinary forms, and copy ordinary `Ext/Form.bin` to `Формы/<name>/Form.bin`.
+- Modify `packages/core/metadata/forms/clientApplicationForm/syncToXML.ts`: export metadata XML for ordinary forms and copy optional `Form.bin` back without creating `Ext/Form.xml`.
+- Modify `packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts`: add import tests for ordinary `Form.bin` and metadata-only ordinary forms.
+- Modify `packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts`: add sync tests for ordinary `Form.bin`, metadata-only ordinary forms, and strict managed form body handling.
+- Modify `packages/core/metadata/commonObjects/color/types.ts`: allow raw color refs in JSON schema/YAML type.
+- Modify `packages/core/metadata/commonObjects/color/toYAML.ts`: export raw refs as strings.
+- Modify `packages/core/metadata/commonObjects/color/fromYAML.ts`: import raw ref strings as `{ rawRef }`.
+- Modify `packages/core/metadata/commonObjects/color/toYAML.test.ts`: replace the raw-ref rejection test with export coverage.
+- Modify `packages/core/metadata/commonObjects/color/fromYAML.test.ts`: add raw-ref import coverage.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts`: allow `{}` in DCS typed-value YAML arrays.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.ts`: export array `undefined` items as `{}`.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.ts`: import `{}` inside arrays as `undefined`.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.test.ts`: update nil array expectation.
+- Modify `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.test.ts`: add `{}` array import coverage.
+- Create `packages/core/metadata/commonObjects/standardPeriod/types.ts`: shared model/XML/YAML types and schema for `StandardPeriod`.
+- Create `packages/core/metadata/commonObjects/standardPeriod/fromXML.ts`: XML to model conversion.
+- Create `packages/core/metadata/commonObjects/standardPeriod/toXML.ts`: model to XML conversion.
+- Create `packages/core/metadata/commonObjects/standardPeriod/fromYAML.ts`: YAML to model conversion.
+- Create `packages/core/metadata/commonObjects/standardPeriod/toYAML.ts`: model to YAML conversion.
+- Create `packages/core/metadata/commonObjects/standardPeriod/index.ts`: side-effect import module.
+- Create `packages/core/metadata/commonObjects/standardPeriod/sync.test.ts`: focused conversion tests.
+- Modify `packages/core/metadata/commonObjects/index.ts`: register `standardPeriod`.
+- Modify `packages/core/metadata/commonObjects/metadataValue/types.ts`: add `standardPeriod` to `MetadataValue`.
+- Modify `packages/core/metadata/commonObjects/metadataValue/fromXML.ts`: dispatch `v8:StandardPeriod`.
+- Modify `packages/core/metadata/commonObjects/metadataValue/toXML.ts`: export `standardPeriod`.
+- Modify `packages/core/metadata/commonObjects/metadataValue/fromYAML.ts`: detect StandardPeriod objects before form-choice objects.
+- Modify `packages/core/metadata/commonObjects/metadataValue/toYAML.ts`: export `standardPeriod`.
+- Modify `packages/core/metadata/commonObjects/metadataValue/__fixtures__/data.ts`: add StandardPeriod fixtures.
+
+## Required Reading
+
+- [ ] **Step 1: Read metadata source-of-truth rules**
+
+Run:
+
+```bash
+sed -n '1,220p' .agents/knowledge/metadata/sources-of-truth.md
+```
+
+Expected: document says existing XML fixtures are the source of truth, and opaque external XML files from `Ext/*` must be copied through external sync instead of parsed into model properties.
+
+- [ ] **Step 2: Read YAML contract**
+
+Run:
+
+```bash
+sed -n '1,260p' .agents/knowledge/metadata/yaml-contract.md
+```
+
+Expected: document confirms Russian YAML keys, system enumeration YAML mappings, and existing YAML defaults rules.
+
+- [ ] **Step 3: Read round-trip cycle rules**
+
+Run:
+
+```bash
+sed -n '1,260p' .agents/knowledge/metadata/round-trip-cycle.md
+```
+
+Expected: document confirms XML barrier comes before YAML behavior and existing XML fixtures must not be modified.
+
+- [ ] **Step 4: Regenerate Langium files in a fresh worktree**
+
+Run:
+
+```bash
+pnpm --filter nkdk-language langium:generate
+```
+
+Expected: command exits with code `0`. If pnpm reports no matching project in the current worktree, record that output and continue.
+
+## Task 1: Ordinary Forms With Optional Body
+
+**Files:**
+- Modify: `packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts`
+- Modify: `packages/core/metadata/forms/clientApplicationForm/convertFromXML.ts`
+- Modify: `packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts`
+- Modify: `packages/core/metadata/forms/clientApplicationForm/syncToXML.ts`
+
+- [ ] **Step 1: Add import tests for ordinary forms**
+
+Add these tests inside `describe("import from XML string", () => { ... })` in `packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts`:
+
+```ts
+  it("imports ordinary form metadata and copies Form.bin without Form.xml", async () => {
+    const ordinaryFormName = "ОбычнаяФорма"
+    const input = join(outputDir, "ordinary-input")
+    const formExtDir = join(input, ordinaryFormName, "Ext")
+    fs.mkdirSync(formExtDir, { recursive: true })
+
+    const metadataXML = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Form uuid="ed103b94-8ed1-443a-a7ea-5a2eb7fc6fbc">
+    <Properties>
+      <Name>${ordinaryFormName}</Name>
+      <Synonym>
+        <v8:item>
+          <v8:lang>ru</v8:lang>
+          <v8:content>Обычная форма</v8:content>
+        </v8:item>
+      </Synonym>
+      <Comment/>
+      <FormType>Ordinary</FormType>
+      <IncludeHelpInContents>false</IncludeHelpInContents>
+    </Properties>
+  </Form>
+</MetaDataObject>`
+
+    fs.writeFileSync(join(input, `${ordinaryFormName}.xml`), metadataXML)
+    fs.writeFileSync(join(formExtDir, "Form.bin"), Buffer.from([0, 1, 2, 255]))
+
+    await convertFormFromXML({
+      context: mockContextFromXML(),
+      inputDir: input,
+      formName: ordinaryFormName,
+      outputDir,
+    })
+
+    const formDir = join(outputDir, "Формы", ordinaryFormName)
+    const yaml = fs.readFileSync(join(formDir, "Форма.yaml"), "utf-8")
+    expect(yaml).toContain("Синоним: Обычная форма")
+    expect(yaml).toContain("ТипФормы: Обычная")
+    expect([...fs.readFileSync(join(formDir, "Form.bin"))]).toEqual([0, 1, 2, 255])
+  })
+
+  it("imports metadata-only ordinary form without creating Form.bin", async () => {
+    const ordinaryFormName = "ОбычнаяБезТела"
+    const input = join(outputDir, "ordinary-metadata-only-input")
+    fs.mkdirSync(input, { recursive: true })
+
+    const metadataXML = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Form uuid="ff77d419-36ca-4447-95fe-9f60443c2455">
+    <Properties>
+      <Name>${ordinaryFormName}</Name>
+      <Synonym>
+        <v8:item>
+          <v8:lang>ru</v8:lang>
+          <v8:content>Обычная без тела</v8:content>
+        </v8:item>
+      </Synonym>
+      <Comment/>
+      <FormType>Ordinary</FormType>
+      <IncludeHelpInContents>false</IncludeHelpInContents>
+    </Properties>
+  </Form>
+</MetaDataObject>`
+
+    fs.writeFileSync(join(input, `${ordinaryFormName}.xml`), metadataXML)
+
+    await convertFormFromXML({
+      context: mockContextFromXML(),
+      inputDir: input,
+      formName: ordinaryFormName,
+      outputDir,
+    })
+
+    const formDir = join(outputDir, "Формы", ordinaryFormName)
+    const yaml = fs.readFileSync(join(formDir, "Форма.yaml"), "utf-8")
+    expect(yaml).toContain("Синоним: Обычная без тела")
+    expect(yaml).toContain("ТипФормы: Обычная")
+    expect(fs.existsSync(join(formDir, "Form.bin"))).toBe(false)
+  })
+
+  it("keeps managed form without Form.xml as an input error", async () => {
+    const managedFormName = "УправляемаяБезТела"
+    const input = join(outputDir, "managed-without-body-input")
+    fs.mkdirSync(input, { recursive: true })
+
+    const metadataXML = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Form uuid="aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb">
+    <Properties>
+      <Name>${managedFormName}</Name>
+      <Synonym/>
+      <Comment/>
+      <FormType>Managed</FormType>
+    </Properties>
+  </Form>
+</MetaDataObject>`
+
+    fs.writeFileSync(join(input, `${managedFormName}.xml`), metadataXML)
+
+    await expect(
+      convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: input,
+        formName: managedFormName,
+        outputDir,
+      })
+    ).rejects.toThrow("Form.xml")
+  })
+```
+
+- [ ] **Step 2: Run import tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts -t "ordinary form"
+```
+
+Expected before implementation: FAIL because `convertFormFromXML` tries to read `Ext/Form.xml` for ordinary forms.
+
+- [ ] **Step 3: Add ordinary body detection in `convertFromXML.ts`**
+
+In `packages/core/metadata/forms/clientApplicationForm/convertFromXML.ts`, replace `convertFormFromXML`, `readFormFromXML`, and `parseFormFromXML` with this shape. Keep the existing `join` path import:
+
+```ts
+import { join } from "path"
+```
+
+Add these helper types and functions near `ReadFormFromXMLResult`:
+
+```ts
+type FormBodyKind = "managed" | "ordinaryBinary" | "ordinaryMetadataOnly"
+
+type ParsedFormMetadata = {
+  xmlMetadata: FormMetadataXML
+  metadataXML: string
+}
+
+const getFormTypeFromMetadata = (metadata: FormMetadataXML): string | undefined => metadata.Form?.Properties?.FormType
+
+const isOrdinaryFormMetadata = (metadata: FormMetadataXML): boolean => getFormTypeFromMetadata(metadata) === "Ordinary"
+
+const readParsedFormMetadata = async (params: { inputDir: string; formName: string }): Promise<ParsedFormMetadata> => {
+  const metadataPath = join(params.inputDir, `${params.formName}.xml`)
+  const metadataXML = await fs.promises.readFile(metadataPath, "utf-8")
+  const parsedMetadata = importContentFromXML<{ MetaDataObject: FormMetadataXML }>(metadataXML)
+  return { metadataXML, xmlMetadata: parsedMetadata.MetaDataObject }
+}
+
+const readParsedFormMetadataSync = (params: { inputDir: string; formName: string }): ParsedFormMetadata => {
+  const metadataPath = join(params.inputDir, `${params.formName}.xml`)
+  const metadataXML = fs.readFileSync(metadataPath, "utf-8")
+  const parsedMetadata = importContentFromXML<{ MetaDataObject: FormMetadataXML }>(metadataXML)
+  return { metadataXML, xmlMetadata: parsedMetadata.MetaDataObject }
+}
+
+const detectFormBodyKind = (params: { inputDir: string; formName: string; xmlMetadata: FormMetadataXML }): FormBodyKind => {
+  const formExtDir = join(params.inputDir, params.formName, "Ext")
+  const formXmlPath = join(formExtDir, "Form.xml")
+  const formBinPath = join(formExtDir, "Form.bin")
+
+  if (fs.existsSync(formXmlPath)) return "managed"
+  if (!isOrdinaryFormMetadata(params.xmlMetadata)) {
+    throw new Error(`Managed form body is missing: ${formXmlPath}`)
+  }
+  if (fs.existsSync(formBinPath)) return "ordinaryBinary"
+  return "ordinaryMetadataOnly"
+}
+```
+
+Then implement metadata-only parsing:
+
+```ts
+function parseFormMetadataOnlyFromXML(params: {
+  context: ConfigurationContextFromXML
+  xmlMetadata: FormMetadataXML
+}): ClientApplicationForm {
+  const metadataProperties = importPropertiesFromXML({
+    context: params.context,
+    xml: params.xmlMetadata,
+    rule: ClientApplicationFormRules,
+    tags: [FormRulesTags.Metadata],
+  })
+
+  return {
+    itemType: ClientApplicationFormRules.itemType,
+    ...metadataProperties,
+    childItems: [],
+    commands: [],
+  }
+}
+```
+
+Add the missing imports for this helper:
+
+```ts
+import { importPropertiesFromXML } from "~/metadata/orchestration"
+import { ClientApplicationFormRules } from "./rules"
+import { FormRulesTags } from "./types"
+```
+
+Rewrite `convertFormFromXML` so ordinary forms use metadata-only parsing and optional `Form.bin` copy:
+
+```ts
+export const convertFormFromXML = async (params: {
+  context: ConfigurationContextFromXML
+  inputDir: string
+  formName: string
+  outputDir: string
+}): Promise<void> => {
+  const { context, inputDir, formName, outputDir } = params
+
+  const { metadataXML, xmlMetadata } = await readParsedFormMetadata({ inputDir, formName })
+  const bodyKind = detectFormBodyKind({ inputDir, formName, xmlMetadata })
+
+  const form =
+    bodyKind === "managed"
+      ? parseFormFromXML({
+          context,
+          formXML: await fs.promises.readFile(join(inputDir, formName, "Ext", "Form.xml"), "utf-8"),
+          metadataXML,
+        })
+      : parseFormMetadataOnlyFromXML({ context, xmlMetadata })
+
+  const { yaml, externalFiles } = await convertFormToYAML({ context, form })
+
+  await writeFormToYAML({ formYAML: yaml, externalFiles, formName, outputDir })
+
+  const formNkdkDir = join(outputDir, "Формы", formName)
+  if (bodyKind === "managed") {
+    await copyFormItemExternalFilesFromXML({
+      formXmlDir: join(inputDir, formName, "Ext"),
+      formNkdkDir,
+    })
+  }
+  if (bodyKind === "ordinaryBinary") {
+    await fs.promises.mkdir(formNkdkDir, { recursive: true })
+    await fs.promises.copyFile(join(inputDir, formName, "Ext", "Form.bin"), join(formNkdkDir, "Form.bin"))
+  }
+}
+```
+
+Rewrite `readFormFromXML` similarly:
+
+```ts
+export function readFormFromXML(params: {
+  context: ConfigurationContextFromXML
+  inputDir: string
+  formName: string
+}): ClientApplicationForm {
+  const { context, inputDir, formName } = params
+  const { metadataXML, xmlMetadata } = readParsedFormMetadataSync({ inputDir, formName })
+  const bodyKind = detectFormBodyKind({ inputDir, formName, xmlMetadata })
+
+  if (bodyKind !== "managed") {
+    return parseFormMetadataOnlyFromXML({ context, xmlMetadata })
+  }
+
+  const formXML = fs.readFileSync(join(inputDir, formName, "Ext", "Form.xml"), "utf-8")
+  return parseFormFromXML({ context, formXML, metadataXML })
+}
+```
+
+- [ ] **Step 4: Run import tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add sync tests for ordinary forms**
+
+Add these tests inside `describe("sync ClientApplicationForm to XML", () => { ... })` in `packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts`:
+
+```ts
+  it("syncs ordinary Form.bin back to XML without creating Form.xml", async () => {
+    const tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "nakidka-ordinary-form-bin-"))
+    const xmlInputDir = join(tmpRoot, "xml")
+    const yamlDir = join(tmpRoot, "yaml")
+    const ordinaryFormName = "ОбычнаяФорма"
+
+    try {
+      const formExtDir = join(xmlInputDir, ordinaryFormName, "Ext")
+      fs.mkdirSync(formExtDir, { recursive: true })
+      fs.writeFileSync(
+        join(xmlInputDir, `${ordinaryFormName}.xml`),
+        `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Form uuid="ed103b94-8ed1-443a-a7ea-5a2eb7fc6fbc">
+    <Properties>
+      <Name>${ordinaryFormName}</Name>
+      <Synonym/>
+      <Comment/>
+      <FormType>Ordinary</FormType>
+    </Properties>
+  </Form>
+</MetaDataObject>`
+      )
+      fs.writeFileSync(join(formExtDir, "Form.bin"), Buffer.from([7, 8, 9]))
+
+      await convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: xmlInputDir,
+        formName: ordinaryFormName,
+        outputDir: yamlDir,
+      })
+
+      await syncFormToXML({
+        context: mockContextToXML(),
+        inputDir: yamlDir,
+        referenceDir: xmlInputDir,
+        formName: ordinaryFormName,
+        outputDir,
+      })
+
+      expect(fs.existsSync(join(outputDir, "Forms", ordinaryFormName, "Ext", "Form.xml"))).toBe(false)
+      expect([...fs.readFileSync(join(outputDir, "Forms", ordinaryFormName, "Ext", "Form.bin"))]).toEqual([7, 8, 9])
+      expect(fs.existsSync(join(outputDir, "Forms", `${ordinaryFormName}.xml`))).toBe(true)
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+
+  it("syncs metadata-only ordinary form without creating Ext", async () => {
+    const tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "nakidka-ordinary-form-metadata-only-"))
+    const xmlInputDir = join(tmpRoot, "xml")
+    const yamlDir = join(tmpRoot, "yaml")
+    const ordinaryFormName = "ОбычнаяБезТела"
+
+    try {
+      fs.mkdirSync(xmlInputDir, { recursive: true })
+      fs.writeFileSync(
+        join(xmlInputDir, `${ordinaryFormName}.xml`),
+        `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Form uuid="ff77d419-36ca-4447-95fe-9f60443c2455">
+    <Properties>
+      <Name>${ordinaryFormName}</Name>
+      <Synonym/>
+      <Comment/>
+      <FormType>Ordinary</FormType>
+    </Properties>
+  </Form>
+</MetaDataObject>`
+      )
+
+      await convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: xmlInputDir,
+        formName: ordinaryFormName,
+        outputDir: yamlDir,
+      })
+
+      await syncFormToXML({
+        context: mockContextToXML(),
+        inputDir: yamlDir,
+        referenceDir: xmlInputDir,
+        formName: ordinaryFormName,
+        outputDir,
+      })
+
+      expect(fs.existsSync(join(outputDir, "Forms", `${ordinaryFormName}.xml`))).toBe(true)
+      expect(fs.existsSync(join(outputDir, "Forms", ordinaryFormName, "Ext"))).toBe(false)
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+```
+
+- [ ] **Step 6: Run sync tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts -t "ordinary"
+```
+
+Expected before implementation: FAIL because `syncFormToXML` always writes `Ext/Form.xml`.
+
+- [ ] **Step 7: Implement ordinary sync path in `syncToXML.ts`**
+
+In `packages/core/metadata/forms/clientApplicationForm/syncToXML.ts`, add helpers:
+
+```ts
+const isOrdinaryForm = (form: { formType?: string }): boolean => form.formType === "Ordinary"
+
+const copyOrdinaryFormBinToXML = async (params: {
+  formDir: string
+  outputDir: string
+  formName: string
+  xmlManifest?: import("~/metadata/appliedObjects/configuration/migrations/xmlManifest").XmlSyncManifest
+}): Promise<void> => {
+  const src = join(params.formDir, "Form.bin")
+  if (!fs.existsSync(src)) return
+
+  const dst = join(params.outputDir, "Forms", params.formName, "Ext", "Form.bin")
+  await fs.promises.mkdir(join(dst, ".."), { recursive: true })
+  await fs.promises.copyFile(src, dst)
+  params.xmlManifest?.addFile(dst)
+}
+```
+
+In `syncFormToXML`, after `const form = importClientApplicationFormFromYAML(...)`, branch before reading reference form XML:
+
+```ts
+  if (isOrdinaryForm(form)) {
+    const contextFromXML: ConfigurationContextFromXML = {
+      fromXML: { forReference: true },
+      defaultLanguage: context.defaultLanguage,
+      version: "2.20",
+    }
+    const referenceForm = readFormFromXML({
+      context: contextFromXML,
+      inputDir: referenceDir,
+      formName,
+    })
+    const metadataXML = exportFormMetadataToXML({
+      context: contextWithFormDir,
+      form,
+      referenceForm,
+      name: formName,
+    })
+
+    await writeOrdinaryFormMetadataToXML({
+      metadataXML,
+      formName,
+      outputDir,
+      xmlManifest: params.xmlManifest,
+    })
+    await copyOrdinaryFormBinToXML({
+      formDir,
+      outputDir,
+      formName,
+      xmlManifest: params.xmlManifest,
+    })
+    return
+  }
+```
+
+Add writer:
+
+```ts
+const writeOrdinaryFormMetadataToXML = async (params: {
+  metadataXML: FormMetadataXML
+  formName: string
+  outputDir: string
+  xmlManifest?: import("~/metadata/appliedObjects/configuration/migrations/xmlManifest").XmlSyncManifest
+}): Promise<void> => {
+  const formsOutDir = join(params.outputDir, "Forms")
+  const formMetadataPath = join(formsOutDir, `${params.formName}.xml`)
+  await fs.promises.mkdir(formsOutDir, { recursive: true })
+  await fs.promises.writeFile(formMetadataPath, xmlExport({ MetaDataObject: params.metadataXML }), "utf-8")
+  params.xmlManifest?.addFile(formMetadataPath)
+}
+```
+
+- [ ] **Step 8: Run form tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 1**
+
+Run:
+
+```bash
+git add packages/core/metadata/forms/clientApplicationForm/convertFromXML.ts packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts packages/core/metadata/forms/clientApplicationForm/syncToXML.ts packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts
+git commit -m "fix: :bug: сохранить ordinary form body"
+```
+
+Expected: commit succeeds.
+
+## Task 2: Raw Color YAML
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/color/types.ts`
+- Modify: `packages/core/metadata/commonObjects/color/toYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/color/fromYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/color/toYAML.test.ts`
+- Modify: `packages/core/metadata/commonObjects/color/fromYAML.test.ts`
+
+- [ ] **Step 1: Replace raw color YAML rejection test**
+
+In `packages/core/metadata/commonObjects/color/toYAML.test.ts`, replace the test that expects `"Color YAML: rawRef is XML-only"` with:
+
+```ts
+  it.each(["0", "0:615512b6-4378-4fce-86f1-a56725f945da"])("exports raw XML color ref %s to YAML", (rawRef) => {
+    const result = exportColorToYAML(mockContext, mockRule, { rawRef })
+
+    expect(result).toBe(rawRef)
+  })
+```
+
+- [ ] **Step 2: Add raw color YAML import test**
+
+In `packages/core/metadata/commonObjects/color/fromYAML.test.ts`, add:
+
+```ts
+  it.each(["0", "0:615512b6-4378-4fce-86f1-a56725f945da"])("imports raw XML color ref %s from YAML", (rawRef) => {
+    const result = importColorFromYAML(mockContext, mockRule, rawRef as any)
+
+    expect(result).toEqual({ rawRef })
+  })
+```
+
+- [ ] **Step 3: Run color YAML tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/commonObjects/color/toYAML.test.ts packages/core/metadata/commonObjects/color/fromYAML.test.ts
+```
+
+Expected before implementation: FAIL because raw color refs are rejected on export and imported as absolute colors.
+
+- [ ] **Step 4: Extend color YAML type/schema**
+
+In `packages/core/metadata/commonObjects/color/types.ts`, replace `ColorJSONSchema` with:
+
+```ts
+export const RawColorRefJSONSchema = Type.String({ pattern: "^0(?::[0-9a-fA-F-]+)?$" })
+export const ColorJSONSchema = Type.Union([...webColors, AbsoluteColorJSONSchema, RawColorRefJSONSchema])
+```
+
+- [ ] **Step 5: Export raw color refs to YAML**
+
+In `packages/core/metadata/commonObjects/color/toYAML.ts`, replace:
+
+```ts
+  if (isRawColorRef(color)) throw new Error("Color YAML: rawRef is XML-only")
+```
+
+with:
+
+```ts
+  if (isRawColorRef(color)) return color.rawRef
+```
+
+- [ ] **Step 6: Import raw color refs from YAML**
+
+In `packages/core/metadata/commonObjects/color/fromYAML.ts`, update the import from `types`:
+
+```ts
+import { Color, ColorYAML, isRawColorRefValue } from "./types"
+```
+
+Add this check immediately after `if (!data) return undefined`:
+
+```ts
+  if (isRawColorRefValue(data)) return { rawRef: data }
+```
+
+- [ ] **Step 7: Run color tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/commonObjects/color/fromXML.test.ts packages/core/metadata/commonObjects/color/toXML.test.ts packages/core/metadata/commonObjects/color/fromYAML.test.ts packages/core/metadata/commonObjects/color/toYAML.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/color/types.ts packages/core/metadata/commonObjects/color/toYAML.ts packages/core/metadata/commonObjects/color/fromYAML.ts packages/core/metadata/commonObjects/color/toYAML.test.ts packages/core/metadata/commonObjects/color/fromYAML.test.ts
+git commit -m "fix: :bug: сохранить raw Color в YAML"
+```
+
+Expected: commit succeeds.
+
+## Task 3: DCS Typed Value Nil Array Item
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.test.ts`
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.test.ts`
+
+- [ ] **Step 1: Update export test for nil array item**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.test.ts`, replace `it("rejects xsi:nil array item as XML-only", ...)` with:
+
+```ts
+  it("exports xsi:nil array item as empty object", () => {
+    expect(
+      testExportPropertyToYAML({
+        rule,
+        value: [{ type: "string", value: "x" }, undefined],
+      })
+    ).toEqual({ value: ["'x'", {}] })
+  })
+```
+
+- [ ] **Step 2: Add import test for empty object array item**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.test.ts`, add:
+
+```ts
+  it("imports empty object array item as xsi:nil position", () => {
+    expect(
+      testImportPropertyFromYAML({
+        rule,
+        value: ["'x'", {}],
+      })
+    ).toEqual([{ type: "string", value: "x" }, undefined])
+  })
+```
+
+- [ ] **Step 3: Run DCS typed-value YAML tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.test.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.test.ts
+```
+
+Expected before implementation: FAIL because export throws on `undefined`, and import cannot classify `{}`.
+
+- [ ] **Step 4: Allow empty object in YAML type**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts`, add an empty-object schema:
+
+```ts
+export const DcsMetadataTypedValueNilYAMLJSONSchema = Type.Object({}, { additionalProperties: false })
+```
+
+Then include it in `DcsMetadataTypedValueJSONSchema`:
+
+```ts
+export const DcsMetadataTypedValueJSONSchema = Type.Union([
+  Type.Literal("Порядок"),
+  Type.Literal("СписокЗначений"),
+  Type.String(),
+  Type.Number(),
+  BooleanJSONSchema,
+  StandartBeginningDateJSONSchema,
+  DcsMetadataTypedValueNilYAMLJSONSchema,
+])
+```
+
+- [ ] **Step 5: Export nil array items as empty objects**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.ts`, delete `const NIL_XML_ONLY_ERROR = ...` and replace the array branch with:
+
+```ts
+  if (Array.isArray(value)) {
+    return value.map((item) => (item === undefined ? {} : exportSingle(context, rule, item)))
+  }
+```
+
+- [ ] **Step 6: Import empty object array items as undefined**
+
+In `packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.ts`, add:
+
+```ts
+const isNilYAML = (value: DcsMetadataTypedValueYAML): boolean =>
+  typeof value === "object" && value !== null && !Array.isArray(value) && Object.keys(value).length === 0
+```
+
+Then replace the array branch with:
+
+```ts
+  if (Array.isArray(value)) {
+    const sourceItems = Array.isArray(sourceValue) ? sourceValue : []
+    return value.map((item, index) => (isNilYAML(item) ? undefined : importSingle(context, rule, item, sourceItems[index])))
+  }
+```
+
+Also update the return type to allow `undefined` array items:
+
+```ts
+): DcsMetadataTypedValue | (DcsMetadataTypedValue | undefined)[] | undefined => {
+```
+
+And update `importDcsMetadataTypedValueFromYAMLForRule` return type similarly:
+
+```ts
+): DcsMetadataTypedValue | (DcsMetadataTypedValue | undefined)[] | undefined =>
+```
+
+- [ ] **Step 7: Run DCS typed-value tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromXML.test.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toXML.test.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.test.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 3**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.test.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.test.ts
+git commit -m "fix: :bug: сохранить nil DCS typed value в YAML"
+```
+
+Expected: commit succeeds.
+
+## Task 4: StandardPeriod Value Type
+
+**Files:**
+- Create: `packages/core/metadata/commonObjects/standardPeriod/types.ts`
+- Create: `packages/core/metadata/commonObjects/standardPeriod/fromXML.ts`
+- Create: `packages/core/metadata/commonObjects/standardPeriod/toXML.ts`
+- Create: `packages/core/metadata/commonObjects/standardPeriod/fromYAML.ts`
+- Create: `packages/core/metadata/commonObjects/standardPeriod/toYAML.ts`
+- Create: `packages/core/metadata/commonObjects/standardPeriod/index.ts`
+- Create: `packages/core/metadata/commonObjects/standardPeriod/sync.test.ts`
+- Modify: `packages/core/metadata/commonObjects/index.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataValue/types.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataValue/fromXML.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataValue/toXML.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataValue/fromYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataValue/toYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataValue/__fixtures__/data.ts`
+
+- [ ] **Step 1: Create StandardPeriod focused tests**
+
+Create `packages/core/metadata/commonObjects/standardPeriod/sync.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { mockContext } from "~/tests/mockContext"
+import { importStandardPeriodFromXML } from "./fromXML"
+import { importStandardPeriodFromYAML } from "./fromYAML"
+import { exportStandardPeriodToXML } from "./toXML"
+import { exportStandardPeriodToYAML } from "./toYAML"
+
+describe("StandardPeriod", () => {
+  it("round-trips custom period through YAML", () => {
+    const model = {
+      variant: "Custom",
+      startDate: "0001-01-01T00:00:00",
+      endDate: "0001-01-01T00:00:00",
+    } as const
+
+    const yaml = exportStandardPeriodToYAML(model)
+    expect(yaml).toEqual({
+      Вариант: "ПроизвольныйПериод",
+      ДатаНачала: "01.01.0001 00:00:00",
+      ДатаОкончания: "01.01.0001 00:00:00",
+    })
+    expect(importStandardPeriodFromYAML(mockContext, undefined, yaml)).toEqual(model)
+  })
+
+  it("round-trips period variant without dates through XML", () => {
+    const xml = {
+      "_xsi:type": "v8:StandardPeriod",
+      "v8:variant": { "_xsi:type": "v8:StandardPeriodVariant", "#text": "Today" },
+    } as const
+
+    const model = importStandardPeriodFromXML(xml)
+    expect(model).toEqual({ variant: "Today" })
+    expect(exportStandardPeriodToXML(model)).toEqual(xml)
+  })
+})
+```
+
+- [ ] **Step 2: Run StandardPeriod focused test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/commonObjects/standardPeriod/sync.test.ts
+```
+
+Expected before implementation: FAIL because module files do not exist.
+
+- [ ] **Step 3: Create StandardPeriod types**
+
+Create `packages/core/metadata/commonObjects/standardPeriod/types.ts`:
+
+```ts
+import { Static, Type } from "@sinclair/typebox"
+import {
+  StandardPeriodVariantFromYAML,
+  type StandardPeriodVariant,
+} from "~/metadata/systemEnumerations/types"
+
+export interface StandardPeriod {
+  variant: StandardPeriodVariant
+  startDate?: string
+  endDate?: string
+}
+
+const standardPeriodVariants = Object.keys(StandardPeriodVariantFromYAML).map((key) => Type.Literal(key))
+
+const russianDateTimePattern =
+  "^(0[1-9]|[12][0-9]|3[01])\\.(0[1-9]|1[0-2])\\.[0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
+
+export const StandardPeriodJSONSchema = Type.Object({
+  Вариант: Type.Union(standardPeriodVariants),
+  ДатаНачала: Type.Optional(Type.String({ pattern: russianDateTimePattern })),
+  ДатаОкончания: Type.Optional(Type.String({ pattern: russianDateTimePattern })),
+})
+
+export type StandardPeriodYAML = Static<typeof StandardPeriodJSONSchema>
+
+export interface StandardPeriodXML {
+  "_xsi:type"?: "v8:StandardPeriod"
+  "v8:variant": {
+    "_xsi:type"?: "v8:StandardPeriodVariant"
+    "#text"?: StandardPeriodVariant
+  }
+  "v8:startDate"?: string
+  "v8:endDate"?: string
+}
+```
+
+- [ ] **Step 4: Create StandardPeriod XML converters**
+
+Create `packages/core/metadata/commonObjects/standardPeriod/fromXML.ts`:
+
+```ts
+import type { StandardPeriod, StandardPeriodXML } from "./types"
+
+export const importStandardPeriodFromXML = (xml: StandardPeriodXML | undefined): StandardPeriod | undefined => {
+  if (!xml) return undefined
+
+  const variant = xml["v8:variant"]?.["#text"]
+  if (!variant) return undefined
+
+  return {
+    variant,
+    ...(xml["v8:startDate"] !== undefined ? { startDate: xml["v8:startDate"] } : {}),
+    ...(xml["v8:endDate"] !== undefined ? { endDate: xml["v8:endDate"] } : {}),
+  }
+}
+```
+
+Create `packages/core/metadata/commonObjects/standardPeriod/toXML.ts`:
+
+```ts
+import type { StandardPeriod, StandardPeriodXML } from "./types"
+
+export const exportStandardPeriodToXML = (value: StandardPeriod | undefined): StandardPeriodXML | undefined => {
+  if (!value) return undefined
+
+  return {
+    "_xsi:type": "v8:StandardPeriod",
+    "v8:variant": {
+      "_xsi:type": "v8:StandardPeriodVariant",
+      "#text": value.variant,
+    },
+    ...(value.startDate !== undefined ? { "v8:startDate": value.startDate } : {}),
+    ...(value.endDate !== undefined ? { "v8:endDate": value.endDate } : {}),
+  }
+}
+```
+
+- [ ] **Step 5: Create StandardPeriod YAML converters**
+
+Create `packages/core/metadata/commonObjects/standardPeriod/toYAML.ts`:
+
+```ts
+import { format } from "date-fns"
+import { StandardPeriodVariantToYAML } from "~/metadata/systemEnumerations/types"
+import type { StandardPeriod, StandardPeriodYAML } from "./types"
+
+const formatISODateTimeToRussian = (value: string): string => {
+  const date = new Date(value)
+  if (isNaN(date.getTime())) return value
+  return format(date, "dd.MM.yyyy HH:mm:ss")
+}
+
+export const exportStandardPeriodToYAML = (value: StandardPeriod | undefined): StandardPeriodYAML | undefined => {
+  if (!value) return undefined
+
+  return {
+    Вариант: StandardPeriodVariantToYAML[value.variant],
+    ...(value.startDate !== undefined ? { ДатаНачала: formatISODateTimeToRussian(value.startDate) } : {}),
+    ...(value.endDate !== undefined ? { ДатаОкончания: formatISODateTimeToRussian(value.endDate) } : {}),
+  }
+}
+```
+
+Create `packages/core/metadata/commonObjects/standardPeriod/fromYAML.ts`:
+
+```ts
+import { format, parse } from "date-fns"
+import { ConfigurationContext } from "~/metadata/context/types"
+import { PropertyRule } from "~/metadata/forms/elements/calendarField/rules"
+import { importSystemEnumerationFromYAML } from "~/metadata/systemEnumerations/fromYAML"
+import type { StandardPeriodVariant } from "~/metadata/systemEnumerations/types"
+import type { StandardPeriod, StandardPeriodYAML } from "./types"
+
+const parseRussianDateTimeToISO = (value: string): string => {
+  try {
+    const parsed = parse(value, "dd.MM.yyyy HH:mm:ss", new Date())
+    if (isNaN(parsed.getTime())) return value
+    return format(parsed, "yyyy-MM-dd'T'HH:mm:ss")
+  } catch {
+    return value
+  }
+}
+
+export const importStandardPeriodFromYAML = (
+  context: ConfigurationContext,
+  _rule: PropertyRule | undefined,
+  yaml: StandardPeriodYAML | undefined
+): StandardPeriod | undefined => {
+  if (!yaml) return undefined
+
+  const variant = importSystemEnumerationFromYAML<StandardPeriodVariant>({
+    context,
+    rule: { type: "SystemEnumeration", typeSE: "StandardPeriodVariant" },
+    value: yaml.Вариант,
+  })
+  if (!variant) return undefined
+
+  return {
+    variant,
+    ...(yaml.ДатаНачала !== undefined ? { startDate: parseRussianDateTimeToISO(yaml.ДатаНачала) } : {}),
+    ...(yaml.ДатаОкончания !== undefined ? { endDate: parseRussianDateTimeToISO(yaml.ДатаОкончания) } : {}),
+  }
+}
+```
+
+Create `packages/core/metadata/commonObjects/standardPeriod/index.ts`:
+
+```ts
+export * from "./types"
+export * from "./fromXML"
+export * from "./fromYAML"
+export * from "./toXML"
+export * from "./toYAML"
+```
+
+- [ ] **Step 6: Run focused StandardPeriod tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/commonObjects/standardPeriod/sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Add MetadataValue StandardPeriod fixture**
+
+In `packages/core/metadata/commonObjects/metadataValue/__fixtures__/data.ts`, add this fixture before the `valueList` fixture:
+
+```ts
+  {
+    name: "standardPeriod",
+    rule: { type: "MetadataValue", valueType: ["standardPeriod"] },
+    internal: {
+      type: "standardPeriod",
+      value: {
+        variant: "Custom",
+        startDate: "0001-01-01T00:00:00",
+        endDate: "0001-01-01T00:00:00",
+      },
+    },
+    YAML: {
+      Вариант: "ПроизвольныйПериод",
+      ДатаНачала: "01.01.0001 00:00:00",
+      ДатаОкончания: "01.01.0001 00:00:00",
+    },
+    XML: `<Value xsi:type="v8:StandardPeriod">
+	<v8:variant xsi:type="v8:StandardPeriodVariant">Custom</v8:variant>
+	<v8:startDate>0001-01-01T00:00:00</v8:startDate>
+	<v8:endDate>0001-01-01T00:00:00</v8:endDate>
+</Value>`,
+  },
+```
+
+- [ ] **Step 8: Run MetadataValue tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/commonObjects/metadataValue/fromXML.test.ts packages/core/metadata/commonObjects/metadataValue/toXML.test.ts packages/core/metadata/commonObjects/metadataValue/fromYAML.test.ts packages/core/metadata/commonObjects/metadataValue/toYAML.test.ts
+```
+
+Expected before MetadataValue integration: FAIL because `standardPeriod` is not part of `MetadataValue`.
+
+- [ ] **Step 9: Integrate StandardPeriod into MetadataValue types**
+
+In `packages/core/metadata/commonObjects/metadataValue/types.ts`, import StandardPeriod:
+
+```ts
+import { StandardPeriod, StandardPeriodJSONSchema, StandardPeriodXML, StandardPeriodYAML } from "../standardPeriod/types"
+```
+
+Add to `MetadataValueTypeToXML`:
+
+```ts
+  standardPeriod: "v8:StandardPeriod",
+```
+
+Add to `MetadataValueTypeToXMLTypes`:
+
+```ts
+  ["standardPeriod", StandardPeriod],
+```
+
+Add interface:
+
+```ts
+export interface MetadataStandardPeriodValue {
+  type: "standardPeriod"
+  value: StandardPeriod
+}
+```
+
+Update `MetadataTypedValue` union:
+
+```ts
+  MetadataTypedPrimitiveValue | MetadataFixedArrayValue | MetadataFormChoiceListValue | MetadataValueListValue | MetadataStandardPeriodValue,
+```
+
+Update XML union:
+
+```ts
+  | StandardPeriodXML
+```
+
+Update YAML schema union:
+
+```ts
+    StandardPeriodJSONSchema,
+```
+
+Update `MetadataValueYAML` if needed by adding:
+
+```ts
+export type MetadataStandardPeriodValueYAML = StandardPeriodYAML
+```
+
+- [ ] **Step 10: Integrate StandardPeriod into MetadataValue converters**
+
+In `metadataValue/fromXML.ts`, import:
+
+```ts
+import { importStandardPeriodFromXML } from "../standardPeriod/fromXML"
+import type { StandardPeriodXML } from "../standardPeriod/types"
+```
+
+Add before the primitive check:
+
+```ts
+  if (resultedType === "standardPeriod") {
+    const value = importStandardPeriodFromXML(data as StandardPeriodXML)
+    return value === undefined ? undefined : { type: "standardPeriod", value }
+  }
+```
+
+In `metadataValue/toXML.ts`, import:
+
+```ts
+import { exportStandardPeriodToXML } from "../standardPeriod/toXML"
+```
+
+Add before the primitive check:
+
+```ts
+  if (value.type === "standardPeriod") {
+    return exportStandardPeriodToXML(value.value)
+  }
+```
+
+In `metadataValue/fromYAML.ts`, import:
+
+```ts
+import { importStandardPeriodFromYAML } from "../standardPeriod/fromYAML"
+```
+
+Add before the form-choice object branch:
+
+```ts
+  if (typeof data === "object" && !Array.isArray(data) && "Вариант" in data) {
+    const value = importStandardPeriodFromYAML(context, undefined, data as any)
+    if (value !== undefined) {
+      const result = { type: "standardPeriod", value } as MetadataTypedValue
+      assertValueType(ruleTyped?.valueType, result.type, "fromYAML")
+      return result
+    }
+  }
+```
+
+In `metadataValue/toYAML.ts`, import:
+
+```ts
+import { exportStandardPeriodToYAML } from "../standardPeriod/toYAML"
+```
+
+Add before the primitive check:
+
+```ts
+  if (data.type === "standardPeriod") return exportStandardPeriodToYAML(data.value as any)
+```
+
+In `packages/core/metadata/commonObjects/index.ts`, add:
+
+```ts
+import "./standardPeriod"
+```
+
+- [ ] **Step 11: Run MetadataValue tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/commonObjects/metadataValue/fromXML.test.ts packages/core/metadata/commonObjects/metadataValue/toXML.test.ts packages/core/metadata/commonObjects/metadataValue/fromYAML.test.ts packages/core/metadata/commonObjects/metadataValue/toYAML.test.ts packages/core/metadata/commonObjects/standardPeriod/sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 12: Commit Task 4**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/standardPeriod packages/core/metadata/commonObjects/index.ts packages/core/metadata/commonObjects/metadataValue/types.ts packages/core/metadata/commonObjects/metadataValue/fromXML.ts packages/core/metadata/commonObjects/metadataValue/toXML.ts packages/core/metadata/commonObjects/metadataValue/fromYAML.ts packages/core/metadata/commonObjects/metadataValue/toYAML.ts packages/core/metadata/commonObjects/metadataValue/__fixtures__/data.ts
+git commit -m "feat: :sparkles: поддержать StandardPeriod в MetadataValue"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Import-Blocker Verification
+
+**Files:**
+- No source files expected.
+- Uses: `.agents/skills/round-trip-yaml/round-trip.sh`
+
+- [ ] **Step 1: Check `erp` import blockers**
+
+Run:
+
+```bash
+env NKDK_XML_REPO=/Users/nikita/git/round-trip-source NKDK_XML_DIR=/Users/nikita/git/round-trip-source/erp ./.agents/skills/round-trip-yaml/round-trip.sh --triage --all-configs --batch-size 5
+```
+
+Expected: command no longer stops at import with these errors:
+
+```text
+ENOENT ... Ext/Form.xml
+Color YAML: rawRef is XML-only
+DcsMetadataTypedValue YAML: xsi:nil is XML-only
+```
+
+Diffs may remain; this task verifies import blockers, not all round-trip diffs.
+
+- [ ] **Step 2: Check `small` import blockers**
+
+Run:
+
+```bash
+pnpm -s --dir /Users/nikita/git/nakidka-core/packages/cli exec tsx src/cli.ts import /Users/nikita/git/round-trip-source/small /private/tmp/round-trip-yaml-import-small-check
+```
+
+Expected: command no longer reports:
+
+```text
+MetadataEnumeration "ТипыНалогообложенияНДС": ENOENT ... Ext/Form.xml
+MetadataCommonForm "ВыборПериодаМП": MetadataValue: не распознан тип: v8:StandardPeriod
+```
+
+- [ ] **Step 3: Check `trade` import blockers**
+
+Run:
+
+```bash
+pnpm -s --dir /Users/nikita/git/nakidka-core/packages/cli exec tsx src/cli.ts import /Users/nikita/git/round-trip-source/trade /private/tmp/round-trip-yaml-import-trade-check
+```
+
+Expected: command no longer reports:
+
+```text
+MetadataDocumentJournal "ЧекиККМ": DcsMetadataTypedValue YAML: xsi:nil is XML-only
+```
+
+- [ ] **Step 4: Run focused package tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test:isolated -- packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts packages/core/metadata/commonObjects/color/fromYAML.test.ts packages/core/metadata/commonObjects/color/toYAML.test.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.test.ts packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.test.ts packages/core/metadata/commonObjects/metadataValue/fromXML.test.ts packages/core/metadata/commonObjects/metadataValue/toXML.test.ts packages/core/metadata/commonObjects/metadataValue/fromYAML.test.ts packages/core/metadata/commonObjects/metadataValue/toYAML.test.ts packages/core/metadata/commonObjects/standardPeriod/sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit verification note if source changed after prior commits**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no source changes. If only the plan/spec files are uncommitted, leave them for the documentation commit chosen by the user.
+
+## Self-Review
+
+- Spec coverage: ordinary `Form.bin`, metadata-only ordinary form, raw `Color`, DCS typed-value nil array items, and `MetadataValue StandardPeriod` each have a dedicated task.
+- Placeholder scan: no forbidden placeholder instructions remain.
+- Type consistency: the plan uses `standardPeriod` as the internal `MetadataValue` type key, `StandardPeriod` as the shared model, and YAML keys `Вариант`, `ДатаНачала`, `ДатаОкончания` consistently.

--- a/docs/superpowers/specs/2026-05-22-erp-round-trip-yaml-import-blockers-design.md
+++ b/docs/superpowers/specs/2026-05-22-erp-round-trip-yaml-import-blockers-design.md
@@ -1,0 +1,327 @@
+# ERP round-trip-yaml import blockers
+
+## Контекст
+
+Общий прогон `round-trip-yaml --triage --all-configs` проходит каталоги
+`acc` и `doc`, но падает на стадии `import` для `erp`.
+
+Проверенный результат:
+
+- `acc`: `10780` успешно, `0` ошибок;
+- `doc`: `4915` успешно, `0` ошибок;
+- `erp`: `18460` успешно, `8` ошибок.
+
+Ошибки `erp` сгруппированы так:
+
+- пять обычных форм с `Ext/Form.bin` вместо `Ext/Form.xml`;
+- один `Color YAML: rawRef is XML-only`;
+- два `DcsMetadataTypedValue YAML: xsi:nil is XML-only`.
+
+Дополнительная проверка каталогов после `erp` выявила еще один import-блокер
+в `small`: обычная форма с metadata-файлом, но без `Ext/Form.xml` и
+`Ext/Form.bin`. В том же каталоге найден блокер `MetadataValue` для
+`v8:StandardPeriod`.
+
+Цель этой спеки - зафиксировать принятые решения по всем группам import-блокеров.
+
+## Принято: обычные формы через `Form.bin`
+
+### Проблема
+
+В `erp` есть формы, у которых есть metadata-файл формы:
+
+```text
+Forms/<ИмяФормы>.xml
+```
+
+и бинарное тело обычной формы:
+
+```text
+Forms/<ИмяФормы>/Ext/Form.bin
+```
+
+При этом управляемого XML-тела формы нет:
+
+```text
+Forms/<ИмяФормы>/Ext/Form.xml
+```
+
+Сейчас `convertFormFromXML` безусловно читает `Ext/Form.xml`, поэтому импорт
+всего metadata-объекта падает с `ENOENT`.
+
+### Решение
+
+Обычная форма должна round-trip-иться как сочетание YAML-метаданных и
+непрозрачного бинарного файла.
+
+На импорте из XML в nkdk:
+
+1. `Forms/<ИмяФормы>.xml` преобразуется в `Формы/<ИмяФормы>/Форма.yaml`, как
+   для управляемых форм.
+2. Если вместо `Ext/Form.xml` найден `Ext/Form.bin`, файл копируется в
+   `Формы/<ИмяФормы>/Form.bin`.
+3. Отсутствие `Ext/Form.xml` не считается ошибкой, если рядом есть
+   `Ext/Form.bin`.
+4. Бинарное тело формы не разбирается и не нормализуется.
+
+На синхронизации из nkdk в XML:
+
+1. `Формы/<ИмяФормы>/Форма.yaml` восстанавливает `Forms/<ИмяФормы>.xml`.
+2. `Формы/<ИмяФормы>/Form.bin` копируется обратно в
+   `Forms/<ИмяФормы>/Ext/Form.bin`.
+3. Для такой формы `Forms/<ИмяФормы>/Ext/Form.xml` не создается.
+
+### Границы
+
+- Не пытаться декодировать `Form.bin`.
+- Не хранить `Forms/<ИмяФормы>.xml` как сырой XML-файл: metadata-часть формы
+  остается в YAML.
+- Не менять XML-репозиторий и не добавлять отсутствующие `Form.xml`.
+
+### Проверка
+
+- Тест импорта формы с `Forms/<Имя>.xml` и `Forms/<Имя>/Ext/Form.bin` должен
+  получить `Форма.yaml` и `Form.bin`.
+- Тест синхронизации такой формы должен получить `Forms/<Имя>.xml` и
+  `Forms/<Имя>/Ext/Form.bin`, но не `Forms/<Имя>/Ext/Form.xml`.
+- Общий `round-trip-yaml --triage --all-configs` должен пройти эти пять форм
+  без `ENOENT`.
+
+## Принято: raw `Color` в YAML
+
+### Проблема
+
+Для short XML round-trip уже поддержан raw color reference вида:
+
+```xml
+<dcscor:value xsi:type="v8ui:Color">0:615512b6-4378-4fce-86f1-a56725f945da</dcscor:value>
+```
+
+XML-импорт сохраняет такое значение как raw-ссылку, а XML-экспорт возвращает
+строку без преобразования. Но полный YAML round-trip падает, потому что
+`exportColorToYAML` считает raw-ссылку XML-only значением.
+
+### Решение
+
+Raw `Color` должен иметь YAML-представление по аналогии с `Picture`:
+
+```yaml
+Цвет: "0:615512b6-4378-4fce-86f1-a56725f945da"
+```
+
+Правила:
+
+- `rawRef` вида `0` и `0:<uuid>` экспортируется в YAML как строка;
+- такая строка при импорте из YAML возвращается в модель как `{ rawRef }`;
+- обычные цвета `style:`, `win:`, `web:` и `#RRGGBB` сохраняют текущий формат;
+- паттерн raw-ссылки остается узким: только `0` и `0:<uuid>`.
+
+### Границы
+
+- Не вводить обертку `{ Вид, Значение }` для raw `Color`.
+- Не пытаться разрешать `0:<uuid>` в имя цвета или ссылку на объект.
+- Не расширять raw-режим на любые неизвестные префиксы.
+
+### Проверка
+
+- `toYAML` для `{ rawRef: "0:<uuid>" }` возвращает строку `"0:<uuid>"`.
+- `fromYAML` для `"0:<uuid>"` возвращает `{ rawRef: "0:<uuid>" }`.
+- `toXML` после YAML-цикла восстанавливает исходный `0:<uuid>`.
+- Существующие тесты обычных цветов остаются зелеными.
+
+## Принято: metadata-only ordinary form
+
+### Проблема
+
+В `small` найден обычный form metadata-файл:
+
+```text
+Enums/ТипыНалогообложенияНДС/Forms/ПродажаНаЭкспорт.xml
+```
+
+В нем `FormType=Ordinary`, но нет ни управляемого тела:
+
+```text
+Forms/ПродажаНаЭкспорт/Ext/Form.xml
+```
+
+ни бинарного тела обычной формы:
+
+```text
+Forms/ПродажаНаЭкспорт/Ext/Form.bin
+```
+
+Сейчас такой случай падает так же, как ordinary form с `Form.bin`, потому что
+`convertFormFromXML` безусловно читает `Ext/Form.xml`.
+
+### Решение
+
+Если `Forms/<ИмяФормы>.xml` имеет `FormType=Ordinary`, а `Ext/Form.xml` и
+`Ext/Form.bin` отсутствуют, форма считается metadata-only ordinary form.
+
+На импорте из XML в nkdk:
+
+1. `Forms/<ИмяФормы>.xml` преобразуется в `Формы/<ИмяФормы>/Форма.yaml`.
+2. Файл `Формы/<ИмяФормы>/Form.bin` не создается.
+3. Отсутствие `Ext/Form.xml` не считается ошибкой только для
+   `FormType=Ordinary`.
+
+На синхронизации из nkdk в XML:
+
+1. `Формы/<ИмяФормы>/Форма.yaml` восстанавливает `Forms/<ИмяФормы>.xml`.
+2. Если `Формы/<ИмяФормы>/Form.bin` отсутствует, `Forms/<ИмяФормы>/Ext`
+   и `Forms/<ИмяФормы>/Ext/Form.xml` не создаются.
+
+### Границы
+
+- Для управляемой формы без `Ext/Form.xml` поведение остается строгим:
+  это ошибка входных данных.
+- Не создавать пустой `Ext/Form.xml`.
+- Не создавать пустой `Form.bin`.
+
+### Проверка
+
+- Тест импорта metadata-only ordinary form получает только `Форма.yaml`.
+- Тест синхронизации metadata-only ordinary form получает только
+  `Forms/<Имя>.xml`.
+- Управляемая форма без `Ext/Form.xml` продолжает падать.
+
+## Принято: `DcsMetadataTypedValue` nil в массиве
+
+### Проблема
+
+Оставшиеся две ошибки `erp` связаны с `DcsMetadataTypedValue`, где XML содержит
+nil-элемент внутри массива typed values, например:
+
+```xml
+<dcsset:right xsi:nil="true"/>
+```
+
+Текущий XML-импорт сохраняет такую позицию как `undefined`, но YAML-экспорт
+массива падает:
+
+```text
+DcsMetadataTypedValue YAML: xsi:nil is XML-only
+```
+
+### Наблюдение
+
+Это не тот же случай, что `SettingsParameterValue`: там можно не писать ключ
+`Значение` и восстановить nil по reference. Здесь nil является элементом
+массива, поэтому отсутствие YAML-элемента потеряет позицию.
+
+В проекте уже есть близкий формат для `DcsAvailableValues`: nil-элемент
+представлен пустым объектом `{}`.
+
+### Решение
+
+Для `DcsMetadataTypedValue[]` принимается формат пустого объекта по аналогии с
+`DcsAvailableValues`:
+
+```yaml
+ПраваяЧасть:
+  - {}
+  - ".Поле"
+```
+
+- `undefined`-элемент массива экспортируется в YAML как `{}`;
+- `{}` при импорте такого массива возвращается в `undefined`;
+- одиночное значение `DcsMetadataTypedValue` без массива не получает новый
+  nil-маркер без отдельного решения.
+
+Такой формат сохраняет позицию nil-элемента в массиве и не вводит строковый
+псевдомаркер.
+
+### Границы
+
+- Не использовать `null` для nil-позиции.
+- Не пропускать nil-элемент при экспорте массива.
+- Не менять compact YAML для `SettingsParameterValue`.
+- Не вводить nil-представление для одиночного `DcsMetadataTypedValue` без
+  отдельного подтвержденного случая.
+
+### Проверка
+
+- `toYAML` для массива с `undefined` возвращает `{}` на той же позиции.
+- `fromYAML` для `{}` внутри массива возвращает `undefined`.
+- XML после YAML-цикла восстанавливает `<dcsset:right xsi:nil="true"/>`.
+- Существующие сценарии `SettingsParameterValue` с reference nil остаются без
+  явного YAML-маркера.
+
+## Принято: `MetadataValue` StandardPeriod
+
+### Проблема
+
+В `small/CommonForms/ВыборПериодаМП/Ext/Form.xml` choice list содержит значения:
+
+```xml
+<Value xsi:type="v8:StandardPeriod">
+  <v8:variant xsi:type="v8:StandardPeriodVariant">Custom</v8:variant>
+  <v8:startDate>0001-01-01T00:00:00</v8:startDate>
+  <v8:endDate>0001-01-01T00:00:00</v8:endDate>
+</Value>
+```
+
+и варианты без дат:
+
+```xml
+<Value xsi:type="v8:StandardPeriod">
+  <v8:variant xsi:type="v8:StandardPeriodVariant">Today</v8:variant>
+</Value>
+```
+
+`TypeDescription` уже знает тип `v8:StandardPeriod`, но `MetadataValue` не
+поддерживает его как значение и падает:
+
+```text
+MetadataValue: не распознан тип: v8:StandardPeriod
+```
+
+### Решение
+
+Добавить `StandardPeriod` как отдельный тип `MetadataValue`.
+
+YAML-формат:
+
+```yaml
+Вариант: Сегодня
+ДатаНачала: 01.01.0001 00:00:00
+ДатаОкончания: 01.01.0001 00:00:00
+```
+
+Правила:
+
+- XML `v8:variant` экспортируется в YAML-ключ `Вариант` через
+  `StandardPeriodVariantToYAML`;
+- XML `v8:startDate` экспортируется в `ДатаНачала`;
+- XML `v8:endDate` экспортируется в `ДатаОкончания`;
+- даты отсутствуют в YAML, если их нет в XML;
+- обратный импорт YAML восстанавливает `v8:StandardPeriod`;
+- формат даты совпадает с уже используемым форматом
+  `StandardBeginningDate`: `ДД.ММ.ГГГГ ЧЧ:ММ:СС`.
+
+### Границы
+
+- Не заменять `StandardPeriod` на строку варианта.
+- Не хранить XML `StandardPeriod` как raw-объект.
+- Не менять `TypeDescription`: тип уже поддержан там отдельно.
+
+### Проверка
+
+- `MetadataValue fromXML` импортирует `v8:StandardPeriod` с датами и без дат.
+- `MetadataValue toYAML` экспортирует `Вариант`, `ДатаНачала`,
+  `ДатаОкончания`.
+- `MetadataValue fromYAML` импортирует этот объект обратно.
+- `MetadataValue toXML` восстанавливает `v8:StandardPeriod`.
+- Импорт `small/CommonForms/ВыборПериодаМП` больше не падает на
+  `MetadataValue`.
+
+## Критерии готовности серии
+
+- `erp` больше не падает на пяти ordinary forms с `Form.bin`.
+- `small` больше не падает на metadata-only ordinary form.
+- `erp` больше не падает на raw `Color` в YAML.
+- `erp` больше не падает на `DcsMetadataTypedValue` nil внутри массива.
+- `small` больше не падает на `MetadataValue` `v8:StandardPeriod`.
+- После реализации общий `round-trip-yaml --triage --all-configs` доходит
+  дальше текущих import-блокеров `erp`.

--- a/packages/core/metadata/commonObjects/color/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/color/fromYAML.test.ts
@@ -18,4 +18,16 @@ describe("importColorFromYAML", () => {
       expect(result).toEqual(color)
     }
   )
+
+  it.each(["0", "0:615512b6-4378-4fce-86f1-a56725f945da"])("imports raw XML color ref %s from YAML", (rawRef) => {
+    const result = importColorFromYAML(mockContext, mockRule, rawRef)
+
+    expect(result).toEqual({ rawRef })
+  })
+
+  it("does not treat malformed 0-prefixed strings as raw XML color refs", () => {
+    const result = importColorFromYAML(mockContext, mockRule, "0:not-a-uuid")
+
+    expect(result).toEqual({ type: "Absolute", value: "0:not-a-uuid" })
+  })
 })

--- a/packages/core/metadata/commonObjects/color/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/color/fromYAML.ts
@@ -3,7 +3,7 @@ import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { ConfigurationContext } from "../../context/types"
 import { importSystemEnumerationFromYAMLDeprecated } from "../../systemEnumerations/fromYAML"
 import * as SE from "../../systemEnumerations/types"
-import { Color, ColorYAML } from "./types"
+import { Color, ColorYAML, isRawColorRefValue } from "./types"
 
 export const importColorFromYAML = (
   _context: ConfigurationContext,
@@ -11,6 +11,10 @@ export const importColorFromYAML = (
   data: ColorYAML | undefined
 ): Color | undefined => {
   if (!data) return undefined
+
+  if (isRawColorRefValue(data)) {
+    return { rawRef: data }
+  }
 
   // Проверяем, является ли это custom style color (начинается с "ЭлементСтиля.")
   if (data.startsWith("ЭлементСтиля.")) {

--- a/packages/core/metadata/commonObjects/color/toYAML.test.ts
+++ b/packages/core/metadata/commonObjects/color/toYAML.test.ts
@@ -16,9 +16,9 @@ describe("exportColorToYAML", () => {
     expect(result).toEqual(enterpriseExpected)
   })
 
-  it("should reject raw XML color ref", () => {
-    expect(() =>
-      exportColorToYAML(mockContext, mockRule, { rawRef: "0:615512b6-4378-4fce-86f1-a56725f945da" })
-    ).toThrow("Color YAML: rawRef is XML-only")
+  it.each(["0", "0:615512b6-4378-4fce-86f1-a56725f945da"])("exports raw XML color ref %s to YAML", (rawRef) => {
+    const result = exportColorToYAML(mockContext, mockRule, { rawRef })
+
+    expect(result).toBe(rawRef)
   })
 })

--- a/packages/core/metadata/commonObjects/color/toYAML.ts
+++ b/packages/core/metadata/commonObjects/color/toYAML.ts
@@ -12,7 +12,7 @@ export const exportColorToYAML = <T extends Color | undefined>(
 ): string | undefined => {
   if (!color) return undefined
 
-  if (isRawColorRef(color)) throw new Error("Color YAML: rawRef is XML-only")
+  if (isRawColorRef(color)) return color.rawRef
 
   if (color.type === "StyleItem") {
     const standardColor = exportSystemEnumerationToYAMLDeprecated<SE.StyleColors>(

--- a/packages/core/metadata/commonObjects/color/types.ts
+++ b/packages/core/metadata/commonObjects/color/types.ts
@@ -14,7 +14,7 @@ export function isRawColorRef(color: Color): color is RawColorRef {
   return "rawRef" in color
 }
 
-const rawColorRefPattern = /^0(?::[0-9a-fA-F-]+)?$/
+const rawColorRefPattern = /^0(?::[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})?$/
 
 export function isRawColorRefValue(value: string): boolean {
   return rawColorRefPattern.test(value)
@@ -25,7 +25,8 @@ export type ColorXML = string
 const webColors = Object.keys(WebColorsFromYAML).map((key) => Type.Literal(key))
 
 export const AbsoluteColorJSONSchema = Type.String({ pattern: "^#[0-9A-Fa-f]{6}$" })
-export const ColorJSONSchema = Type.Union([...webColors, AbsoluteColorJSONSchema])
+export const RawColorRefJSONSchema = Type.String({ pattern: rawColorRefPattern.source })
+export const ColorJSONSchema = Type.Union([...webColors, AbsoluteColorJSONSchema, RawColorRefJSONSchema])
 
 export type ColorYAML = Static<typeof ColorJSONSchema>
 

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.test.ts
@@ -64,4 +64,13 @@ describe("import DcsMetadataTypedValue from YAML", () => {
       })
     ).toEqual({ type: "DesignTimeValue", value: "Справочник.Организации.ПустаяСсылка" })
   })
+
+  it("imports empty object array item as xsi:nil position", () => {
+    expect(
+      testImportPropertyFromYAML({
+        rule,
+        value: ["'x'", {}],
+      })
+    ).toEqual([{ type: "string", value: "x" }, undefined])
+  })
 })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/fromYAML.ts
@@ -2,7 +2,15 @@ import { ConfigurationContext } from "~/metadata/context/types"
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { PropertyRule } from "~/metadata/orchestration/property/types"
 import { DcsMetadataTypedValueRegistry } from "./rules"
-import { DcsMetadataTypedValue, DcsMetadataTypedValuePropertyRule, DcsMetadataTypedValueYAML } from "./types"
+import {
+  DcsMetadataTypedValue,
+  DcsMetadataTypedValueArrayItemYAML,
+  DcsMetadataTypedValuePropertyRule,
+  DcsMetadataTypedValueYAML,
+} from "./types"
+
+const isNilArrayItemYAML = (value: DcsMetadataTypedValueArrayItemYAML): value is Record<string, never> =>
+  typeof value === "object" && value !== null && !Array.isArray(value) && Object.keys(value).length === 0
 
 const detectTypeFromYAML = (
   context: ConfigurationContext,
@@ -53,13 +61,16 @@ const importSingle = (
 export const importDcsMetadataTypedValueFromYAML = (
   context: ConfigurationContext,
   rule: DcsMetadataTypedValuePropertyRule,
-  value: DcsMetadataTypedValueYAML | DcsMetadataTypedValueYAML[] | undefined,
+  value: DcsMetadataTypedValueYAML | DcsMetadataTypedValueArrayItemYAML[] | undefined,
   sourceValue?: DcsMetadataTypedValue | DcsMetadataTypedValue[]
-): DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined => {
+): DcsMetadataTypedValue | (DcsMetadataTypedValue | undefined)[] | undefined => {
   if (value === undefined) return undefined
   if (Array.isArray(value)) {
     const sourceItems = Array.isArray(sourceValue) ? sourceValue : []
-    return value.map((item, index) => importSingle(context, rule, item, sourceItems[index]))
+    return value.map((item, index) => {
+      if (isNilArrayItemYAML(item)) return undefined
+      return importSingle(context, rule, item, sourceItems[index])
+    })
   }
   return importSingle(context, rule, value, Array.isArray(sourceValue) ? undefined : sourceValue)
 }
@@ -69,11 +80,11 @@ const importDcsMetadataTypedValueFromYAMLForRule = (
   rule: PropertyRule,
   value: unknown,
   sourceValue?: unknown
-): DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined =>
+): DcsMetadataTypedValue | (DcsMetadataTypedValue | undefined)[] | undefined =>
   importDcsMetadataTypedValueFromYAML(
     context,
     rule as DcsMetadataTypedValuePropertyRule,
-    value as DcsMetadataTypedValueYAML | DcsMetadataTypedValueYAML[],
+    value as DcsMetadataTypedValueYAML | DcsMetadataTypedValueArrayItemYAML[],
     sourceValue as DcsMetadataTypedValue | DcsMetadataTypedValue[] | undefined
   )
 

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.test.ts
@@ -18,13 +18,13 @@ describe("export DcsMetadataTypedValue to YAML", () => {
     ).toEqual({ value: fixture.YAML })
   })
 
-  it("rejects xsi:nil array item as XML-only", () => {
-    expect(() =>
+  it("exports xsi:nil array item as empty object", () => {
+    expect(
       testExportPropertyToYAML({
         rule,
         value: [{ type: "string", value: "x" }, undefined],
       })
-    ).toThrow("DcsMetadataTypedValue YAML: xsi:nil is XML-only")
+    ).toEqual({ value: ["'x'", {}] })
   })
 
   it("exports ref as YAML metadata reference", () => {

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/toYAML.ts
@@ -2,9 +2,12 @@ import { ConfigurationContext } from "~/metadata/context/types"
 import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { PropertyRule } from "~/metadata/orchestration/property/types"
 import { DcsMetadataTypedValueRegistry } from "./rules"
-import { DcsMetadataTypedValue, DcsMetadataTypedValuePropertyRule, DcsMetadataTypedValueYAML } from "./types"
-
-const NIL_XML_ONLY_ERROR = "DcsMetadataTypedValue YAML: xsi:nil is XML-only"
+import {
+  DcsMetadataTypedValue,
+  DcsMetadataTypedValueArrayItemYAML,
+  DcsMetadataTypedValuePropertyRule,
+  DcsMetadataTypedValueYAML,
+} from "./types"
 
 const exportSingle = (
   context: ConfigurationContext,
@@ -28,11 +31,11 @@ export const exportDcsMetadataTypedValueToYAML = (
   context: ConfigurationContext,
   rule: DcsMetadataTypedValuePropertyRule,
   value: DcsMetadataTypedValue | (DcsMetadataTypedValue | undefined)[] | undefined
-): DcsMetadataTypedValueYAML | DcsMetadataTypedValueYAML[] | undefined => {
+): DcsMetadataTypedValueYAML | DcsMetadataTypedValueArrayItemYAML[] | undefined => {
   if (value === undefined) return undefined
   if (Array.isArray(value)) {
     return value.map((item) => {
-      if (item === undefined) throw new Error(NIL_XML_ONLY_ERROR)
+      if (item === undefined) return {}
       return exportSingle(context, rule, item)
     })
   }
@@ -43,7 +46,7 @@ const exportDcsMetadataTypedValueToYAMLForRule = (
   context: ConfigurationContext,
   rule: PropertyRule,
   value: unknown
-): DcsMetadataTypedValueYAML | DcsMetadataTypedValueYAML[] | undefined =>
+): DcsMetadataTypedValueYAML | DcsMetadataTypedValueArrayItemYAML[] | undefined =>
   exportDcsMetadataTypedValueToYAML(
     context,
     rule as DcsMetadataTypedValuePropertyRule,

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts
@@ -61,6 +61,8 @@ export const DcsMetadataTypedValueJSONSchema = Type.Union([
 ])
 
 export type DcsMetadataTypedValueYAML = Static<typeof DcsMetadataTypedValueJSONSchema>
+export type DcsMetadataTypedValueNilArrayItemYAML = Record<string, never>
+export type DcsMetadataTypedValueArrayItemYAML = DcsMetadataTypedValueYAML | DcsMetadataTypedValueNilArrayItemYAML
 
 export type DcsMetadataTypedValueUndefinedTypeXML = {
   "_xsi:type": "v8:Type"

--- a/packages/core/metadata/commonObjects/index.ts
+++ b/packages/core/metadata/commonObjects/index.ts
@@ -172,6 +172,7 @@ import "./metadataRegisterResource/register"
 import "./recalculation/register"
 import "./accountingFlag/register"
 import "./standardAttributeDescription/registerCollectionRule"
+import "./standardPeriod"
 import "./standardTabularSectionDescription/register"
 
 import "./exchangePlanContent/register"

--- a/packages/core/metadata/commonObjects/metadataValue/__fixtures__/data.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/__fixtures__/data.ts
@@ -161,4 +161,26 @@ export const metadataValueFixtures: MetadataValueFixture[] = [
     YAML: "СписокЗначений",
     XML: '<Value xsi:type="xr:ValueList"/>',
   },
+  {
+    name: "standardPeriod",
+    rule: { type: "MetadataValue", valueType: ["standardPeriod"] },
+    internal: {
+      type: "standardPeriod",
+      value: {
+        variant: "Custom",
+        startDate: "0001-01-01T00:00:00",
+        endDate: "0001-01-01T00:00:00",
+      },
+    },
+    YAML: {
+      Вариант: "ПроизвольныйПериод",
+      ДатаНачала: "01.01.0001 00:00:00",
+      ДатаОкончания: "01.01.0001 00:00:00",
+    },
+    XML: `<Value xsi:type="v8:StandardPeriod">
+	<v8:variant xsi:type="v8:StandardPeriodVariant">Custom</v8:variant>
+	<v8:startDate>0001-01-01T00:00:00</v8:startDate>
+	<v8:endDate>0001-01-01T00:00:00</v8:endDate>
+</Value>`,
+  },
 ]

--- a/packages/core/metadata/commonObjects/metadataValue/fromXML.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/fromXML.ts
@@ -5,6 +5,8 @@ import { ConfigurationContextFromXML } from "../../context/types"
 import { importFixedArrayFromXML } from "./fixedArray/fromXML"
 import { importFormChoiceListFromXML } from "./formChoiceList/fromXML"
 import { primitiveValueHandlers } from "./handlers"
+import { importStandardPeriodFromXML } from "../standardPeriod/fromXML"
+import { StandardPeriodXML } from "../standardPeriod/types"
 import {
   MetadataFormChoiceListValue,
   MetadataFormChoiceListValueXML,
@@ -73,6 +75,11 @@ export const importMetadataValueFromXML = (params: {
 
   if (resultedType === "valueList") {
     return { type: "valueList" }
+  }
+
+  if (resultedType === "standardPeriod") {
+    const value = importStandardPeriodFromXML(data as StandardPeriodXML)
+    return value === undefined ? undefined : { type: "standardPeriod", value }
   }
 
   if (!PRIMITIVE_TYPES.includes(resultedType as MetadataPrimitiveValueType)) {

--- a/packages/core/metadata/commonObjects/metadataValue/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/fromYAML.test.ts
@@ -46,5 +46,14 @@ describe("importMetadataValueFromYAML", () => {
         })
       ).toThrowError("MetadataValue: ожидались [string], получен formChoiceListDesTimeValue в fromYAML")
     })
+
+    it("не перехватывает объект с неизвестным вариантом как StandardPeriod", () => {
+      const result = importMetadataValueFromYAML(mockContext, undefined, {
+        Вариант: "ПроизвольнаяДата",
+        Дата: "01.01.0001 00:00:00",
+      } as any)
+
+      expect(result).toBeUndefined()
+    })
   })
 })

--- a/packages/core/metadata/commonObjects/metadataValue/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/fromYAML.ts
@@ -4,6 +4,7 @@ import { ConfigurationContext } from "../../context/types"
 import { importFixedArrayFromYAML } from "./fixedArray/fromYAML"
 import { importFormChoiceListFromYAML } from "./formChoiceList/fromYAML"
 import { primitiveValueHandlers } from "./handlers"
+import { importStandardPeriodFromYAML, isStandardPeriodYAML } from "../standardPeriod/fromYAML"
 import {
   MetadataFixedArrayValueYAMLInput,
   MetadataFormChoiceListValue,
@@ -44,6 +45,14 @@ export const importMetadataValueFromYAML = (
   }
 
   // Агрегатные типы определяются по форме данных, не по rule
+  if (isStandardPeriodYAML(data)) {
+    const value = importStandardPeriodFromYAML(context, undefined, data)
+    if (value === undefined) return undefined
+    const result = { type: "standardPeriod", value } satisfies MetadataTypedValue
+    assertValueType(ruleTyped?.valueType, result.type, "fromYAML")
+    return result
+  }
+
   if (typeof data === "object" && !Array.isArray(data) && "Представление" in data) {
     const result = importFormChoiceListFromYAML(context, data as MetadataFormChoiceListValueYAML)
     assertValueType(ruleTyped?.valueType, result.type, "fromYAML")

--- a/packages/core/metadata/commonObjects/metadataValue/toXML.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/toXML.ts
@@ -4,6 +4,7 @@ import { ConfigurationContext } from "../../context/types"
 import { exportFixedArrayToXML } from "./fixedArray/toXML"
 import { exportFormChoiceListToXML } from "./formChoiceList/toXML"
 import { primitiveValueHandlers } from "./handlers"
+import { exportStandardPeriodToXML } from "../standardPeriod/toXML"
 import {
   MetadataFixedArrayValue,
   MetadataFormChoiceListValue,
@@ -80,6 +81,10 @@ export const exportMetadataValueToXML = (params: {
 
   if (value.type === "valueList") {
     return { "_xsi:type": MetadataValueTypeToXML.valueList }
+  }
+
+  if (value.type === "standardPeriod") {
+    return exportStandardPeriodToXML(value.value)
   }
 
   if (!PRIMITIVE_TYPES.includes(value.type as MetadataPrimitiveValueType)) {

--- a/packages/core/metadata/commonObjects/metadataValue/toYAML.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/toYAML.ts
@@ -4,6 +4,7 @@ import { registerTypeRule } from "~/metadata/orchestration/formElement/factory"
 import { exportFixedArrayToYAML } from "./fixedArray/toYAML"
 import { exportFormChoiceListToYAML } from "./formChoiceList/toYAML"
 import { primitiveValueHandlers } from "./handlers"
+import { exportStandardPeriodToYAML } from "../standardPeriod/toYAML"
 import {
   MetadataFixedArrayValue,
   MetadataFormChoiceListValue,
@@ -45,6 +46,7 @@ export const exportMetadataValueToYAML = (
   if (data.type === "fixedArray") return exportFixedArrayToYAML(context, data as MetadataFixedArrayValue)
   if (data.type === "formChoiceListDesTimeValue") return exportFormChoiceListToYAML(context, data as MetadataFormChoiceListValue)
   if (data.type === "valueList") return "СписокЗначений"
+  if (data.type === "standardPeriod") return exportStandardPeriodToYAML(data.value, context, rule)
 
   if (!PRIMITIVE_TYPES.includes(data.type as MetadataPrimitiveValueType)) {
     throw new Error(`MetadataValue: неподдерживаемый тип для YAML: ${data.type}`)

--- a/packages/core/metadata/commonObjects/metadataValue/types.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/types.ts
@@ -1,6 +1,7 @@
 import { Static, Type } from "@sinclair/typebox"
 import { BasePropertyRule } from "~/metadata/orchestration"
 import { I8nText, I8nTextJSONSchema, I8nTextXML } from "../i8nText/types"
+import { StandardPeriod, StandardPeriodXML, StandardPeriodYAMLJSONSchema } from "../standardPeriod/types"
 
 //#region MetadataValue
 
@@ -18,6 +19,7 @@ export const MetadataValueTypeToXML = {
   DataCompositionComparisonType: "dcsset:DataCompositionComparisonType",
   fixedArray: "v8:FixedArray",
   formChoiceListDesTimeValue: "FormChoiceListDesTimeValue",
+  standardPeriod: "v8:StandardPeriod",
 } as const
 
 export type MetadataValueTypeToXMLTypes = [
@@ -92,6 +94,11 @@ export interface MetadataValueListValue {
   type: "valueList"
 }
 
+export interface MetadataStandardPeriodValue {
+  type: "standardPeriod"
+  value: StandardPeriod
+}
+
 export type MetadataSimpleValue =
   | MetadataTypedPrimitiveValue["value"]
   | MetadataTypedPrimitiveValue["value"][]
@@ -101,7 +108,11 @@ export type MetadataSimpleValue =
     }
 
 export type MetadataTypedValue<T extends MetadataValueType = MetadataValueType> = Extract<
-  MetadataTypedPrimitiveValue | MetadataFixedArrayValue | MetadataFormChoiceListValue | MetadataValueListValue,
+  | MetadataTypedPrimitiveValue
+  | MetadataFixedArrayValue
+  | MetadataFormChoiceListValue
+  | MetadataValueListValue
+  | MetadataStandardPeriodValue,
   { type: T }
 >
 
@@ -154,6 +165,7 @@ export const MetadataValueJSONSchema = Type.Recursive((ThisType) =>
   Type.Union([
     MetadataSingleValueJSONSchema,
     MetadataFixedArrayValueJSONSchema,
+    StandardPeriodYAMLJSONSchema,
     Type.Object({
       Представление: I8nTextJSONSchema,
       Значение: Type.Optional(ThisType),
@@ -192,6 +204,7 @@ export type MetadataValueXML<_Rule = unknown, _Value = unknown> =
   | MetadataFixedArrayValueXML
   | MetadataFormChoiceListValueXML
   | MetadataValueListXML
+  | StandardPeriodXML
   | { "_xsi:nil": true }
 
 /** Validates that the actual type matches the rule's allowed types. Throws if not. */

--- a/packages/core/metadata/commonObjects/standardPeriod/fromXML.ts
+++ b/packages/core/metadata/commonObjects/standardPeriod/fromXML.ts
@@ -1,0 +1,22 @@
+import { StandardPeriod, StandardPeriodXML } from "./types"
+
+const getText = (value: { "#text"?: string } | string | undefined): string | undefined => {
+  if (typeof value === "string") return value
+  return value?.["#text"]
+}
+
+export const importStandardPeriodFromXML = (data: StandardPeriodXML | undefined): StandardPeriod | undefined => {
+  if (data === undefined) return undefined
+
+  const variant = getText(data["v8:variant"])
+  if (variant === undefined) return undefined
+
+  const result: StandardPeriod = { variant: variant as StandardPeriod["variant"] }
+  const startDate = getText(data["v8:startDate"])
+  const endDate = getText(data["v8:endDate"])
+
+  if (startDate !== undefined) result.startDate = startDate
+  if (endDate !== undefined) result.endDate = endDate
+
+  return result
+}

--- a/packages/core/metadata/commonObjects/standardPeriod/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/standardPeriod/fromYAML.ts
@@ -1,0 +1,46 @@
+import { format, parse } from "date-fns"
+import { PropertyRule } from "~/metadata/forms/elements/calendarField/rules"
+import { StandardPeriodVariant, StandardPeriodVariantFromYAML } from "~/metadata/systemEnumerations/types"
+import { ConfigurationContext } from "../../context/types"
+import { StandardPeriod, StandardPeriodYAML } from "./types"
+
+export const isStandardPeriodYAML = (data: unknown): data is StandardPeriodYAML =>
+  typeof data === "object" &&
+  data !== null &&
+  !Array.isArray(data) &&
+  "Вариант" in data &&
+  typeof data.Вариант === "string" &&
+  data.Вариант in StandardPeriodVariantFromYAML
+
+const parseDateTime = (dateTime: string | undefined): string | undefined => {
+  if (dateTime === undefined) return undefined
+
+  try {
+    const date = parse(dateTime, "dd.MM.yyyy HH:mm:ss", new Date())
+    if (!isNaN(date.getTime())) return format(date, "yyyy-MM-dd'T'HH:mm:ss")
+    return dateTime
+  } catch {
+    return dateTime
+  }
+}
+
+export const importStandardPeriodFromYAML = (
+  _context: ConfigurationContext,
+  _rule: PropertyRule | undefined,
+  data: StandardPeriodYAML | undefined
+): StandardPeriod | undefined => {
+  if (data === undefined) return undefined
+  if (!isStandardPeriodYAML(data)) return undefined
+
+  const variant = (StandardPeriodVariantFromYAML as Record<string, StandardPeriodVariant>)[data.Вариант]
+  if (variant === undefined) return undefined
+
+  const result: StandardPeriod = { variant }
+  const startDate = parseDateTime(data.ДатаНачала)
+  const endDate = parseDateTime(data.ДатаОкончания)
+
+  if (startDate !== undefined) result.startDate = startDate
+  if (endDate !== undefined) result.endDate = endDate
+
+  return result
+}

--- a/packages/core/metadata/commonObjects/standardPeriod/index.ts
+++ b/packages/core/metadata/commonObjects/standardPeriod/index.ts
@@ -1,0 +1,5 @@
+import "./fromXML"
+import "./fromYAML"
+import "./toXML"
+import "./toYAML"
+import "./types"

--- a/packages/core/metadata/commonObjects/standardPeriod/sync.test.ts
+++ b/packages/core/metadata/commonObjects/standardPeriod/sync.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { mockContext } from "~/tests/mockContext"
+import { importStandardPeriodFromXML } from "./fromXML"
+import { importStandardPeriodFromYAML } from "./fromYAML"
+import { exportStandardPeriodToXML } from "./toXML"
+import { exportStandardPeriodToYAML } from "./toYAML"
+
+describe("StandardPeriod", () => {
+  it("round-trips custom period through YAML", () => {
+    const model = {
+      variant: "Custom",
+      startDate: "0001-01-01T00:00:00",
+      endDate: "0001-01-01T00:00:00",
+    } as const
+
+    const yaml = exportStandardPeriodToYAML(model)
+    expect(yaml).toEqual({
+      Вариант: "ПроизвольныйПериод",
+      ДатаНачала: "01.01.0001 00:00:00",
+      ДатаОкончания: "01.01.0001 00:00:00",
+    })
+    expect(importStandardPeriodFromYAML(mockContext, undefined, yaml)).toEqual(model)
+  })
+
+  it("round-trips period variant without dates through XML", () => {
+    const xml = {
+      "_xsi:type": "v8:StandardPeriod",
+      "v8:variant": { "_xsi:type": "v8:StandardPeriodVariant", "#text": "Today" },
+    } as const
+
+    const model = importStandardPeriodFromXML(xml)
+    expect(model).toEqual({ variant: "Today" })
+    expect(exportStandardPeriodToXML(model)).toEqual(xml)
+  })
+
+  it("round-trips period variant without dates through YAML", () => {
+    const model = { variant: "Today" } as const
+
+    const yaml = exportStandardPeriodToYAML(model)
+    expect(yaml).toEqual({ Вариант: "Сегодня" })
+    expect(importStandardPeriodFromYAML(mockContext, undefined, yaml)).toEqual(model)
+  })
+})

--- a/packages/core/metadata/commonObjects/standardPeriod/toXML.ts
+++ b/packages/core/metadata/commonObjects/standardPeriod/toXML.ts
@@ -1,0 +1,23 @@
+import { StandardPeriod, StandardPeriodXML } from "./types"
+
+export const exportStandardPeriodToXML = (data: StandardPeriod | undefined): StandardPeriodXML | undefined => {
+  if (data === undefined) return undefined
+
+  const result: StandardPeriodXML = {
+    "_xsi:type": "v8:StandardPeriod",
+    "v8:variant": {
+      "_xsi:type": "v8:StandardPeriodVariant",
+      "#text": data.variant,
+    },
+  }
+
+  if (data.startDate !== undefined) {
+    result["v8:startDate"] = data.startDate
+  }
+
+  if (data.endDate !== undefined) {
+    result["v8:endDate"] = data.endDate
+  }
+
+  return result
+}

--- a/packages/core/metadata/commonObjects/standardPeriod/toYAML.ts
+++ b/packages/core/metadata/commonObjects/standardPeriod/toYAML.ts
@@ -1,0 +1,36 @@
+import { format, parse } from "date-fns"
+import { ConfigurationContext } from "~/metadata/context/types"
+import { PropertyRule } from "~/metadata/forms/elements/calendarField/rules"
+import { StandardPeriodVariantToYAML } from "~/metadata/systemEnumerations/types"
+import { StandardPeriod, StandardPeriodYAML } from "./types"
+
+const formatDateTime = (dateTime: string | undefined): string | undefined => {
+  if (dateTime === undefined) return undefined
+
+  try {
+    const date = parse(dateTime, "yyyy-MM-dd'T'HH:mm:ss", new Date())
+    if (!isNaN(date.getTime())) return format(date, "dd.MM.yyyy HH:mm:ss")
+    return dateTime
+  } catch {
+    return dateTime
+  }
+}
+
+export const exportStandardPeriodToYAML = (
+  data: StandardPeriod | undefined,
+  _context?: ConfigurationContext,
+  _rule?: PropertyRule | undefined
+): StandardPeriodYAML | undefined => {
+  if (data === undefined) return undefined
+
+  const result: StandardPeriodYAML = {
+    Вариант: StandardPeriodVariantToYAML[data.variant],
+  }
+  const startDate = formatDateTime(data.startDate)
+  const endDate = formatDateTime(data.endDate)
+
+  if (startDate !== undefined) result.ДатаНачала = startDate
+  if (endDate !== undefined) result.ДатаОкончания = endDate
+
+  return result
+}

--- a/packages/core/metadata/commonObjects/standardPeriod/types.ts
+++ b/packages/core/metadata/commonObjects/standardPeriod/types.ts
@@ -1,0 +1,36 @@
+import { Static, Type } from "@sinclair/typebox"
+import {
+  StandardPeriodVariant,
+  StandardPeriodVariantFromYAML,
+  StandardPeriodVariantYAML,
+} from "~/metadata/systemEnumerations/types"
+
+const russianDateTimeWithSecondsPattern =
+  "^(0[1-9]|[12][0-9]|3[01])\\.(0[1-9]|1[0-2])\\.[0-9]{4} ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$"
+const standardPeriodVariants = Object.keys(StandardPeriodVariantFromYAML).map((variant) => Type.Literal(variant))
+
+export interface StandardPeriod {
+  variant: StandardPeriodVariant
+  startDate?: string
+  endDate?: string
+}
+
+export interface StandardPeriodXML {
+  "_xsi:type": "v8:StandardPeriod"
+  "v8:variant": {
+    "_xsi:type": "v8:StandardPeriodVariant"
+    "#text": StandardPeriodVariant
+  }
+  "v8:startDate"?: string
+  "v8:endDate"?: string
+}
+
+export const StandardPeriodYAMLJSONSchema = Type.Object({
+  Вариант: Type.Union(standardPeriodVariants),
+  ДатаНачала: Type.Optional(Type.String({ pattern: russianDateTimeWithSecondsPattern })),
+  ДатаОкончания: Type.Optional(Type.String({ pattern: russianDateTimeWithSecondsPattern })),
+})
+
+export interface StandardPeriodYAML extends Static<typeof StandardPeriodYAMLJSONSchema> {
+  Вариант: StandardPeriodVariantYAML
+}

--- a/packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/convertFromXML.test.ts
@@ -60,6 +60,113 @@ describe("import from XML string", () => {
     expect(fs.readFileSync(queryPath, "utf-8")).toBe(expectedQueryText)
   })
 
+  it("imports ordinary form metadata and copies Form.bin without Form.xml", async () => {
+    const ordinaryFormName = "ОбычнаяФорма"
+    const input = join(outputDir, "ordinary-input")
+    const formExtDir = join(input, ordinaryFormName, "Ext")
+    fs.mkdirSync(formExtDir, { recursive: true })
+
+    const metadataXML = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Form uuid="ed103b94-8ed1-443a-a7ea-5a2eb7fc6fbc">
+    <Properties>
+      <Name>${ordinaryFormName}</Name>
+      <Synonym>
+        <v8:item>
+          <v8:lang>ru</v8:lang>
+          <v8:content>Обычная форма</v8:content>
+        </v8:item>
+      </Synonym>
+      <Comment/>
+      <FormType>Ordinary</FormType>
+      <IncludeHelpInContents>false</IncludeHelpInContents>
+    </Properties>
+  </Form>
+</MetaDataObject>`
+
+    fs.writeFileSync(join(input, `${ordinaryFormName}.xml`), metadataXML)
+    fs.writeFileSync(join(formExtDir, "Form.bin"), Buffer.from([0, 1, 2, 255]))
+
+    await convertFormFromXML({
+      context: mockContextFromXML(),
+      inputDir: input,
+      formName: ordinaryFormName,
+      outputDir,
+    })
+
+    const formDir = join(outputDir, "Формы", ordinaryFormName)
+    const yaml = fs.readFileSync(join(formDir, "Форма.yaml"), "utf-8")
+    expect(yaml).toContain("Синоним: Обычная форма")
+    expect([...fs.readFileSync(join(formDir, "Form.bin"))]).toEqual([0, 1, 2, 255])
+  })
+
+  it("imports metadata-only ordinary form without creating Form.bin", async () => {
+    const ordinaryFormName = "ОбычнаяБезТела"
+    const input = join(outputDir, "ordinary-metadata-only-input")
+    fs.mkdirSync(input, { recursive: true })
+
+    const metadataXML = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Form uuid="ff77d419-36ca-4447-95fe-9f60443c2455">
+    <Properties>
+      <Name>${ordinaryFormName}</Name>
+      <Synonym>
+        <v8:item>
+          <v8:lang>ru</v8:lang>
+          <v8:content>Обычная без тела</v8:content>
+        </v8:item>
+      </Synonym>
+      <Comment/>
+      <FormType>Ordinary</FormType>
+      <IncludeHelpInContents>false</IncludeHelpInContents>
+    </Properties>
+  </Form>
+</MetaDataObject>`
+
+    fs.writeFileSync(join(input, `${ordinaryFormName}.xml`), metadataXML)
+
+    await convertFormFromXML({
+      context: mockContextFromXML(),
+      inputDir: input,
+      formName: ordinaryFormName,
+      outputDir,
+    })
+
+    const formDir = join(outputDir, "Формы", ordinaryFormName)
+    const yaml = fs.readFileSync(join(formDir, "Форма.yaml"), "utf-8")
+    expect(yaml).toContain("Синоним: Обычная без тела")
+    expect(fs.existsSync(join(formDir, "Form.bin"))).toBe(false)
+  })
+
+  it("keeps managed form without Form.xml as an input error", async () => {
+    const managedFormName = "УправляемаяБезТела"
+    const input = join(outputDir, "managed-without-body-input")
+    fs.mkdirSync(input, { recursive: true })
+
+    const metadataXML = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Form uuid="aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb">
+    <Properties>
+      <Name>${managedFormName}</Name>
+      <Synonym/>
+      <Comment/>
+      <FormType>Managed</FormType>
+    </Properties>
+  </Form>
+</MetaDataObject>`
+
+    fs.writeFileSync(join(input, `${managedFormName}.xml`), metadataXML)
+
+    await expect(
+      convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: input,
+        formName: managedFormName,
+        outputDir,
+      })
+    ).rejects.toThrow("Form.xml")
+  })
+
   it("копирует внешние картинки элементов формы в YAML-каталоги по имени элемента", async () => {
     const tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "nakidka-form-item-pictures-"))
     const tmpInputDir = join(tmpRoot, "xml")

--- a/packages/core/metadata/forms/clientApplicationForm/convertFromXML.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/convertFromXML.ts
@@ -1,5 +1,5 @@
 import fs from "fs"
-import { join } from "path"
+import { dirname, join } from "path"
 import "~/metadata/commonObjects"
 import { ConfigurationContext, ConfigurationContextFromXML, ExternalFileEntry } from "~/metadata/context/types"
 import { exportClientApplicationFormToYAML } from "~/metadata/forms/clientApplicationForm/toYAML"
@@ -25,14 +25,15 @@ export const convertFormFromXML = async (params: {
   const metadataPath = join(inputDir, `${formName}.xml`)
   const metadataXML = await fs.promises.readFile(metadataPath, "utf-8")
 
-  const formPath = join(inputDir, formName, "Ext", "Form.xml")
-  const formXML = await fs.promises.readFile(formPath, "utf-8")
-
+  const { formXML, hasFormBin } = await readFormBodyFromXML({ inputDir, formName, metadataXML })
   const form = parseFormFromXML({ context, formXML, metadataXML })
 
   const { yaml, externalFiles } = await convertFormToYAML({ context, form })
 
   await writeFormToYAML({ formYAML: yaml, externalFiles, formName, outputDir })
+  if (hasFormBin) {
+    await copyFormBinFromXML({ inputDir, formName, outputDir })
+  }
   await copyFormItemExternalFilesFromXML({
     formXmlDir: join(inputDir, formName, "Ext"),
     formNkdkDir: join(outputDir, "Формы", formName),
@@ -49,8 +50,7 @@ export function readFormFromXML(params: {
   const metadataPath = join(inputDir, `${formName}.xml`)
   const metadataXML = fs.readFileSync(metadataPath, "utf-8")
 
-  const formPath = join(inputDir, formName, "Ext", "Form.xml")
-  const formXML = fs.readFileSync(formPath, "utf-8")
+  const formXML = readFormBodyFromXMLSync({ inputDir, formName, metadataXML }).formXML
 
   const form = parseFormFromXML({ context, formXML, metadataXML })
 
@@ -80,19 +80,76 @@ const writeFormToYAML = async (params: {
   }
 }
 
+const readFormBodyFromXML = async (params: {
+  inputDir: string
+  formName: string
+  metadataXML: string
+}): Promise<{ formXML: string | undefined; hasFormBin: boolean }> => {
+  const { inputDir, formName, metadataXML } = params
+  const formPath = join(inputDir, formName, "Ext", "Form.xml")
+  const formBinPath = join(inputDir, formName, "Ext", "Form.bin")
+  const isOrdinaryForm = getFormTypeFromMetadataXML(metadataXML) === "Ordinary"
+
+  try {
+    return { formXML: await fs.promises.readFile(formPath, "utf-8"), hasFormBin: isOrdinaryForm && fs.existsSync(formBinPath) }
+  } catch (error) {
+    if (!isMissingFileError(error)) throw error
+    if (!isOrdinaryForm) throw error
+    return { formXML: undefined, hasFormBin: fs.existsSync(formBinPath) }
+  }
+}
+
+const readFormBodyFromXMLSync = (params: {
+  inputDir: string
+  formName: string
+  metadataXML: string
+}): { formXML: string | undefined; hasFormBin: boolean } => {
+  const { inputDir, formName, metadataXML } = params
+  const formPath = join(inputDir, formName, "Ext", "Form.xml")
+  const formBinPath = join(inputDir, formName, "Ext", "Form.bin")
+  const isOrdinaryForm = getFormTypeFromMetadataXML(metadataXML) === "Ordinary"
+
+  try {
+    return { formXML: fs.readFileSync(formPath, "utf-8"), hasFormBin: isOrdinaryForm && fs.existsSync(formBinPath) }
+  } catch (error) {
+    if (!isMissingFileError(error)) throw error
+    if (!isOrdinaryForm) throw error
+    return { formXML: undefined, hasFormBin: fs.existsSync(formBinPath) }
+  }
+}
+
+const copyFormBinFromXML = async (params: { inputDir: string; formName: string; outputDir: string }): Promise<void> => {
+  const { inputDir, formName, outputDir } = params
+  const sourcePath = join(inputDir, formName, "Ext", "Form.bin")
+  const targetPath = join(outputDir, "Формы", formName, "Form.bin")
+  await fs.promises.mkdir(dirname(targetPath), { recursive: true })
+  await fs.promises.copyFile(sourcePath, targetPath)
+}
+
+const isMissingFileError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error && error.code === "ENOENT"
+
+const getFormTypeFromMetadataXML = (metadataXML: string): string | undefined => {
+  const parsedMetadata = importContentFromXML<{ MetaDataObject: FormMetadataXML }>(metadataXML)
+  return parsedMetadata.MetaDataObject.Form.Properties.FormType
+}
+
 function parseFormFromXML(params: {
   context: ConfigurationContextFromXML
-  formXML: string
+  formXML: string | undefined
   metadataXML: string
 }): ClientApplicationForm {
   const { context, formXML, metadataXML } = params
 
-  const parsedForm = importContentFromXML<{ Form: ClientApplicationFormXML }>(formXML, { preserveXsiNil: true })
+  const parsedForm =
+    formXML !== undefined
+      ? importContentFromXML<{ Form: ClientApplicationFormXML }>(formXML, { preserveXsiNil: true }).Form
+      : {}
   const parsedMetadata = importContentFromXML<{ MetaDataObject: FormMetadataXML }>(metadataXML)
 
   return importClientApplicationFormFromXML({
     context,
-    xml: parsedForm.Form,
+    xml: parsedForm,
     xmlMetadata: parsedMetadata.MetaDataObject,
   })
 }

--- a/packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts
@@ -178,7 +178,132 @@ describe("sync ClientApplicationForm to XML", () => {
       fs.rmSync(tmpRoot, { recursive: true, force: true })
     }
   })
+
+  it("восстанавливает ordinary form metadata и Form.bin без Ext/Form.xml", async () => {
+    const ordinaryFormName = "ОбычнаяФорма"
+    const tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "nakidka-ordinary-form-bin-"))
+    const xmlInputDir = join(tmpRoot, "xml", "Forms")
+    const yamlInputDir = join(tmpRoot, "yaml")
+    const formExtDir = join(xmlInputDir, ordinaryFormName, "Ext")
+
+    try {
+      fs.mkdirSync(formExtDir, { recursive: true })
+      fs.writeFileSync(join(xmlInputDir, `${ordinaryFormName}.xml`), ordinaryFormMetadataXML(ordinaryFormName))
+      fs.writeFileSync(join(formExtDir, "Form.bin"), Buffer.from([0, 1, 2, 255]))
+
+      await convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: xmlInputDir,
+        formName: ordinaryFormName,
+        outputDir: yamlInputDir,
+      })
+
+      await syncFormToXML({
+        context: mockContextToXML(),
+        inputDir: yamlInputDir,
+        outputDir,
+        referenceDir: xmlInputDir,
+        formName: ordinaryFormName,
+      })
+
+      expect(fs.existsSync(join(outputDir, "Forms", ordinaryFormName, "Ext", "Form.xml"))).toBe(false)
+      expect([...fs.readFileSync(join(outputDir, "Forms", ordinaryFormName, "Ext", "Form.bin"))]).toEqual([
+        0, 1, 2, 255,
+      ])
+      expect(fs.readFileSync(join(outputDir, "Forms", `${ordinaryFormName}.xml`), "utf-8")).toContain(
+        "<FormType>Ordinary</FormType>"
+      )
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+
+  it("восстанавливает metadata-only ordinary form без каталога Ext", async () => {
+    const ordinaryFormName = "ОбычнаяБезТела"
+    const tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "nakidka-ordinary-form-metadata-only-"))
+    const xmlInputDir = join(tmpRoot, "xml", "Forms")
+    const yamlInputDir = join(tmpRoot, "yaml")
+
+    try {
+      fs.mkdirSync(xmlInputDir, { recursive: true })
+      fs.writeFileSync(join(xmlInputDir, `${ordinaryFormName}.xml`), ordinaryFormMetadataXML(ordinaryFormName))
+
+      await convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: xmlInputDir,
+        formName: ordinaryFormName,
+        outputDir: yamlInputDir,
+      })
+
+      await syncFormToXML({
+        context: mockContextToXML(),
+        inputDir: yamlInputDir,
+        outputDir,
+        referenceDir: xmlInputDir,
+        formName: ordinaryFormName,
+      })
+
+      expect(fs.readFileSync(join(outputDir, "Forms", `${ordinaryFormName}.xml`), "utf-8")).toContain(
+        "<FormType>Ordinary</FormType>"
+      )
+      expect(fs.existsSync(join(outputDir, "Forms", ordinaryFormName, "Ext"))).toBe(false)
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+
+  it("сохраняет Ext/Form.xml для ordinary form, если тело есть в reference", async () => {
+    const ordinaryFormName = "ОбычнаяФормаСТелом"
+    const tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "nakidka-ordinary-form-xml-body-"))
+    const xmlInputDir = join(tmpRoot, "xml", "Forms")
+    const yamlInputDir = join(tmpRoot, "yaml")
+    const formExtDir = join(xmlInputDir, ordinaryFormName, "Ext")
+
+    try {
+      fs.mkdirSync(formExtDir, { recursive: true })
+      fs.writeFileSync(join(xmlInputDir, `${ordinaryFormName}.xml`), ordinaryFormMetadataXML(ordinaryFormName))
+      const formXML = readXMLFixtureAsString(import.meta.url, "minimal.xml")
+      fs.writeFileSync(join(formExtDir, "Form.xml"), formXML)
+
+      await convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: xmlInputDir,
+        formName: ordinaryFormName,
+        outputDir: yamlInputDir,
+      })
+
+      await syncFormToXML({
+        context: mockContextToXML(),
+        inputDir: yamlInputDir,
+        outputDir,
+        referenceDir: xmlInputDir,
+        formName: ordinaryFormName,
+      })
+
+      expect(fs.readFileSync(join(outputDir, "Forms", ordinaryFormName, "Ext", "Form.xml"), "utf-8")).toBe(formXML)
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
 })
+
+const ordinaryFormMetadataXML = (formName: string): string => `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<Form uuid="ed103b94-8ed1-443a-a7ea-5a2eb7fc6fbc">
+		<Properties>
+			<Name>${formName}</Name>
+			<Synonym>
+				<v8:item>
+					<v8:lang>ru</v8:lang>
+					<v8:content>${formName}</v8:content>
+				</v8:item>
+			</Synonym>
+			<Comment/>
+			<FormType>Ordinary</FormType>
+			<IncludeHelpInContents>false</IncludeHelpInContents>
+		</Properties>
+	</Form>
+</MetaDataObject>`
 
 describe("round-trip: withDynamicList XML → YAML+bsl → XML", () => {
   const xmlFixturesDir = getXMLFixtureDir(import.meta.url, "sync/xml/Forms")

--- a/packages/core/metadata/forms/clientApplicationForm/syncToXML.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/syncToXML.ts
@@ -1,5 +1,5 @@
 import fs from "fs"
-import { join } from "path"
+import { dirname, join } from "path"
 import { ConfigurationContextFromXML, ConfigurationContextWithExportToXML } from "~/metadata/context/types"
 import { importClientApplicationFormFromYAML } from "~/metadata/forms/clientApplicationForm/fromYAML"
 import { exportClientApplicationFormToXML, exportFormMetadataToXML } from "~/metadata/forms/clientApplicationForm/toXML"
@@ -30,8 +30,6 @@ export const syncFormToXML = async (params: {
 
   const contextWithFormDir = createFormScopedContext({ context, formDir })
 
-  const form = importClientApplicationFormFromYAML(contextWithFormDir, yamlObj)
-
   const contextFromXML: ConfigurationContextFromXML = {
     fromXML: {
       forReference: true,
@@ -45,7 +43,13 @@ export const syncFormToXML = async (params: {
     formName,
   })
 
-  const formXML = exportClientApplicationFormToXML({ context: contextWithFormDir, form, referenceForm })
+  const form = importClientApplicationFormFromYAML(contextWithFormDir, yamlObj, referenceForm)
+  const isOrdinaryForm = form.formType === "Ordinary"
+  const referenceHasFormXML = hasReferenceFormXML({ referenceDir, formName })
+
+  const formXML = isOrdinaryForm && !referenceHasFormXML
+    ? undefined
+    : exportClientApplicationFormToXML({ context: contextWithFormDir, form, referenceForm })
   const metadataXML = exportFormMetadataToXML({
     context: contextWithFormDir,
     form,
@@ -61,11 +65,16 @@ export const syncFormToXML = async (params: {
     outputDir,
     xmlManifest: params.xmlManifest,
   })
-  await copyFormItemExternalFilesToXML({
-    formNkdkDir: formDir,
-    formXmlDir: join(outputDir, "Forms", formName, "Ext"),
-    xmlManifest: params.xmlManifest,
-  })
+  if (formXML !== undefined) {
+    await copyFormItemExternalFilesToXML({
+      formNkdkDir: formDir,
+      formXmlDir: join(outputDir, "Forms", formName, "Ext"),
+      xmlManifest: params.xmlManifest,
+    })
+  }
+  if (isOrdinaryForm) {
+    await copyFormBinToXML({ formDir, formName, outputDir, xmlManifest: params.xmlManifest })
+  }
 }
 
 async function readFormFiles(params: { inputDir: string; formName: string }): Promise<{
@@ -110,9 +119,12 @@ const createFormScopedContext = (params: {
   }
 }
 
+const hasReferenceFormXML = (params: { referenceDir: string; formName: string }): boolean =>
+  fs.existsSync(join(params.referenceDir, params.formName, "Ext", "Form.xml"))
+
 const writeFormToXML = async (params: {
   context: ConfigurationContextWithExportToXML
-  formXML: ClientApplicationFormXML
+  formXML: ClientApplicationFormXML | undefined
   metadataXML: FormMetadataXML
   formName: string
   outputDir: string
@@ -126,10 +138,27 @@ const writeFormToXML = async (params: {
   const formXmlPath = join(formExtDir, "Form.xml")
 
   await fs.promises.mkdir(formsOutDir, { recursive: true })
-  await fs.promises.mkdir(formExtDir, { recursive: true })
 
   await fs.promises.writeFile(formMetadataPath, xmlExport({ MetaDataObject: metadataXML }), "utf-8")
-  await fs.promises.writeFile(formXmlPath, xmlExport({ Form: formXML }), "utf-8")
   params.xmlManifest?.addFile(formMetadataPath)
-  params.xmlManifest?.addFile(formXmlPath)
+  if (formXML !== undefined) {
+    await fs.promises.mkdir(formExtDir, { recursive: true })
+    await fs.promises.writeFile(formXmlPath, xmlExport({ Form: formXML }), "utf-8")
+    params.xmlManifest?.addFile(formXmlPath)
+  }
+}
+
+const copyFormBinToXML = async (params: {
+  formDir: string
+  formName: string
+  outputDir: string
+  xmlManifest?: import("~/metadata/appliedObjects/configuration/migrations/xmlManifest").XmlSyncManifest
+}): Promise<void> => {
+  const sourcePath = join(params.formDir, "Form.bin")
+  if (!fs.existsSync(sourcePath)) return
+
+  const targetPath = join(params.outputDir, "Forms", params.formName, "Ext", "Form.bin")
+  await fs.promises.mkdir(dirname(targetPath), { recursive: true })
+  await fs.promises.copyFile(sourcePath, targetPath)
+  params.xmlManifest?.addFile(targetPath)
 }


### PR DESCRIPTION
## Что сделано
- Добавлена поддержка ordinary forms без Ext/Form.xml и с Form.bin.
- Raw Color refs 0 / 0:<uuid> сохраняются через YAML.
- Nil-позиции DCS typed values сохраняются как {}.
- MetadataValue поддерживает v8:StandardPeriod с YAML-ключами Вариант, ДатаНачала, ДатаОкончания.
- Добавлены спека и план принятых решений.

## Проверки
- pnpm --filter '@nakidka/core' test
- pnpm test
- pnpm exec tsc --noEmit в packages/core
- env NKDK_XML_REPO=/Users/nikita/git/round-trip-source ./.agents/skills/round-trip-yaml/round-trip.sh --triage --all-configs --batch-size 5

## Round-trip
All-configs import/sync прошел по acc/doc/erp/small/trade без ошибок. Остались обычные XML diff: 507.