### PR TITLE
feat: добавить YAML-сводки schema

### DIFF
--- a/docs/superpowers/plans/2026-05-30-schema-yaml-summary.md
+++ b/docs/superpowers/plans/2026-05-30-schema-yaml-summary.md
@@ -1,0 +1,983 @@
+# Schema YAML Summary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Сделать `nkdk schema <target>` удобным выводом для LLM: по умолчанию печатать компактную YAML-сводку, добавить `--keys`, `--required`, `--search`, `--exact`, сохранить точную JSON Schema за `--json-schema`, и обновить внешний навык `.agents`.
+
+**Architecture:** Нормализация JSON Schema живёт в `@nakidka/core`, CLI только выбирает режим, проверяет сочетания флагов и форматирует результат. Все YAML-режимы используют одну структуру `fields`; `--keys` всегда печатает только имена полей по одному на строку.
+
+**Tech Stack:** TypeScript, Vitest, Commander, `yaml`, существующие JSON Schema helpers из `packages/core/metadata/validation`.
+
+---
+
+## File Structure
+
+Создать:
+
+- `packages/core/metadata/validation/schemaSummary.ts` — нормализация JSON Schema в компактную YAML-сводку, поиск и вывод ключей.
+- `packages/core/metadata/validation/schemaSummary.test.ts` — unit-тесты на маленькой схеме из спеки и на ветках `anyOf`.
+
+Изменить:
+
+- `packages/core/index.ts` — экспортировать helpers и типы сводки.
+- `packages/cli/src/commands/schema.ts` — заменить текущий JSON-only вывод на режимы `--json-schema`, `--keys`, `--required`, `--search`, `--exact`.
+- `packages/cli/src/commands/schema.test.ts` — обновить тесты команды под новую семантику.
+- `packages/cli/src/cli.ts` — добавить CLI-флаги и обновить описания.
+- `/Users/nikita/git/new_config_add_item_test/.agents/skills/config-add-item/SKILL.md` — обновить инструкции навыка под новый `nkdk schema`.
+
+Не изменять:
+
+- XML-фикстуры.
+- `packages/core/metadata/**/rules.ts`.
+- fromXML/toXML/fromYAML/toYAML правила.
+
+---
+
+## Step 0: Preflight Context
+
+**Files:**
+
+- Read `.agents/knowledge/metadata/INDEX.md`
+- Read `.agents/knowledge/metadata/sources-of-truth.md`
+- Read `docs/superpowers/specs/2026-05-29-cli-schema-llm-summary-design.md`
+
+**Actions:**
+
+- [ ] Прочитать metadata-инструкции перед изменениями в `packages/core/metadata/**`:
+
+```bash
+sed -n '1,220p' .agents/knowledge/metadata/INDEX.md
+sed -n '1,220p' .agents/knowledge/metadata/sources-of-truth.md
+```
+
+Expected: подтверждено, что задача не меняет XML-фикстуры, XSD-источники и правила metadata-преобразований.
+
+- [ ] Прочитать согласованную спеку:
+
+```bash
+sed -n '1,260p' docs/superpowers/specs/2026-05-29-cli-schema-llm-summary-design.md
+```
+
+Expected: подтверждены режимы `--keys`, `--required`, `--search`, `--exact`, `--json-schema`; `--template` и `--prop` остаются вне границ задачи.
+
+---
+
+## Step 1: Core YAML Summary Helper
+
+**Files:**
+
+- Create `packages/core/metadata/validation/schemaSummary.ts`
+- Create `packages/core/metadata/validation/schemaSummary.test.ts`
+- Modify `packages/core/index.ts`
+
+**Tests First:**
+
+- [ ] Создать `packages/core/metadata/validation/schemaSummary.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  listSchemaSummaryKeys,
+  summarizeJSONSchema,
+} from "./schemaSummary";
+
+const exampleSchema = {
+  type: "object",
+  required: ["Вид"],
+  properties: {
+    Вид: {
+      const: "ПолеВвода",
+      description: "Вид элемента формы.",
+      examples: [],
+    },
+    ПутьКДанным: {
+      type: "string",
+      description: "Путь к реквизиту формы.",
+      pattern: "^[А-Яа-яA-Za-z0-9_.]+$",
+    },
+    Видимость: {
+      type: "boolean",
+      description: null,
+      examples: [],
+    },
+  },
+} satisfies Record<string, unknown>;
+
+describe("schema summary", () => {
+  it("normalizes object properties into fields and removes empty values", () => {
+    expect(summarizeJSONSchema(exampleSchema)).toEqual({
+      fields: [
+        {
+          key: "Вид",
+          required: true,
+          const: "ПолеВвода",
+          description: "Вид элемента формы.",
+        },
+        {
+          key: "ПутьКДанным",
+          required: false,
+          type: ["string"],
+          description: "Путь к реквизиту формы.",
+          pattern: "^[А-Яа-яA-Za-z0-9_.]+$",
+        },
+        {
+          key: "Видимость",
+          required: false,
+          type: ["boolean"],
+        },
+      ],
+    });
+  });
+
+  it("returns plain keys", () => {
+    expect(listSchemaSummaryKeys(exampleSchema)).toEqual([
+      "Вид",
+      "ПутьКДанным",
+      "Видимость",
+    ]);
+  });
+
+  it("filters keys by terms split with pipe", () => {
+    expect(listSchemaSummaryKeys(exampleSchema, { keyTerms: "путь|видим" })).toEqual([
+      "ПутьКДанным",
+      "Видимость",
+    ]);
+  });
+
+  it("returns only required fields", () => {
+    expect(summarizeJSONSchema(exampleSchema, { requiredOnly: true })).toEqual({
+      fields: [
+        {
+          key: "Вид",
+          required: true,
+          const: "ПолеВвода",
+          description: "Вид элемента формы.",
+        },
+      ],
+    });
+  });
+
+  it("searches fields by key and textual schema values", () => {
+    expect(summarizeJSONSchema(exampleSchema, { search: "путь|boolean" })).toEqual({
+      fields: [
+        {
+          key: "ПутьКДанным",
+          required: false,
+          type: ["string"],
+          description: "Путь к реквизиту формы.",
+          pattern: "^[А-Яа-яA-Za-z0-9_.]+$",
+        },
+        {
+          key: "Видимость",
+          required: false,
+          type: ["boolean"],
+        },
+      ],
+    });
+  });
+
+  it("searches exact top-level field names", () => {
+    expect(summarizeJSONSchema(exampleSchema, { search: "ПутьКДанным", exact: true })).toEqual({
+      fields: [
+        {
+          key: "ПутьКДанным",
+          required: false,
+          type: ["string"],
+          description: "Путь к реквизиту формы.",
+          pattern: "^[А-Яа-яA-Za-z0-9_.]+$",
+        },
+      ],
+    });
+  });
+
+  it("returns empty values when nothing matches", () => {
+    expect(summarizeJSONSchema(exampleSchema, { search: "НесуществующееПоле" })).toBeUndefined();
+    expect(listSchemaSummaryKeys(exampleSchema, { search: "НесуществующееПоле" })).toEqual([]);
+  });
+
+  it("collects object properties from anyOf branches", () => {
+    const branchedSchema = {
+      anyOf: [
+        {
+          type: "object",
+          required: ["Вид"],
+          properties: {
+            Вид: { const: "ОбычнаяГруппа" },
+          },
+        },
+        {
+          type: "object",
+          properties: {
+            Элементы: {
+              type: "array",
+              items: { $ref: "#/$defs/FormElement" },
+            },
+          },
+        },
+      ],
+    };
+
+    expect(summarizeJSONSchema(branchedSchema)).toEqual({
+      fields: [
+        {
+          key: "Вид",
+          required: true,
+          const: "ОбычнаяГруппа",
+        },
+        {
+          key: "Элементы",
+          required: false,
+          type: ["array"],
+          items: { $ref: "#/$defs/FormElement" },
+        },
+      ],
+    });
+  });
+});
+```
+
+- [ ] Запустить тест и убедиться, что он падает из-за отсутствующего модуля:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/schemaSummary.test.ts --no-isolate
+```
+
+Expected: Vitest сообщает, что `./schemaSummary` не найден.
+
+**Implementation:**
+
+- [ ] Создать `packages/core/metadata/validation/schemaSummary.ts`:
+
+```ts
+export interface SchemaSummaryOptions {
+  requiredOnly?: boolean;
+  search?: string;
+  exact?: boolean;
+  keyTerms?: string;
+}
+
+export interface SchemaSummary {
+  fields: SchemaFieldSummary[];
+}
+
+export interface SchemaFieldSummary {
+  key: string;
+  required: boolean;
+  [property: string]: unknown;
+}
+
+type JSONRecord = Record<string, unknown>;
+
+interface ObjectSchemaView {
+  properties: Record<string, unknown>;
+  required: Set<string>;
+}
+
+export function summarizeJSONSchema(
+  schema: unknown,
+  options: SchemaSummaryOptions = {},
+): SchemaSummary | undefined {
+  const fields = collectFieldSummaries(schema)
+    .filter((field) => matchesOptions(field, options))
+    .map((field) => filterFieldForKeys(field, options.keyTerms))
+    .filter((field): field is SchemaFieldSummary => field !== undefined);
+
+  return cleanEmpty({ fields }) as SchemaSummary | undefined;
+}
+
+export function listSchemaSummaryKeys(
+  schema: unknown,
+  options: SchemaSummaryOptions = {},
+): string[] {
+  return collectFieldSummaries(schema)
+    .filter((field) => matchesOptions(field, options))
+    .map((field) => field.key)
+    .filter((key) => matchesTerms(key, splitSearchTerms(options.keyTerms)));
+}
+
+export function splitSearchTerms(terms: string | undefined): string[] {
+  return terms
+    ?.split("|")
+    .map((term) => term.trim().toLocaleLowerCase("ru-RU"))
+    .filter(Boolean) ?? [];
+}
+
+function collectFieldSummaries(schema: unknown): SchemaFieldSummary[] {
+  const fields = new Map<string, SchemaFieldSummary>();
+
+  for (const objectSchema of collectObjectSchemas(schema)) {
+    for (const [key, propertySchema] of Object.entries(objectSchema.properties)) {
+      if (fields.has(key)) {
+        continue;
+      }
+
+      const summary = cleanEmpty({
+        key,
+        required: objectSchema.required.has(key),
+        ...normalizeSchemaNode(propertySchema),
+      }) as SchemaFieldSummary | undefined;
+
+      if (summary !== undefined) {
+        fields.set(key, summary);
+      }
+    }
+  }
+
+  return [...fields.values()];
+}
+
+function collectObjectSchemas(schema: unknown): ObjectSchemaView[] {
+  if (!isRecord(schema)) {
+    return [];
+  }
+
+  const result: ObjectSchemaView[] = [];
+  if (isRecord(schema.properties)) {
+    result.push({
+      properties: schema.properties,
+      required: new Set(asStringArray(schema.required)),
+    });
+  }
+
+  for (const keyword of ["anyOf", "oneOf", "allOf"] as const) {
+    const branches = schema[keyword];
+    if (!Array.isArray(branches)) {
+      continue;
+    }
+
+    for (const branch of branches) {
+      result.push(...collectObjectSchemas(branch));
+    }
+  }
+
+  return result;
+}
+
+function normalizeSchemaNode(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node
+      .map((item) => normalizeSchemaNode(item))
+      .map(cleanEmpty)
+      .filter((item) => item !== undefined);
+  }
+
+  if (!isRecord(node)) {
+    return node;
+  }
+
+  const normalized: JSONRecord = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "type" && typeof value === "string") {
+      normalized[key] = [value];
+      continue;
+    }
+
+    normalized[key] = normalizeSchemaNode(value);
+  }
+
+  return cleanEmpty(normalized);
+}
+
+function matchesOptions(field: SchemaFieldSummary, options: SchemaSummaryOptions): boolean {
+  if (options.requiredOnly === true && field.required !== true) {
+    return false;
+  }
+
+  const searchTerms = splitSearchTerms(options.search);
+  if (searchTerms.length === 0) {
+    return true;
+  }
+
+  if (options.exact === true) {
+    return field.key === options.search?.trim();
+  }
+
+  return matchesTerms(collectSearchText(field).join("\n"), searchTerms);
+}
+
+function filterFieldForKeys(
+  field: SchemaFieldSummary,
+  keyTerms: string | undefined,
+): SchemaFieldSummary | undefined {
+  if (!matchesTerms(field.key, splitSearchTerms(keyTerms))) {
+    return undefined;
+  }
+
+  return field;
+}
+
+function matchesTerms(value: string, terms: string[]): boolean {
+  if (terms.length === 0) {
+    return true;
+  }
+
+  const normalizedValue = value.toLocaleLowerCase("ru-RU");
+  return terms.some((term) => normalizedValue.includes(term));
+}
+
+function collectSearchText(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return [String(value)];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(collectSearchText);
+  }
+
+  if (isRecord(value)) {
+    return Object.entries(value).flatMap(([key, childValue]) => [
+      key,
+      ...collectSearchText(childValue),
+    ]);
+  }
+
+  return [];
+}
+
+function cleanEmpty(value: unknown): unknown {
+  if (value == null) {
+    return undefined;
+  }
+
+  if (typeof value === "string") {
+    return value.length > 0 ? value : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const items = value.map(cleanEmpty).filter((item) => item !== undefined);
+    return items.length > 0 ? items : undefined;
+  }
+
+  if (isRecord(value)) {
+    const entries = Object.entries(value)
+      .map(([key, childValue]) => [key, cleanEmpty(childValue)] as const)
+      .filter(([, childValue]) => childValue !== undefined);
+
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+
+  return value;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function isRecord(value: unknown): value is JSONRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+```
+
+- [ ] Добавить экспорт в `packages/core/index.ts`:
+
+```ts
+export {
+  listSchemaSummaryKeys,
+  summarizeJSONSchema,
+  splitSearchTerms,
+  type SchemaFieldSummary,
+  type SchemaSummary,
+  type SchemaSummaryOptions,
+} from "./metadata/validation/schemaSummary";
+```
+
+**Verify:**
+
+- [ ] Запустить:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/schemaSummary.test.ts --no-isolate
+```
+
+Expected: все тесты в `schemaSummary.test.ts` проходят.
+
+- [ ] Зафиксировать изменения:
+
+```bash
+git add packages/core/metadata/validation/schemaSummary.ts packages/core/metadata/validation/schemaSummary.test.ts packages/core/index.ts
+git commit -m "feat: :sparkles: добавить YAML-сводку schema"
+```
+
+---
+
+## Step 2: CLI Schema Modes
+
+**Files:**
+
+- Modify `packages/cli/src/commands/schema.ts`
+- Modify `packages/cli/src/commands/schema.test.ts`
+- Modify `packages/cli/src/cli.ts`
+
+**Tests First:**
+
+- [ ] Обновить `packages/cli/src/commands/schema.test.ts`, сохранив style существующих тестов:
+
+```ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { printSchema } from "./schema";
+
+describe("schema command", () => {
+  const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+  afterEach(() => {
+    writeSpy.mockClear();
+  });
+
+  it("prints YAML summary by schema name by default", () => {
+    printSchema("InputField");
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+    expect(output).toContain("fields:");
+    expect(output).toContain("key: Вид");
+    expect(output).toContain("const: ПолеВвода");
+    expect(output).not.toContain("enum: []");
+    expect(output).not.toContain("description: null");
+  });
+
+  it("prints plain keys", () => {
+    printSchema("InputField", { keys: true });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+    expect(output.split("\n")).toContain("Вид");
+    expect(output).not.toContain("fields:");
+  });
+
+  it("filters plain keys by pipe-separated terms", () => {
+    printSchema("InputField", { keys: "путь|вид" });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+    expect(output.split("\n")).toContain("Вид");
+    expect(output.split("\n")).toContain("ПутьКДанным");
+  });
+
+  it("prints required fields as YAML summary", () => {
+    printSchema("InputField", { required: true });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+    expect(output).toContain("fields:");
+    expect(output).toContain("key: Вид");
+    expect(output).not.toContain("schema:");
+  });
+
+  it("prints required keys only", () => {
+    printSchema("InputField", { required: true, keys: true });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+    expect(output.trim()).toBe("Вид");
+  });
+
+  it("prints search results in the same YAML shape", () => {
+    printSchema("InputField", { search: "ПутьКДанным" });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+    expect(output).toContain("fields:");
+    expect(output).toContain("key: ПутьКДанным");
+    expect(output).not.toContain("matches:");
+    expect(output).not.toContain("query:");
+  });
+
+  it("prints exact search result", () => {
+    printSchema("InputField", { search: "ПутьКДанным", exact: true });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+    expect(output).toContain("key: ПутьКДанным");
+    expect(output).not.toContain("key: Вид\n");
+  });
+
+  it("prints exact search keys only", () => {
+    printSchema("InputField", { search: "ПутьКДанным", exact: true, keys: true });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+
+    expect(output.trim()).toBe("ПутьКДанным");
+  });
+
+  it("prints JSON Schema when requested", () => {
+    printSchema("InputField", { jsonSchema: true });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+    const schema = JSON.parse(output) as Record<string, unknown>;
+
+    expect(schema).toHaveProperty("$schema");
+    expect(schema).toHaveProperty("definitions");
+  });
+
+  it("prints inlined JSON Schema when requested", () => {
+    printSchema("InputField", { jsonSchema: true, inline: true });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+    const schema = JSON.parse(output) as Record<string, unknown>;
+
+    expect(schema).toHaveProperty("$schema");
+    expect(output).not.toContain('"$ref"');
+  });
+
+  it("prints JSON Schema for project file with refs", () => {
+    printSchema("Справочник/Договоры/Формы/ФормаЭлемента/Форма.yaml", {
+      jsonSchema: true,
+      project: "examples",
+    });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+    const schema = JSON.parse(output) as Record<string, unknown>;
+
+    expect(schema).toHaveProperty("$schema");
+    expect(output).toContain('"$ref"');
+  });
+
+  it("prints inlined JSON Schema for project file", () => {
+    printSchema("Справочник/Договоры/Формы/ФормаЭлемента/Форма.yaml", {
+      jsonSchema: true,
+      project: "examples",
+      inline: true,
+    });
+
+    const output = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+    const schema = JSON.parse(output) as Record<string, unknown>;
+
+    expect(schema).toHaveProperty("$schema");
+    expect(output).not.toContain('"$ref"');
+  });
+
+  it("does not print anything for unknown target", () => {
+    printSchema("UnknownSchema");
+
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects incompatible JSON Schema flags", () => {
+    expect(() => printSchema("InputField", { jsonSchema: true, keys: true })).toThrow(
+      "--json-schema несовместим",
+    );
+  });
+
+  it("rejects inline without JSON Schema", () => {
+    expect(() => printSchema("InputField", { inline: true })).toThrow(
+      "--inline можно использовать только вместе с --json-schema",
+    );
+  });
+
+  it("rejects exact without search", () => {
+    expect(() => printSchema("InputField", { exact: true })).toThrow(
+      "--exact можно использовать только вместе с --search",
+    );
+  });
+
+  it("rejects required with search", () => {
+    expect(() => printSchema("InputField", { required: true, search: "путь" })).toThrow(
+      "--required и --search нельзя использовать одновременно",
+    );
+  });
+});
+```
+
+- [ ] Запустить тест и убедиться, что он падает на текущем API:
+
+```bash
+pnpm --filter @nakidka/cli exec vitest run src/commands/schema.test.ts --no-isolate
+```
+
+Expected: TypeScript или тесты падают из-за отсутствующего `printSchema` и новых опций.
+
+**Implementation:**
+
+- [ ] Заменить содержимое `packages/cli/src/commands/schema.ts`:
+
+```ts
+import {
+  exportJSONSchemaForProjectFile,
+  exportJSONSchemaForSchemaName,
+  listSchemaSummaryKeys,
+  summarizeJSONSchema,
+  type SchemaSummaryOptions,
+} from "@nakidka/core";
+import { stringify } from "yaml";
+
+export interface SchemaCommandOptions {
+  project?: string;
+  inline?: boolean;
+  jsonSchema?: boolean;
+  keys?: boolean | string;
+  required?: boolean;
+  search?: string;
+  exact?: boolean;
+}
+
+export function printSchema(target: string, options: SchemaCommandOptions = {}): void {
+  validateSchemaOptions(options);
+
+  const schema = loadJSONSchema(target, options);
+  if (schema == null) {
+    return;
+  }
+
+  if (options.jsonSchema === true) {
+    process.stdout.write(`${JSON.stringify(schema, null, 2)}\n`);
+    return;
+  }
+
+  const summaryOptions: SchemaSummaryOptions = {
+    requiredOnly: options.required === true,
+    search: options.search,
+    exact: options.exact === true,
+    keyTerms: typeof options.keys === "string" ? options.keys : undefined,
+  };
+
+  if (options.keys !== undefined) {
+    const keys = listSchemaSummaryKeys(schema, summaryOptions);
+    if (keys.length > 0) {
+      process.stdout.write(`${keys.join("\n")}\n`);
+    }
+    return;
+  }
+
+  const summary = summarizeJSONSchema(schema, summaryOptions);
+  if (summary == null) {
+    if (options.exact === true) {
+      throw new Error(`Поле "${options.search?.trim()}" не найдено в JSON Schema`);
+    }
+    return;
+  }
+
+  process.stdout.write(stringify(summary));
+}
+
+export function printJSONSchema(target: string, options: SchemaCommandOptions = {}): void {
+  printSchema(target, { ...options, jsonSchema: true });
+}
+
+function loadJSONSchema(target: string, options: SchemaCommandOptions): unknown {
+  return options.project != null
+    ? exportJSONSchemaForProjectFile(options.project, target, {
+        inlineRefs: options.inline === true,
+      })
+    : exportJSONSchemaForSchemaName(target, {
+        inlineRefs: options.inline === true,
+      });
+}
+
+function validateSchemaOptions(options: SchemaCommandOptions): void {
+  if (options.inline === true && options.jsonSchema !== true) {
+    throw new Error("--inline можно использовать только вместе с --json-schema");
+  }
+
+  if (options.jsonSchema === true) {
+    const hasSummaryFlags =
+      options.keys !== undefined ||
+      options.required === true ||
+      options.search != null ||
+      options.exact === true;
+
+    if (hasSummaryFlags) {
+      throw new Error("--json-schema несовместим с --keys, --required, --search и --exact");
+    }
+    return;
+  }
+
+  if (options.required === true && options.search != null) {
+    throw new Error("--required и --search нельзя использовать одновременно");
+  }
+
+  if (options.exact === true && options.search == null) {
+    throw new Error("--exact можно использовать только вместе с --search");
+  }
+
+  if (options.search != null && options.search.trim().length === 0) {
+    throw new Error("--search требует непустой запрос");
+  }
+}
+```
+
+- [ ] Изменить `packages/cli/src/cli.ts` для команды `schema`:
+
+```ts
+program
+  .command("schema <target>")
+  .description("Показать YAML-сводку JSON Schema по имени схемы или пути YAML-файла")
+  .option("--project <yamlDir>", "Корень YAML-проекта для разрешения пути файла")
+  .option("--json-schema", "Вывести точную JSON Schema вместо YAML-сводки")
+  .option("--inline", "Встроить $ref в режиме --json-schema")
+  .option("--keys [terms]", "Вывести только имена полей; terms фильтрует по частям строки через |")
+  .option("--required", "Показать только обязательные поля")
+  .option("--search <terms>", "Найти поля по частям строки через |")
+  .option("--exact", "Точный поиск имени поля в режиме --search")
+  .action((target: string, options: SchemaCommandOptions) => {
+    printSchema(target, options);
+  });
+```
+
+- [ ] Убедиться, что импорт в `packages/cli/src/cli.ts` использует `printSchema`, а не `printJSONSchema`.
+
+**Verify:**
+
+- [ ] Запустить:
+
+```bash
+pnpm --filter @nakidka/cli exec vitest run src/commands/schema.test.ts --no-isolate
+```
+
+Expected: все тесты `schema.test.ts` проходят.
+
+- [ ] Запустить ручные проверки:
+
+```bash
+pnpm --filter @nakidka/cli dev schema InputField --keys
+pnpm --filter @nakidka/cli dev schema InputField --search ПутьКДанным --exact
+pnpm --filter @nakidka/cli dev schema InputField --json-schema
+```
+
+Expected:
+
+- первая команда печатает имена полей, включая `Вид`;
+- вторая команда печатает YAML с корнем `fields` и полем `ПутьКДанным`;
+- третья команда печатает JSON, начинающийся с `{`.
+
+- [ ] Зафиксировать изменения:
+
+```bash
+git add packages/cli/src/commands/schema.ts packages/cli/src/commands/schema.test.ts packages/cli/src/cli.ts
+git commit -m "feat: :sparkles: обновить вывод schema"
+```
+
+---
+
+## Step 3: External Skill Update
+
+**Files:**
+
+- Modify `/Users/nikita/git/new_config_add_item_test/.agents/skills/config-add-item/SKILL.md`
+
+**Implementation:**
+
+- [ ] Открыть навык и найти разделы, где он просит читать полную JSON Schema через `nkdk schema`.
+
+```bash
+rg -n "nkdk schema|schema" /Users/nikita/git/new_config_add_item_test/.agents/skills/config-add-item/SKILL.md
+```
+
+- [ ] Обновить инструкции навыка этим фрагментом:
+
+````md
+Для ориентации по YAML-формату сначала используй компактную сводку:
+
+```bash
+nkdk schema "Справочник/Договоры/Формы/ФормаЭлемента/Форма.yaml" --project examples
+```
+
+Для быстрых вопросов:
+
+```bash
+nkdk schema InputField --keys
+nkdk schema InputField --keys "путь|вид"
+nkdk schema InputField --required
+nkdk schema InputField --required --keys
+nkdk schema InputField --search "путь|тип"
+nkdk schema InputField --search ПутьКДанным --exact
+```
+
+Если сводки недостаточно и нужно увидеть исходную JSON Schema, используй:
+
+```bash
+nkdk schema InputField --json-schema
+nkdk schema InputField --json-schema --inline
+nkdk schema "Справочник/Договоры/Формы/ФормаЭлемента/Форма.yaml" --project examples --json-schema
+```
+````
+
+- [ ] Если sandbox запрещает редактировать `/Users/nikita/git/new_config_add_item_test/.agents`, запросить разрешение на запись в этот путь и повторить изменение.
+
+**Verify:**
+
+- [ ] Прочитать обновлённый фрагмент:
+
+```bash
+sed -n '1,220p' /Users/nikita/git/new_config_add_item_test/.agents/skills/config-add-item/SKILL.md
+```
+
+Expected: навык описывает YAML-сводку по умолчанию, `--keys`, `--required`, `--search`, `--exact`, и `--json-schema` как запасной режим.
+
+- [ ] Проверить, является ли внешний каталог git-репозиторием:
+
+```bash
+git -C /Users/nikita/git/new_config_add_item_test status --short
+```
+
+Expected: если команда успешна, в статусе есть только ожидаемое изменение `SKILL.md` или другие пользовательские изменения, которые не трогаем.
+
+- [ ] Если внешний каталог является git-репозиторием и пользовательские изменения не мешают, зафиксировать только файл навыка:
+
+```bash
+git -C /Users/nikita/git/new_config_add_item_test add .agents/skills/config-add-item/SKILL.md
+git -C /Users/nikita/git/new_config_add_item_test commit -m "docs: :memo: обновить навык schema"
+```
+
+---
+
+## Step 4: Full Verification
+
+**Commands:**
+
+- [ ] Проверить core helper:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/schemaSummary.test.ts --no-isolate
+```
+
+Expected: тесты `schemaSummary.test.ts` проходят.
+
+- [ ] Проверить CLI command:
+
+```bash
+pnpm --filter @nakidka/cli exec vitest run src/commands/schema.test.ts --no-isolate
+```
+
+Expected: тесты `schema.test.ts` проходят.
+
+- [ ] Проверить весь проект:
+
+```bash
+pnpm test
+```
+
+Expected: все пакеты проходят; допустимы только уже существующие skipped-тесты.
+
+- [ ] Проверить рабочее дерево:
+
+```bash
+git status --short
+```
+
+Expected: нет незакоммиченных изменений в worktree `/Users/nikita/git/nakidka-core/.worktrees/schema-yaml-summary`.
+
+**Manual CLI Smoke:**
+
+- [ ] Выполнить:
+
+```bash
+pnpm --filter @nakidka/cli dev schema InputField --keys
+pnpm --filter @nakidka/cli dev schema InputField --search "путь|вид"
+pnpm --filter @nakidka/cli dev schema InputField --search ПутьКДанным --exact
+pnpm --filter @nakidka/cli dev schema InputField --required --keys
+pnpm --filter @nakidka/cli dev schema InputField --json-schema
+```
+
+Expected:
+
+- `--keys` печатает plain text без YAML;
+- `--search` печатает YAML с корнем `fields`;
+- `--exact` печатает один field при точном совпадении;
+- `--required --keys` печатает только обязательные имена;
+- `--json-schema` печатает точную JSON Schema.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,7 @@
 import { Command } from "commander"
 import { importConfiguration } from "./commands/import"
 import { deleteMigration, generateMigration, renameMigration } from "./commands/migration"
-import { printJSONSchema } from "./commands/schema"
+import { printSchema, type SchemaCommandOptions } from "./commands/schema"
 import { shortRoundTrip } from "./commands/shortRoundTrip"
 import { syncConfiguration } from "./commands/sync"
 import { updateGraph, updateGraphFile } from "./commands/updateGraph"
@@ -71,12 +71,17 @@ program
 
 program
   .command("schema")
-  .description("Показать JSON Schema для YAML-файла проекта или имени схемы")
+  .description("Показать YAML-сводку JSON Schema для YAML-файла проекта или имени схемы")
   .argument("<target>", "путь к YAML-файлу проекта или имя схемы")
   .option("--project <yamlDir>", "путь к корню YAML-проекта")
-  .option("--inline", "развернуть составные подсхемы в одном JSON")
-  .action((target: string, opts: { project?: string; inline?: boolean }) => {
-    run(() => printJSONSchema(target, opts))
+  .option("--json-schema", "вывести точную JSON Schema вместо YAML-сводки")
+  .option("--inline", "развернуть составные подсхемы в режиме --json-schema")
+  .option("--keys [terms]", "вывести только имена полей; terms фильтрует по частям строки через |")
+  .option("--required", "показать только обязательные поля")
+  .option("--search <terms>", "найти поля по частям строки через |")
+  .option("--exact", "точный поиск имени поля в режиме --search")
+  .action((target: string, opts: SchemaCommandOptions) => {
+    run(() => printSchema(target, opts))
   })
 
 program

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,7 @@
 import { Command } from "commander"
 import { importConfiguration } from "./commands/import"
 import { deleteMigration, generateMigration, renameMigration } from "./commands/migration"
-import { printSchema, type SchemaCommandOptions } from "./commands/schema"
+import { normalizeSchemaCommandInput, printSchema, type SchemaCommandOptions } from "./commands/schema"
 import { shortRoundTrip } from "./commands/shortRoundTrip"
 import { syncConfiguration } from "./commands/sync"
 import { updateGraph, updateGraphFile } from "./commands/updateGraph"
@@ -72,7 +72,7 @@ program
 program
   .command("schema")
   .description("Показать YAML-сводку JSON Schema для YAML-файла проекта или имени схемы")
-  .argument("<target>", "путь к YAML-файлу проекта или имя схемы")
+  .argument("[target]", "путь к YAML-файлу проекта или имя схемы")
   .option("--project <yamlDir>", "путь к корню YAML-проекта")
   .option("--json-schema", "вывести точную JSON Schema вместо YAML-сводки")
   .option("--inline", "развернуть составные подсхемы в режиме --json-schema")
@@ -80,8 +80,11 @@ program
   .option("--required", "показать только обязательные поля")
   .option("--search <terms>", "найти поля по частям строки через |")
   .option("--exact", "точный поиск имени поля в режиме --search")
-  .action((target: string, opts: SchemaCommandOptions) => {
-    run(() => printSchema(target, opts))
+  .action((target: string | undefined, opts: SchemaCommandOptions) => {
+    run(() => {
+      const normalized = normalizeSchemaCommandInput(target, opts)
+      return printSchema(normalized.target, normalized.options)
+    })
   })
 
 program

--- a/packages/cli/src/commands/schema.test.ts
+++ b/packages/cli/src/commands/schema.test.ts
@@ -1,55 +1,179 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { printJSONSchema } from "./schema"
+import { printSchema } from "./schema"
 
 describe("schema command", () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it("prints compact JSON schema for a project file", async () => {
+  const captureStdout = () => vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+  const writtenText = (stdout: ReturnType<typeof captureStdout>) => stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
+
+  it("prints YAML summary by schema name by default", async () => {
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
 
-    await printJSONSchema("Справочник/Товары/Свойства.yaml", {})
+    await printSchema("InputField", {})
 
-    expect(stdout).toHaveBeenCalledOnce()
-    const text = String(stdout.mock.calls[0]?.[0])
-    const schema = JSON.parse(text)
-    expect(text).toContain("\n  ")
-    expect(schema.properties.Реквизиты.additionalProperties).toEqual({ $ref: "nkdk://schema/MetadataCatalogAttribute" })
+    const text = writtenText(stdout)
+    expect(text).toContain("fields:")
+    expect(text).toContain("key: Вид")
+    expect(text).toContain("const: ПолеВвода")
+    expect(text).not.toContain("enum: []")
+    expect(text).not.toContain("description: null")
   })
 
-  it("prints compact JSON schema by schema name", async () => {
-    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+  it("prints plain keys", async () => {
+    const stdout = captureStdout()
 
-    await printJSONSchema("InputField", {})
+    await printSchema("InputField", { keys: true })
 
-    const schema = JSON.parse(String(stdout.mock.calls[0]?.[0]))
+    const text = writtenText(stdout)
+    expect(text).toContain("Вид\n")
+    expect(text).not.toContain("fields:")
+  })
+
+  it("filters plain keys by terms", async () => {
+    const stdout = captureStdout()
+
+    await printSchema("InputField", { keys: "путь|вид" })
+
+    const text = writtenText(stdout)
+    expect(text).toContain("Вид\n")
+    expect(text).toContain("ПутьКДанным\n")
+    expect(text).not.toContain("fields:")
+  })
+
+  it("prints required YAML summary without wrapper metadata", async () => {
+    const stdout = captureStdout()
+
+    await printSchema("InputField", { required: true })
+
+    const text = writtenText(stdout)
+    expect(text).toContain("fields:")
+    expect(text).toContain("key: Вид")
+    expect(text).not.toContain("schema:")
+  })
+
+  it("prints required keys only", async () => {
+    const stdout = captureStdout()
+
+    await printSchema("InputField", { required: true, keys: true })
+
+    expect(writtenText(stdout)).toBe("Вид\n")
+  })
+
+  it("prints search YAML summary without wrapper metadata", async () => {
+    const stdout = captureStdout()
+
+    await printSchema("InputField", { search: "ПутьКДанным" })
+
+    const text = writtenText(stdout)
+    expect(text).toContain("fields:")
+    expect(text).toContain("key: ПутьКДанным")
+    expect(text).not.toContain("matches:")
+    expect(text).not.toContain("query:")
+  })
+
+  it("prints exact search YAML summary for one field", async () => {
+    const stdout = captureStdout()
+
+    await printSchema("InputField", { search: "ПутьКДанным", exact: true })
+
+    const text = writtenText(stdout)
+    expect(text).toContain("fields:")
+    expect(text).toContain("key: ПутьКДанным")
+    expect(text).not.toContain("key: Вид")
+  })
+
+  it("prints exact search keys only", async () => {
+    const stdout = captureStdout()
+
+    await printSchema("InputField", { search: "ПутьКДанным", exact: true, keys: true })
+
+    expect(writtenText(stdout)).toBe("ПутьКДанным\n")
+  })
+
+  it("prints JSON schema by schema name when requested", async () => {
+    const stdout = captureStdout()
+
+    await printSchema("InputField", { jsonSchema: true })
+
+    const schema = JSON.parse(writtenText(stdout))
     expect(schema.properties.Вид).toEqual(expect.objectContaining({ const: "ПолеВвода" }))
   })
 
-  it("prints inline JSON schema when requested", async () => {
-    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+  it("prints inline JSON schema for project file when requested", async () => {
+    const stdout = captureStdout()
 
-    await printJSONSchema("Справочник/Товары/Свойства.yaml", { inline: true })
+    await printSchema("Справочник/Товары/Свойства.yaml", { jsonSchema: true, inline: true })
 
-    const text = String(stdout.mock.calls[0]?.[0])
+    const text = writtenText(stdout)
     expect(text).not.toContain("nkdk://schema/MetadataCatalogAttribute")
     expect(JSON.parse(text).properties).toHaveProperty("Реквизиты")
   })
 
+  it("prints external-ref JSON schema for project file", async () => {
+    const stdout = captureStdout()
+
+    await printSchema("Справочник/Товары/Свойства.yaml", { jsonSchema: true })
+
+    const schema = JSON.parse(writtenText(stdout))
+    expect(schema.properties.Реквизиты.additionalProperties).toEqual({ $ref: "nkdk://schema/MetadataCatalogAttribute" })
+  })
+
   it("resolves relative file from explicit project", async () => {
-    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+    const stdout = captureStdout()
 
-    await printJSONSchema("Документ/Заказ/Свойства.yaml", { project: process.cwd() })
+    await printSchema("Документ/Заказ/Свойства.yaml", { jsonSchema: true, project: process.cwd() })
 
-    const text = String(stdout.mock.calls[0]?.[0])
+    const text = writtenText(stdout)
     expect(JSON.parse(text).properties).toHaveProperty("СтандартныеРеквизиты")
   })
 
   it("does not write stdout when schema lookup fails", async () => {
-    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+    const stdout = captureStdout()
 
-    await expect(printJSONSchema("UnknownSchema", {})).rejects.toThrow(/Неизвестная JSON Schema/)
+    await expect(printSchema("UnknownSchema", {})).rejects.toThrow(/Неизвестная JSON Schema/)
+
+    expect(stdout).not.toHaveBeenCalled()
+  })
+
+  it("throws when exact search has no matching field", async () => {
+    const stdout = captureStdout()
+
+    await expect(printSchema("InputField", { search: "НесуществующееПоле", exact: true })).rejects.toThrow(
+      'Поле "НесуществующееПоле" не найдено в JSON Schema',
+    )
+
+    expect(stdout).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [{ inline: true }, "--inline можно использовать только вместе с --json-schema"],
+    [
+      { jsonSchema: true, keys: true },
+      "--json-schema несовместим с --keys, --required, --search и --exact",
+    ],
+    [
+      { jsonSchema: true, required: true },
+      "--json-schema несовместим с --keys, --required, --search и --exact",
+    ],
+    [
+      { jsonSchema: true, search: "Вид" },
+      "--json-schema несовместим с --keys, --required, --search и --exact",
+    ],
+    [
+      { jsonSchema: true, exact: true },
+      "--json-schema несовместим с --keys, --required, --search и --exact",
+    ],
+    [{ required: true, search: "Вид" }, "--required и --search нельзя использовать одновременно"],
+    [{ exact: true }, "--exact можно использовать только вместе с --search"],
+    [{ search: "" }, "--search требует непустой запрос"],
+    [{ search: " | " }, "--search требует непустой запрос"],
+  ])("rejects invalid option combination %#", async (options, message) => {
+    const stdout = captureStdout()
+
+    await expect(printSchema("InputField", options)).rejects.toThrow(message)
 
     expect(stdout).not.toHaveBeenCalled()
   })

--- a/packages/cli/src/commands/schema.test.ts
+++ b/packages/cli/src/commands/schema.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { printSchema } from "./schema"
+import { normalizeSchemaCommandInput, printJSONSchema, printSchema } from "./schema"
 
 describe("schema command", () => {
   afterEach(() => {
@@ -112,6 +112,16 @@ describe("schema command", () => {
     expect(JSON.parse(text).properties).toHaveProperty("Реквизиты")
   })
 
+  it("keeps printJSONSchema compatibility wrapper behavior", async () => {
+    const stdout = captureStdout()
+
+    await printJSONSchema("Справочник/Товары/Свойства.yaml", { inline: true })
+
+    const text = writtenText(stdout)
+    expect(text).not.toContain("nkdk://schema/MetadataCatalogAttribute")
+    expect(JSON.parse(text).properties).toHaveProperty("Реквизиты")
+  })
+
   it("prints external-ref JSON schema for project file", async () => {
     const stdout = captureStdout()
 
@@ -146,6 +156,20 @@ describe("schema command", () => {
     )
 
     expect(stdout).not.toHaveBeenCalled()
+  })
+
+  it("normalizes bare keys option before target", () => {
+    expect(normalizeSchemaCommandInput(undefined, { keys: "InputField" })).toEqual({
+      target: "InputField",
+      options: { keys: true },
+    })
+  })
+
+  it("keeps keys terms when target is present", () => {
+    expect(normalizeSchemaCommandInput("InputField", { keys: "путь|вид" })).toEqual({
+      target: "InputField",
+      options: { keys: "путь|вид" },
+    })
   })
 
   it.each([

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,11 +1,26 @@
-import { exportJSONSchemaForProjectFile, exportJSONSchemaForSchemaName } from "@nakidka/core"
+import {
+  exportJSONSchemaForProjectFile,
+  exportJSONSchemaForSchemaName,
+  listSchemaSummaryKeys,
+  splitSearchTerms,
+  summarizeJSONSchema,
+  type SchemaSummaryOptions,
+} from "@nakidka/core"
+import { stringify } from "yaml"
 
 export interface SchemaCommandOptions {
   project?: string
   inline?: boolean
+  jsonSchema?: boolean
+  keys?: boolean | string
+  required?: boolean
+  search?: string
+  exact?: boolean
 }
 
-export const printJSONSchema = async (target: string, options: SchemaCommandOptions): Promise<void> => {
+export const printSchema = async (target: string, options: SchemaCommandOptions = {}): Promise<void> => {
+  validateSchemaCommandOptions(options)
+
   const context = {
     defaultLanguage: "ru",
     version: "2.20",
@@ -25,5 +40,65 @@ export const printJSONSchema = async (target: string, options: SchemaCommandOpti
         mode,
       })
 
-  process.stdout.write(`${JSON.stringify(schema, null, 2)}\n`)
+  if (options.jsonSchema === true) {
+    process.stdout.write(`${JSON.stringify(schema, null, 2)}\n`)
+    return
+  }
+
+  const summaryOptions: SchemaSummaryOptions = {
+    requiredOnly: options.required === true,
+    search: options.search,
+    exact: options.exact === true,
+    keyTerms: typeof options.keys === "string" ? options.keys : undefined,
+  }
+
+  if (options.keys !== undefined) {
+    const keys = listSchemaSummaryKeys(schema, summaryOptions)
+    if (keys.length > 0) {
+      process.stdout.write(`${keys.join("\n")}\n`)
+    }
+    if (options.exact === true && keys.length === 0) {
+      throw new Error(`Поле "${options.search}" не найдено в JSON Schema`)
+    }
+    return
+  }
+
+  const summary = summarizeJSONSchema(schema, summaryOptions)
+  if (summary === undefined) {
+    if (options.exact === true) {
+      throw new Error(`Поле "${options.search}" не найдено в JSON Schema`)
+    }
+    return
+  }
+
+  process.stdout.write(stringify(summary))
+}
+
+export const printJSONSchema = async (target: string, options: SchemaCommandOptions = {}): Promise<void> => {
+  await printSchema(target, { ...options, jsonSchema: true })
+}
+
+function validateSchemaCommandOptions(options: SchemaCommandOptions): void {
+  if (options.inline === true && options.jsonSchema !== true) {
+    throw new Error("--inline можно использовать только вместе с --json-schema")
+  }
+
+  if (
+    options.jsonSchema === true &&
+    (options.keys !== undefined || options.required === true || options.search !== undefined || options.exact === true)
+  ) {
+    throw new Error("--json-schema несовместим с --keys, --required, --search и --exact")
+  }
+
+  if (options.required === true && options.search !== undefined) {
+    throw new Error("--required и --search нельзя использовать одновременно")
+  }
+
+  if (options.exact === true && options.search === undefined) {
+    throw new Error("--exact можно использовать только вместе с --search")
+  }
+
+  if (options.search !== undefined && splitSearchTerms(options.search).length === 0) {
+    throw new Error("--search требует непустой запрос")
+  }
 }

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -18,6 +18,29 @@ export interface SchemaCommandOptions {
   exact?: boolean
 }
 
+export interface NormalizedSchemaCommandInput {
+  target: string
+  options: SchemaCommandOptions
+}
+
+export function normalizeSchemaCommandInput(
+  target: string | undefined,
+  options: SchemaCommandOptions,
+): NormalizedSchemaCommandInput {
+  if (target !== undefined) {
+    return { target, options }
+  }
+
+  if (typeof options.keys === "string") {
+    return {
+      target: options.keys,
+      options: { ...options, keys: true },
+    }
+  }
+
+  throw new Error("Не указан target для schema")
+}
+
 export const printSchema = async (target: string, options: SchemaCommandOptions = {}): Promise<void> => {
   validateSchemaCommandOptions(options)
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -80,5 +80,13 @@ export {
   type ExportJSONSchemaForProjectFileParams,
   type ExportJSONSchemaForSchemaNameParams,
 } from "./metadata/validation/projectFileSchema"
+export {
+  listSchemaSummaryKeys,
+  summarizeJSONSchema,
+  splitSearchTerms,
+  type SchemaFieldSummary,
+  type SchemaSummary,
+  type SchemaSummaryOptions,
+} from "./metadata/validation/schemaSummary"
 export { exportMetadataDocumentToJSONSchema } from "./metadata/appliedObjects/metadataDocument/toJSONSchema"
 export { exportMetadataEnumerationToJSONSchema } from "./metadata/appliedObjects/metadataEnumeration/toJSONSchema"

--- a/packages/core/metadata/validation/schemaSummary.test.ts
+++ b/packages/core/metadata/validation/schemaSummary.test.ts
@@ -147,4 +147,37 @@ describe("schema summary", () => {
       ],
     })
   })
+
+  it("keeps summary required flag when a field schema has its own required properties", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        Настройки: {
+          type: "object",
+          required: ["Имя"],
+          properties: {
+            Имя: {
+              type: "string",
+            },
+          },
+        },
+      },
+    }
+
+    expect(summarizeJSONSchema(schema)).toEqual({
+      fields: [
+        {
+          key: "Настройки",
+          required: false,
+          type: ["object"],
+          properties: {
+            Имя: {
+              type: ["string"],
+            },
+          },
+        },
+      ],
+    })
+    expect(summarizeJSONSchema(schema, { requiredOnly: true })).toBeUndefined()
+  })
 })

--- a/packages/core/metadata/validation/schemaSummary.test.ts
+++ b/packages/core/metadata/validation/schemaSummary.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest"
+
+import { listSchemaSummaryKeys, summarizeJSONSchema } from "./schemaSummary"
+
+const exampleSchema = {
+  type: "object",
+  required: ["Вид"],
+  properties: {
+    Вид: {
+      const: "ПолеВвода",
+      description: "Вид элемента формы.",
+      examples: [],
+    },
+    ПутьКДанным: {
+      type: "string",
+      description: "Путь к реквизиту формы.",
+      pattern: "^[А-Яа-яA-Za-z0-9_.]+$",
+    },
+    Видимость: {
+      type: "boolean",
+      description: null,
+      examples: [],
+    },
+  },
+} satisfies Record<string, unknown>
+
+describe("schema summary", () => {
+  it("normalizes object properties into fields and removes empty values", () => {
+    expect(summarizeJSONSchema(exampleSchema)).toEqual({
+      fields: [
+        {
+          key: "Вид",
+          required: true,
+          const: "ПолеВвода",
+          description: "Вид элемента формы.",
+        },
+        {
+          key: "ПутьКДанным",
+          required: false,
+          type: ["string"],
+          description: "Путь к реквизиту формы.",
+          pattern: "^[А-Яа-яA-Za-z0-9_.]+$",
+        },
+        {
+          key: "Видимость",
+          required: false,
+          type: ["boolean"],
+        },
+      ],
+    })
+  })
+
+  it("returns plain keys", () => {
+    expect(listSchemaSummaryKeys(exampleSchema)).toEqual(["Вид", "ПутьКДанным", "Видимость"])
+  })
+
+  it("filters keys by terms split with pipe", () => {
+    expect(listSchemaSummaryKeys(exampleSchema, { keyTerms: "путь|видим" })).toEqual(["ПутьКДанным", "Видимость"])
+  })
+
+  it("returns only required fields", () => {
+    expect(summarizeJSONSchema(exampleSchema, { requiredOnly: true })).toEqual({
+      fields: [
+        {
+          key: "Вид",
+          required: true,
+          const: "ПолеВвода",
+          description: "Вид элемента формы.",
+        },
+      ],
+    })
+  })
+
+  it("searches fields by key and textual schema values", () => {
+    expect(summarizeJSONSchema(exampleSchema, { search: "путь|boolean" })).toEqual({
+      fields: [
+        {
+          key: "ПутьКДанным",
+          required: false,
+          type: ["string"],
+          description: "Путь к реквизиту формы.",
+          pattern: "^[А-Яа-яA-Za-z0-9_.]+$",
+        },
+        {
+          key: "Видимость",
+          required: false,
+          type: ["boolean"],
+        },
+      ],
+    })
+  })
+
+  it("searches exact top-level field names", () => {
+    expect(summarizeJSONSchema(exampleSchema, { search: "ПутьКДанным", exact: true })).toEqual({
+      fields: [
+        {
+          key: "ПутьКДанным",
+          required: false,
+          type: ["string"],
+          description: "Путь к реквизиту формы.",
+          pattern: "^[А-Яа-яA-Za-z0-9_.]+$",
+        },
+      ],
+    })
+  })
+
+  it("returns empty values when nothing matches", () => {
+    expect(summarizeJSONSchema(exampleSchema, { search: "НесуществующееПоле" })).toBeUndefined()
+    expect(listSchemaSummaryKeys(exampleSchema, { search: "НесуществующееПоле" })).toEqual([])
+  })
+
+  it("collects object properties from anyOf branches", () => {
+    const branchedSchema = {
+      anyOf: [
+        {
+          type: "object",
+          required: ["Вид"],
+          properties: {
+            Вид: { const: "ОбычнаяГруппа" },
+          },
+        },
+        {
+          type: "object",
+          properties: {
+            Элементы: {
+              type: "array",
+              items: { $ref: "#/$defs/FormElement" },
+            },
+          },
+        },
+      ],
+    }
+
+    expect(summarizeJSONSchema(branchedSchema)).toEqual({
+      fields: [
+        {
+          key: "Вид",
+          required: true,
+          const: "ОбычнаяГруппа",
+        },
+        {
+          key: "Элементы",
+          required: false,
+          type: ["array"],
+          items: { $ref: "#/$defs/FormElement" },
+        },
+      ],
+    })
+  })
+})

--- a/packages/core/metadata/validation/schemaSummary.test.ts
+++ b/packages/core/metadata/validation/schemaSummary.test.ts
@@ -148,6 +148,67 @@ describe("schema summary", () => {
     })
   })
 
+  it("collects object properties from oneOf branches", () => {
+    const branchedSchema = {
+      oneOf: [
+        {
+          type: "object",
+          required: ["Вид"],
+          properties: {
+            Вид: { const: "Кнопка" },
+          },
+        },
+      ],
+    }
+
+    expect(summarizeJSONSchema(branchedSchema)).toEqual({
+      fields: [
+        {
+          key: "Вид",
+          required: true,
+          const: "Кнопка",
+        },
+      ],
+    })
+  })
+
+  it("merges duplicate allOf fields and preserves required constraints", () => {
+    const composedSchema = {
+      allOf: [
+        {
+          type: "object",
+          properties: {
+            Имя: {
+              type: "string",
+              description: "Имя объекта.",
+            },
+          },
+        },
+        {
+          type: "object",
+          required: ["Имя"],
+          properties: {
+            Имя: {
+              pattern: "^[А-Яа-яA-Za-z0-9_]+$",
+            },
+          },
+        },
+      ],
+    }
+
+    expect(summarizeJSONSchema(composedSchema, { requiredOnly: true })).toEqual({
+      fields: [
+        {
+          key: "Имя",
+          required: true,
+          type: ["string"],
+          description: "Имя объекта.",
+          pattern: "^[А-Яа-яA-Za-z0-9_]+$",
+        },
+      ],
+    })
+  })
+
   it("keeps summary required flag when a field schema has its own required properties", () => {
     const schema = {
       type: "object",

--- a/packages/core/metadata/validation/schemaSummary.test.ts
+++ b/packages/core/metadata/validation/schemaSummary.test.ts
@@ -209,6 +209,76 @@ describe("schema summary", () => {
     })
   })
 
+  it("preserves conflicting allOf field constraints", () => {
+    const composedSchema = {
+      allOf: [
+        {
+          type: "object",
+          properties: {
+            Код: {
+              type: "string",
+              pattern: "^A",
+            },
+          },
+        },
+        {
+          type: "object",
+          properties: {
+            Код: {
+              pattern: "B$",
+            },
+          },
+        },
+      ],
+    }
+
+    expect(summarizeJSONSchema(composedSchema)).toEqual({
+      fields: [
+        {
+          key: "Код",
+          required: false,
+          type: ["string"],
+          allOf: [{ pattern: "^A" }, { pattern: "B$" }],
+        },
+      ],
+    })
+  })
+
+  it("preserves conflicting allOf array constraints", () => {
+    const composedSchema = {
+      allOf: [
+        {
+          type: "object",
+          properties: {
+            Настройки: {
+              type: "object",
+              required: ["А"],
+            },
+          },
+        },
+        {
+          type: "object",
+          properties: {
+            Настройки: {
+              required: ["Б"],
+            },
+          },
+        },
+      ],
+    }
+
+    expect(summarizeJSONSchema(composedSchema)).toEqual({
+      fields: [
+        {
+          key: "Настройки",
+          required: false,
+          type: ["object"],
+          allOf: [{ required: ["А"] }, { required: ["Б"] }],
+        },
+      ],
+    })
+  })
+
   it("keeps summary required flag when a field schema has its own required properties", () => {
     const schema = {
       type: "object",

--- a/packages/core/metadata/validation/schemaSummary.ts
+++ b/packages/core/metadata/validation/schemaSummary.ts
@@ -48,21 +48,21 @@ export function splitSearchTerms(terms: string | undefined): string[] {
 
 function collectFieldCandidates(schema: unknown): FieldCandidate[] {
   const fields: FieldCandidate[] = []
-  const collectedKeys = new Set<string>()
+  const fieldIndex = new Map<string, number>()
 
-  collectFieldsFromSchema(schema, fields, collectedKeys)
+  collectFieldsFromSchema(schema, fields, fieldIndex)
 
   return fields
 }
 
-function collectFieldsFromSchema(schema: unknown, fields: FieldCandidate[], collectedKeys: Set<string>): void {
+function collectFieldsFromSchema(schema: unknown, fields: FieldCandidate[], fieldIndex: Map<string, number>): void {
   if (!isRecord(schema)) {
     return
   }
 
-  collectObjectProperties(schema, fields, collectedKeys)
+  collectObjectProperties(schema, fields, fieldIndex, "first")
 
-  for (const branchKey of ["anyOf", "oneOf", "allOf"]) {
+  for (const branchKey of ["anyOf", "oneOf"]) {
     const branches = schema[branchKey]
 
     if (!Array.isArray(branches)) {
@@ -70,15 +70,60 @@ function collectFieldsFromSchema(schema: unknown, fields: FieldCandidate[], coll
     }
 
     for (const branch of branches) {
-      collectFieldsFromSchema(branch, fields, collectedKeys)
+      collectFieldsFromSchema(branch, fields, fieldIndex)
     }
+  }
+
+  const allOfBranches = schema.allOf
+
+  if (!Array.isArray(allOfBranches)) {
+    return
+  }
+
+  for (const branch of allOfBranches) {
+    collectFieldsFromAllOfBranch(branch, fields, fieldIndex)
+  }
+}
+
+function collectFieldsFromAllOfBranch(
+  schema: unknown,
+  fields: FieldCandidate[],
+  fieldIndex: Map<string, number>
+): void {
+  if (!isRecord(schema)) {
+    return
+  }
+
+  collectObjectProperties(schema, fields, fieldIndex, "merge")
+
+  for (const branchKey of ["anyOf", "oneOf"]) {
+    const branches = schema[branchKey]
+
+    if (!Array.isArray(branches)) {
+      continue
+    }
+
+    for (const branch of branches) {
+      collectFieldsFromSchema(branch, fields, fieldIndex)
+    }
+  }
+
+  const allOfBranches = schema.allOf
+
+  if (!Array.isArray(allOfBranches)) {
+    return
+  }
+
+  for (const branch of allOfBranches) {
+    collectFieldsFromAllOfBranch(branch, fields, fieldIndex)
   }
 }
 
 function collectObjectProperties(
   schema: Record<string, unknown>,
   fields: FieldCandidate[],
-  collectedKeys: Set<string>
+  fieldIndex: Map<string, number>,
+  duplicateMode: "first" | "merge"
 ): void {
   const properties = schema.properties
 
@@ -89,17 +134,63 @@ function collectObjectProperties(
   const requiredKeys = readRequiredKeys(schema.required)
 
   for (const [key, value] of Object.entries(properties)) {
-    if (collectedKeys.has(key) || !isRecord(value)) {
+    if (!isRecord(value)) {
       continue
     }
 
-    collectedKeys.add(key)
+    const existingIndex = fieldIndex.get(key)
+
+    if (existingIndex !== undefined) {
+      if (duplicateMode === "merge") {
+        const existingField = fields[existingIndex]
+
+        if (existingField !== undefined) {
+          fields[existingIndex] = {
+            ...existingField,
+            required: existingField.required || requiredKeys.has(key),
+            schema: mergeSchemaProperties(existingField.schema, value),
+          }
+        }
+      }
+
+      continue
+    }
+
+    fieldIndex.set(key, fields.length)
     fields.push({
       key,
       required: requiredKeys.has(key),
       schema: value,
     })
   }
+}
+
+function mergeSchemaProperties(base: Record<string, unknown>, next: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base }
+
+  for (const [key, value] of Object.entries(next)) {
+    const mergedValue = mergeSchemaPropertyValue(result[key], value)
+
+    if (mergedValue !== undefined) {
+      result[key] = mergedValue
+    }
+  }
+
+  return result
+}
+
+function mergeSchemaPropertyValue(base: unknown, next: unknown): unknown {
+  const cleanNext = removeEmptyValues(next)
+
+  if (cleanNext === undefined) {
+    return base
+  }
+
+  if (isRecord(base) && isRecord(next)) {
+    return mergeSchemaProperties(base, next)
+  }
+
+  return cleanNext
 }
 
 function readRequiredKeys(required: unknown): Set<string> {

--- a/packages/core/metadata/validation/schemaSummary.ts
+++ b/packages/core/metadata/validation/schemaSummary.ts
@@ -169,28 +169,79 @@ function mergeSchemaProperties(base: Record<string, unknown>, next: Record<strin
   const result: Record<string, unknown> = { ...base }
 
   for (const [key, value] of Object.entries(next)) {
-    const mergedValue = mergeSchemaPropertyValue(result[key], value)
-
-    if (mergedValue !== undefined) {
-      result[key] = mergedValue
-    }
+    mergeSchemaProperty(result, key, value)
   }
 
   return result
 }
 
-function mergeSchemaPropertyValue(base: unknown, next: unknown): unknown {
+function mergeSchemaProperty(result: Record<string, unknown>, key: string, next: unknown): void {
   const cleanNext = removeEmptyValues(next)
 
   if (cleanNext === undefined) {
-    return base
+    return
   }
 
-  if (isRecord(base) && isRecord(next)) {
-    return mergeSchemaProperties(base, next)
+  const existingAllOfSchemas = getAllOfSchemasForKey(result.allOf, key)
+  const base = result[key]
+  const cleanBase = removeEmptyValues(base)
+
+  if (existingAllOfSchemas.length === 0 && isRecord(base) && isRecord(next)) {
+    result[key] = mergeSchemaProperties(base, next)
+    return
   }
 
-  return cleanNext
+  if (existingAllOfSchemas.length === 0 && (cleanBase === undefined || areValuesEqual(cleanBase, cleanNext))) {
+    result[key] = cleanNext
+    return
+  }
+
+  const conflictSchemas =
+    existingAllOfSchemas.length > 0 ? existingAllOfSchemas : cleanBase !== undefined ? [{ [key]: cleanBase }] : []
+  const nextSchema = { [key]: cleanNext }
+  const allOf = [...removeAllOfSchemasForKey(result.allOf, key), ...conflictSchemas]
+
+  if (!conflictSchemas.some((schema) => areValuesEqual(schema, nextSchema))) {
+    allOf.push(nextSchema)
+  }
+
+  delete result[key]
+  result.allOf = allOf
+}
+
+function getAllOfSchemasForKey(allOf: unknown, key: string): Record<string, unknown>[] {
+  if (!Array.isArray(allOf)) {
+    return []
+  }
+
+  return allOf.filter((schema): schema is Record<string, unknown> => isRecord(schema) && key in schema)
+}
+
+function removeAllOfSchemasForKey(allOf: unknown, key: string): unknown[] {
+  if (!Array.isArray(allOf)) {
+    return []
+  }
+
+  return allOf.filter((schema) => !isRecord(schema) || !(key in schema))
+}
+
+function areValuesEqual(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((item, index) => areValuesEqual(item, right[index]))
+  }
+
+  if (isRecord(left) && isRecord(right)) {
+    const leftEntries = Object.entries(left)
+    const rightKeys = Object.keys(right)
+
+    return leftEntries.length === rightKeys.length && leftEntries.every(([key, value]) => areValuesEqual(value, right[key]))
+  }
+
+  return false
 }
 
 function readRequiredKeys(required: unknown): Set<string> {

--- a/packages/core/metadata/validation/schemaSummary.ts
+++ b/packages/core/metadata/validation/schemaSummary.ts
@@ -115,9 +115,9 @@ function normalizeFieldSummary(field: FieldCandidate): SchemaFieldSummary {
   const schemaProperties = isRecord(normalizedSchema) ? normalizedSchema : {}
 
   return {
+    ...schemaProperties,
     key: field.key,
     required: field.required,
-    ...schemaProperties,
   }
 }
 

--- a/packages/core/metadata/validation/schemaSummary.ts
+++ b/packages/core/metadata/validation/schemaSummary.ts
@@ -1,0 +1,227 @@
+export interface SchemaSummaryOptions {
+  requiredOnly?: boolean
+  search?: string
+  exact?: boolean
+  keyTerms?: string
+}
+
+export interface SchemaSummary {
+  fields: SchemaFieldSummary[]
+}
+
+export interface SchemaFieldSummary {
+  key: string
+  required: boolean
+  [property: string]: unknown
+}
+
+interface FieldCandidate {
+  key: string
+  required: boolean
+  schema: Record<string, unknown>
+}
+
+export function summarizeJSONSchema(schema: unknown, options: SchemaSummaryOptions = {}): SchemaSummary | undefined {
+  const fields = collectFieldCandidates(schema)
+    .map((field) => normalizeFieldSummary(field))
+    .filter((field) => matchesOptions(field, options))
+
+  if (fields.length === 0) {
+    return undefined
+  }
+
+  return { fields }
+}
+
+export function listSchemaSummaryKeys(schema: unknown, options: SchemaSummaryOptions = {}): string[] {
+  return summarizeJSONSchema(schema, options)?.fields.map((field) => field.key) ?? []
+}
+
+export function splitSearchTerms(terms: string | undefined): string[] {
+  return (
+    terms
+      ?.split("|")
+      .map((term) => term.trim())
+      .filter((term) => term.length > 0) ?? []
+  )
+}
+
+function collectFieldCandidates(schema: unknown): FieldCandidate[] {
+  const fields: FieldCandidate[] = []
+  const collectedKeys = new Set<string>()
+
+  collectFieldsFromSchema(schema, fields, collectedKeys)
+
+  return fields
+}
+
+function collectFieldsFromSchema(schema: unknown, fields: FieldCandidate[], collectedKeys: Set<string>): void {
+  if (!isRecord(schema)) {
+    return
+  }
+
+  collectObjectProperties(schema, fields, collectedKeys)
+
+  for (const branchKey of ["anyOf", "oneOf", "allOf"]) {
+    const branches = schema[branchKey]
+
+    if (!Array.isArray(branches)) {
+      continue
+    }
+
+    for (const branch of branches) {
+      collectFieldsFromSchema(branch, fields, collectedKeys)
+    }
+  }
+}
+
+function collectObjectProperties(
+  schema: Record<string, unknown>,
+  fields: FieldCandidate[],
+  collectedKeys: Set<string>
+): void {
+  const properties = schema.properties
+
+  if (!isRecord(properties)) {
+    return
+  }
+
+  const requiredKeys = readRequiredKeys(schema.required)
+
+  for (const [key, value] of Object.entries(properties)) {
+    if (collectedKeys.has(key) || !isRecord(value)) {
+      continue
+    }
+
+    collectedKeys.add(key)
+    fields.push({
+      key,
+      required: requiredKeys.has(key),
+      schema: value,
+    })
+  }
+}
+
+function readRequiredKeys(required: unknown): Set<string> {
+  if (!Array.isArray(required)) {
+    return new Set()
+  }
+
+  return new Set(required.filter((key): key is string => typeof key === "string"))
+}
+
+function normalizeFieldSummary(field: FieldCandidate): SchemaFieldSummary {
+  const normalizedSchema = removeEmptyValues(normalizeScalarType(field.schema))
+  const schemaProperties = isRecord(normalizedSchema) ? normalizedSchema : {}
+
+  return {
+    key: field.key,
+    required: field.required,
+    ...schemaProperties,
+  }
+}
+
+function normalizeScalarType(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeScalarType(item))
+  }
+
+  if (!isRecord(value)) {
+    return value
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      key,
+      key === "type" && typeof item === "string" ? [item] : normalizeScalarType(item),
+    ])
+  )
+}
+
+function removeEmptyValues(value: unknown): unknown {
+  if (value === null || value === undefined || value === "") {
+    return undefined
+  }
+
+  if (Array.isArray(value)) {
+    const values = value.map((item) => removeEmptyValues(item)).filter((item) => item !== undefined)
+
+    return values.length > 0 ? values : undefined
+  }
+
+  if (isRecord(value)) {
+    const entries = Object.entries(value)
+      .map(([key, item]) => [key, removeEmptyValues(item)] as const)
+      .filter(([, item]) => item !== undefined)
+
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined
+  }
+
+  return value
+}
+
+function matchesOptions(field: SchemaFieldSummary, options: SchemaSummaryOptions): boolean {
+  if (options.requiredOnly && !field.required) {
+    return false
+  }
+
+  if (!matchesKeyTerms(field.key, options.keyTerms)) {
+    return false
+  }
+
+  if (!matchesSearch(field, options)) {
+    return false
+  }
+
+  return true
+}
+
+function matchesKeyTerms(key: string, keyTerms: string | undefined): boolean {
+  const terms = splitSearchTerms(keyTerms)
+
+  return terms.length === 0 || terms.some((term) => includesRussianLower(key, term))
+}
+
+function matchesSearch(field: SchemaFieldSummary, options: SchemaSummaryOptions): boolean {
+  const terms = splitSearchTerms(options.search)
+
+  if (terms.length === 0) {
+    return true
+  }
+
+  if (options.exact) {
+    return field.key.toLocaleLowerCase("ru-RU") === options.search?.trim().toLocaleLowerCase("ru-RU")
+  }
+
+  const text = collectSearchText(field).join("\n")
+
+  return terms.some((term) => includesRussianLower(text, term))
+}
+
+function collectSearchText(value: unknown): string[] {
+  if (value === null || value === undefined) {
+    return []
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return [String(value)]
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectSearchText(item))
+  }
+
+  if (isRecord(value)) {
+    return Object.entries(value).flatMap(([key, item]) => [key, ...collectSearchText(item)])
+  }
+
+  return []
+}
+
+function includesRussianLower(value: string, term: string): boolean {
+  return value.toLocaleLowerCase("ru-RU").includes(term.toLocaleLowerCase("ru-RU"))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}


### PR DESCRIPTION
## Что изменилось
- добавлен core-helper для компактной YAML-сводки JSON Schema
- обновлена команда nkdk schema: YAML по умолчанию, --json-schema, --keys, --required, --search, --exact
- добавлены тесты и план реализации

## Проверка
- pnpm test
- pnpm --filter @nakidka/core exec vitest run metadata/validation/schemaSummary.test.ts --no-isolate
- pnpm --filter @nakidka/cli exec vitest run src/commands/schema.test.ts --no-isolate
- pnpm --filter @nakidka/cli exec tsc --noEmit
- smoke: nkdk schema InputField --keys / --required --keys / --search ПутьКДанным --exact / --json-schema