### PR TITLE
Не создавать GraphStub в bulk replace

### DIFF
--- a/packages/graph/src/bulk/plan.ts
+++ b/packages/graph/src/bulk/plan.ts
@@ -70,8 +70,6 @@ export const createBulkPlan = (files: readonly FileGraphData[]): BulkPlan => {
     return id
   }
 
-  const ensureStub = (logicalId: string): number => addNode("GraphStub", logicalId, {})
-
   for (const file of files) {
     addNode("File", file.filePath, fileProps(file))
     for (const node of file.nodes) {
@@ -84,18 +82,21 @@ export const createBulkPlan = (files: readonly FileGraphData[]): BulkPlan => {
     if (fileNodeId === undefined) throw new Error(`Missing File node in bulk plan: ${file.filePath}`)
 
     for (const edge of file.edges) {
-      const src = nodeIdByLogicalId.get(edge.src) ?? ensureStub(edge.src)
-      const tgt = nodeIdByLogicalId.get(edge.tgt) ?? ensureStub(edge.tgt)
+      const src = nodeIdByLogicalId.get(edge.src)
+      const tgt = nodeIdByLogicalId.get(edge.tgt)
+      if (src === undefined || tgt === undefined) continue
       groupPush(edgeGroups, edge.kind, { src, tgt, props: normalizeBulkProperties(edgeProps(file, edge)) })
     }
 
     for (const nodeId of file.declaredNodeIds ?? file.nodes.map((node: NodeData) => node.id)) {
-      const tgt = nodeIdByLogicalId.get(nodeId) ?? ensureStub(nodeId)
+      const tgt = nodeIdByLogicalId.get(nodeId)
+      if (tgt === undefined) continue
       groupPush(edgeGroups, "DECLARES", { src: fileNodeId, tgt, props: {} })
     }
 
     for (const nodeId of file.contributedNodeIds ?? []) {
-      const tgt = nodeIdByLogicalId.get(nodeId) ?? ensureStub(nodeId)
+      const tgt = nodeIdByLogicalId.get(nodeId)
+      if (tgt === undefined) continue
       groupPush(edgeGroups, "CONTRIBUTES", { src: fileNodeId, tgt, props: {} })
     }
   }

--- a/packages/graph/src/bulk/replaceGraphBulk.ts
+++ b/packages/graph/src/bulk/replaceGraphBulk.ts
@@ -1,4 +1,4 @@
-import { deleteGraph } from "../internal/connection"
+import { deleteGraph, graphNameOf, rawCommand } from "../internal/connection"
 import type { GraphConnection } from "../internal/connection"
 import { ensureFileIndexes, ensureLabelIndexes, validateReplacePayload } from "../internal/operations"
 import type { FileGraphData, GraphProgress } from "../types"
@@ -29,6 +29,7 @@ export const replaceGraphBulk = async (
 ): Promise<void> => {
   validateReplacePayload(files)
   await report("resetGraph", opts.onProgress, () => deleteGraph(conn))
+  await rawCommand(conn, ["DEL", graphNameOf(conn)])
 
   const plan = await (async () => {
     let created = createBulkPlan(files)

--- a/packages/graph/tests/bulk/plan.test.ts
+++ b/packages/graph/tests/bulk/plan.test.ts
@@ -3,7 +3,7 @@ import { createBulkPlan } from "../../src/bulk/plan"
 import type { FileGraphData } from "../../src/types"
 
 describe("bulk plan", () => {
-  it("назначает стабильные numeric IDs для File, предметных узлов и stub-узлов", () => {
+  it("пропускает связи с отсутствующими узлами как обычный replace-путь", () => {
     const files: FileGraphData[] = [
       {
         filePath: "a.yaml",
@@ -17,23 +17,20 @@ describe("bulk plan", () => {
 
     const plan = createBulkPlan(files)
 
-    expect(plan.nodeCount).toBe(3)
-    expect(plan.edgeCount).toBe(3)
+    expect(plan.nodeCount).toBe(2)
+    expect(plan.edgeCount).toBe(1)
     expect(plan.nodeIdByLogicalId).toEqual(new Map([
       ["a.yaml", 0],
       ["A", 1],
-      ["Missing", 2],
     ]))
     expect(plan.nodeGroups.map((group) => [group.label, group.nodes.map((node) => node.id)])).toEqual([
       ["File", [0]],
       ["MetadataCatalog", [1]],
-      ["GraphStub", [2]],
     ])
     expect(plan.labels).not.toContain("GraphNode")
+    expect(plan.labels).not.toContain("GraphStub")
     expect(plan.edgeGroups.map((group) => [group.kind, group.edges.map((edge) => [edge.src, edge.tgt])])).toEqual([
-      ["VALUE", [[1, 2]]],
       ["DECLARES", [[0, 1]]],
-      ["CONTRIBUTES", [[0, 2]]],
     ])
   })
 })

--- a/packages/graph/tests/bulk/replaceGraphBulk.test.ts
+++ b/packages/graph/tests/bulk/replaceGraphBulk.test.ts
@@ -2,16 +2,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   deleteGraph: vi.fn(),
+  graphNameOf: vi.fn(),
   ensureFileIndexes: vi.fn(),
   ensureLabelIndexes: vi.fn(),
   query: vi.fn(),
+  rawCommand: vi.fn(),
   validateReplacePayload: vi.fn(),
   writeBulkCommands: vi.fn(),
 }))
 
 vi.mock("../../src/internal/connection", () => ({
   deleteGraph: mocks.deleteGraph,
+  graphNameOf: mocks.graphNameOf,
   query: mocks.query,
+  rawCommand: mocks.rawCommand,
 }))
 
 vi.mock("../../src/internal/operations", () => ({
@@ -31,9 +35,11 @@ import type { FileGraphData } from "../../src/types"
 describe("replaceGraphBulk", () => {
   beforeEach(() => {
     mocks.deleteGraph.mockReset().mockResolvedValue(undefined)
+    mocks.graphNameOf.mockReset().mockReturnValue("testGraph")
     mocks.ensureFileIndexes.mockReset().mockResolvedValue(undefined)
     mocks.ensureLabelIndexes.mockReset().mockResolvedValue(undefined)
     mocks.query.mockReset().mockResolvedValue(undefined)
+    mocks.rawCommand.mockReset().mockResolvedValue(1)
     mocks.validateReplacePayload.mockReset()
     mocks.writeBulkCommands.mockReset().mockResolvedValue({ commands: 1, nodeBlobs: 1, edgeBlobs: 0, totalBytes: 1 })
   })
@@ -53,5 +59,21 @@ describe("replaceGraphBulk", () => {
     expect(mocks.query.mock.calls.map((call) => call[0] as string)).not.toContain(
       "MATCH (n) WHERE n.id IS NOT NULL AND NOT n:File SET n:GraphNode",
     )
+  })
+
+  it("удаляет ключ графа после GRAPH.DELETE перед GRAPH.BULK", async () => {
+    const files: FileGraphData[] = [{
+      filePath: "a.yaml",
+      fileStats: { mtimeMs: 1, size: 2, updatedAt: 3 },
+      nodes: [{ id: "A", label: "MetadataObject", props: { kind: "MetadataCatalog" } }],
+      edges: [],
+      declaredNodeIds: ["A"],
+    }]
+
+    await replaceGraphBulk({} as GraphConnection, files)
+
+    expect(mocks.deleteGraph).toHaveBeenCalledBefore(mocks.rawCommand)
+    expect(mocks.rawCommand).toHaveBeenCalledWith({} as GraphConnection, ["DEL", "testGraph"])
+    expect(mocks.rawCommand).toHaveBeenCalledBefore(mocks.writeBulkCommands)
   })
 })


### PR DESCRIPTION
## Что сделано
- bulk plan больше не материализует отсутствующие endpoints как GraphStub
- bulk replace удаляет ключ графа после GRAPH.DELETE перед GRAPH.BULK
- поведение bulk replace выровнено с обычным replace-путём

## Проверка
- pnpm --filter @nakidka/graph test
- pnpm --filter '@nakidka/core' test
- pnpm --filter @nakidka/cli exec tsx src/cli.ts update-graph --replace --bulk /Users/nikita/git/erp_nkdk
- FalkorDB: GraphStub = 0, MetadataHTTPService label отсутствует