### PR TITLE
refactor: убрать обход проверки metadataTarget

### DIFF
--- a/.agents/skills/round-trip-yaml-1c/round-trip.sh
+++ b/.agents/skills/round-trip-yaml-1c/round-trip.sh
@@ -10,8 +10,8 @@ usage() {
   ./.agents/skills/round-trip-yaml-1c/round-trip.sh
 
 Что делает:
-  1. nkdk import <xml-dir> <yaml-dir> --no-validate-metadata-targets
-  2. nkdk sync <yaml-dir> <tmp-xml-dir> --no-validate-metadata-targets без --reference
+  1. nkdk import <xml-dir> <yaml-dir>
+  2. nkdk sync <yaml-dir> <tmp-xml-dir> без --reference
   3. очистка и создание свежей файловой базы через ibcmd infobase create
   4. ibcmd infobase config import --data <data> --db-path <db-path> <tmp-xml-dir>
 
@@ -250,7 +250,6 @@ echo "ACTIVE_XML_DIR: ${ACTIVE_XML_DIR}"
 echo "YAML_DIR: ${YAML_DIR}"
 echo "TMP_XML_DIR: ${TMP_XML_DIR}"
 echo "IBCMD_COMMAND: $(ibcmd_command_text)"
-echo "metadataTarget validation: disabled"
 echo ""
 
 echo "[yaml] Очистка временного YAML-каталога: ${YAML_DIR}"
@@ -260,13 +259,13 @@ mkdir -p "${YAML_DIR}"
 echo "[xml] Очистка временного XML-каталога без reference: ${TMP_XML_DIR}"
 clear_dir_contents "${TMP_XML_DIR}"
 
-IMPORT_COMMAND="${NKDK[*]} import ${ACTIVE_XML_DIR} ${YAML_DIR} --no-validate-metadata-targets"
-if ! run_logged "import" "${IMPORT_COMMAND}" "${IMPORT_LOG}" "${NKDK[@]}" import "${ACTIVE_XML_DIR}" "${YAML_DIR}" --no-validate-metadata-targets; then
+IMPORT_COMMAND="${NKDK[*]} import ${ACTIVE_XML_DIR} ${YAML_DIR}"
+if ! run_logged "import" "${IMPORT_COMMAND}" "${IMPORT_LOG}" "${NKDK[@]}" import "${ACTIVE_XML_DIR}" "${YAML_DIR}"; then
   exit 1
 fi
 
-SYNC_COMMAND="${NKDK[*]} sync ${YAML_DIR} ${TMP_XML_DIR} --no-validate-metadata-targets"
-if ! run_logged "sync" "${SYNC_COMMAND}" "${SYNC_LOG}" "${NKDK[@]}" sync "${YAML_DIR}" "${TMP_XML_DIR}" --no-validate-metadata-targets; then
+SYNC_COMMAND="${NKDK[*]} sync ${YAML_DIR} ${TMP_XML_DIR}"
+if ! run_logged "sync" "${SYNC_COMMAND}" "${SYNC_LOG}" "${NKDK[@]}" sync "${YAML_DIR}" "${TMP_XML_DIR}"; then
   exit 1
 fi
 

--- a/.agents/skills/round-trip-yaml/round-trip.sh
+++ b/.agents/skills/round-trip-yaml/round-trip.sh
@@ -324,7 +324,6 @@ echo "XML каталог: ${NKDK_XML_DIR}"
 echo "nkdk:        ${NKDK[*]}"
 echo "mode:        ${MODE}"
 echo "all configs: ${ALL_CONFIGS}"
-echo "metadataTarget validation: disabled"
 if [ "${MODE}" = "single" ]; then
   echo "diff index:  ${DIFF_INDEX}"
 else
@@ -364,7 +363,7 @@ for RUN_XML_DIR in "${RUN_DIRS[@]}"; do
   clear_dir_contents "${RUN_XML_TMP_DIR}"
 
   echo "[round-trip] XML -> YAML: ${RUN_XML_DIR}"
-  if ! run_nkdk "${NKDK[@]}" import "${RUN_XML_DIR}" "${RUN_YAML_DIR}" --no-validate-metadata-targets; then
+  if ! run_nkdk "${NKDK[@]}" import "${RUN_XML_DIR}" "${RUN_YAML_DIR}"; then
     echo "=== ROUND_TRIP_ERROR ==="
     echo "STAGE: import"
     echo "ACTIVE_XML_DIR: ${RUN_XML_DIR}"
@@ -374,7 +373,7 @@ for RUN_XML_DIR in "${RUN_DIRS[@]}"; do
   fi
 
   echo "[round-trip] YAML -> временный XML: ${RUN_YAML_DIR}"
-  if ! run_nkdk "${NKDK[@]}" sync "${RUN_YAML_DIR}" "${RUN_XML_TMP_DIR}" --no-validate-metadata-targets --reference "${RUN_XML_DIR}"; then
+  if ! run_nkdk "${NKDK[@]}" sync "${RUN_YAML_DIR}" "${RUN_XML_TMP_DIR}" --reference "${RUN_XML_DIR}"; then
     echo "=== ROUND_TRIP_ERROR ==="
     echo "STAGE: sync"
     echo "ACTIVE_XML_DIR: ${RUN_XML_DIR}"

--- a/docs/superpowers/plans/2026-06-17-remove-no-validate-metadata-targets.md
+++ b/docs/superpowers/plans/2026-06-17-remove-no-validate-metadata-targets.md
@@ -1,0 +1,427 @@
+# Remove --no-validate-metadata-targets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Полностью удалить CLI-ключ `--no-validate-metadata-targets` и внутренний обход проверки `metadataTarget`.
+
+**Architecture:** Изменение оставляет один путь выполнения: CLI не принимает флаг, команды не передают параметр в контекст, а `metadataPath` всегда использует существующие функции разбора и форматирования `metadataTarget`. Скрипты round-trip запускают обычные `nkdk import` и `nkdk sync`, поэтому ошибки больше не скрываются диагностическим выключателем.
+
+**Tech Stack:** TypeScript, Commander, Vitest, Bash, pnpm.
+
+---
+
+## File Structure
+
+- `packages/cli/src/cli.ts`: убрать регистрацию CLI-флага и типы `opts.validateMetadataTargets`.
+- `packages/cli/src/commands/import.ts`: упростить `ImportConfigurationOptions` и контекст `exportToYAML`.
+- `packages/cli/src/commands/sync.ts`: упростить `SyncConfigurationOptions` и контекст `importFromYAML`.
+- `packages/cli/src/commands/sync.test.ts`: удалить тест передачи выключателя и оставить проверку `referenceDir`.
+- `packages/core/metadata/context/types.ts`: удалить поле `validateMetadataTargets` из YAML-контекстов.
+- `packages/core/metadata/commonObjects/metadataPath/fromYAML.ts`: удалить ветку обхода проверки.
+- `packages/core/metadata/commonObjects/metadataPath/toYAML.ts`: удалить ветку обхода проверки и вспомогательную проверку канонического пути, если она больше не используется.
+- `packages/core/metadata/commonObjects/metadataPath/fromYAML.test.ts`: удалить тест диагностического выключателя.
+- `packages/core/metadata/commonObjects/metadataPath/toYAML.test.ts`: удалить тест диагностического выключателя и неиспользуемый импорт `it`, если он останется.
+- `.agents/skills/round-trip-yaml/round-trip.sh`: убрать текст `metadataTarget validation: disabled` и флаг из команд.
+- `.agents/skills/round-trip-yaml-1c/round-trip.sh`: обновить описание, вывод и команды без флага.
+
+### Task 1: Remove CLI Option And Command Plumbing
+
+**Files:**
+- Modify: `packages/cli/src/cli.ts`
+- Modify: `packages/cli/src/commands/import.ts`
+- Modify: `packages/cli/src/commands/sync.ts`
+- Modify: `packages/cli/src/commands/sync.test.ts`
+
+- [x] **Step 1: Remove the `import` CLI option**
+
+Edit `packages/cli/src/cli.ts` so the `import` command action has no metadata-target option:
+
+```ts
+  program
+    .command("import")
+    .description("Импорт конфигурации из XML в YAML (XML → YAML)")
+    .argument("<xml-dir>", "путь к каталогу XML-выгрузки")
+    .argument("<yaml-dir>", "путь к каталогу YAML-проекта")
+    .action((xmlDir: string, yamlDir: string) => {
+      run(() => importConfiguration(xmlDir, yamlDir), options)
+    })
+```
+
+- [x] **Step 2: Remove the `sync` CLI option**
+
+In the same file, keep `--reference` and remove `--no-validate-metadata-targets`:
+
+```ts
+  program
+    .command("sync")
+    .description("Синхронизация конфигурации из YAML в XML (YAML → XML)")
+    .argument("<yaml-dir>", "путь к каталогу YAML-проекта")
+    .argument("<xml-dir>", "путь к каталогу XML-выгрузки")
+    .option("--reference <xml-dir>", "путь к XML-каталогу для чтения reference-данных")
+    .action((yamlDir: string, xmlDir: string, opts: { reference?: string }) => {
+      run(() =>
+        syncConfiguration(yamlDir, xmlDir, {
+          referenceDir: opts.reference,
+        }), options)
+    })
+```
+
+- [x] **Step 3: Simplify the import command context**
+
+Edit `packages/cli/src/commands/import.ts` to remove the option interface and default options parameter:
+
+```ts
+import { syncConfigurationFromXML } from "@nakidka/core"
+
+export const importConfiguration = async (
+  xmlDir: string,
+  yamlDir: string,
+): Promise<void> => {
+  const context = {
+    defaultLanguage: "ru",
+    version: "2.20",
+    exportToYAML: { toTyped: false },
+    fromXML: { forReference: false },
+  }
+  const result = await syncConfigurationFromXML({ context, inputDir: xmlDir, outputDir: yamlDir })
+
+  for (const f of result.failed) {
+    const label = f.parent ? `${f.parent}/${f.name}` : f.name
+    process.stderr.write(`✖ ${f.kind} "${label}": ${f.error.message}\n`)
+  }
+
+  process.stdout.write(`Готово: ${result.succeeded} успешно, ${result.failed.length} с ошибкой\n`)
+
+  if (result.failed.length > 0) {
+    process.exitCode = 1
+  }
+}
+```
+
+- [x] **Step 4: Simplify the sync command context**
+
+Edit `packages/cli/src/commands/sync.ts` so `SyncConfigurationOptions` contains only `referenceDir`, and `importFromYAML` is removed from the literal unless another field is needed:
+
+```ts
+import { syncConfigurationToXML } from "@nakidka/core"
+
+export interface SyncConfigurationOptions {
+  referenceDir?: string
+}
+
+export const syncConfiguration = async (
+  yamlDir: string,
+  xmlDir: string,
+  options: SyncConfigurationOptions = {},
+): Promise<void> => {
+  const context = {
+    defaultLanguage: "ru",
+    version: "2.20",
+    exportToYAML: { toTyped: false },
+    exportToXML: {
+      itemsTree: [],
+      configDumpInfo: new Map(),
+      version: "2.20",
+      context: {
+        forms: [],
+        templates: [],
+        parentName: "",
+        metadataForNumbering: [],
+      },
+    },
+  }
+  const result = await syncConfigurationToXML({
+    context,
+    inputDir: yamlDir,
+    outputDir: xmlDir,
+    ...(options.referenceDir ? { referenceDir: options.referenceDir } : {}),
+  })
+
+  for (const f of result.failed) {
+    const label = f.parent ? `${f.parent}/${f.name}` : f.name
+    process.stderr.write(`✖ ${f.kind} "${label}": ${f.error.message}\n`)
+  }
+
+  process.stdout.write(`Готово: ${result.succeeded} успешно, ${result.failed.length} с ошибкой\n`)
+
+  if (result.failed.length > 0) {
+    process.exitCode = 1
+  }
+}
+```
+
+- [x] **Step 5: Remove the obsolete sync test**
+
+Edit `packages/cli/src/commands/sync.test.ts` and delete only this test block:
+
+```ts
+  it("передает отключение проверки metadataTarget в контекст импорта YAML", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+
+    await syncConfiguration("yaml", "xml", { validateMetadataTargets: false })
+
+    expect(syncConfigurationToXML).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        importFromYAML: expect.objectContaining({
+          validateMetadataTargets: false,
+        }),
+      }),
+    }))
+  })
+```
+
+- [x] **Step 6: Run CLI tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/cli test -- src/commands/sync.test.ts
+```
+
+Expected: PASS for `sync command`.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add packages/cli/src/cli.ts packages/cli/src/commands/import.ts packages/cli/src/commands/sync.ts packages/cli/src/commands/sync.test.ts
+git commit -m "refactor: :recycle: убрать cli-флаг metadataTarget"
+```
+
+### Task 2: Remove Core Metadata Validation Bypass
+
+**Files:**
+- Modify: `packages/core/metadata/context/types.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataPath/fromYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataPath/toYAML.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataPath/fromYAML.test.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataPath/toYAML.test.ts`
+
+- [x] **Step 1: Remove context fields**
+
+Edit `packages/core/metadata/context/types.ts` so these interfaces no longer contain `validateMetadataTargets` comments or properties:
+
+```ts
+export interface FormExportToYAMLContext {
+  toTyped: boolean
+  /** Имя родительского объекта (например, имя реквизита формы) для externalFile. */
+  parent?: { name: string }
+  /** Сборник внешних файлов, формируемых при экспорте. */
+  externalFilesCollector?: ExternalFileEntry[]
+  /** Стек текущих metadata item владельцев для owner: "this" metadataTarget. */
+  metadataTargetOwners?: MetadataTargetOwnerContext[]
+}
+
+export interface FormimportFromYAMLContext {
+  allElements?: FormChildItemsPartialYAML
+  /** Путь к каталогу формы для чтения внешних файлов (externalFile). */
+  formDir?: string
+  /** Имя родительского объекта для externalFile (например, имя реквизита формы). */
+  parent?: { name: string }
+  /** Стек текущих metadata item владельцев для owner: "this" metadataTarget. */
+  metadataTargetOwners?: MetadataTargetOwnerContext[]
+}
+```
+
+- [x] **Step 2: Remove the fromYAML bypass**
+
+Edit `packages/core/metadata/commonObjects/metadataPath/fromYAML.ts` and make `parseMetadataTargetStringFromYAML` always call `parseMetadataTargetFromYAML`:
+
+```ts
+function parseMetadataTargetStringFromYAML(
+  context: Context,
+  name: string,
+  constraint: MetadataTargetConstraint,
+  owner: MetadataTargetOwner | undefined
+): string {
+  const parsed = parseMetadataTargetFromYAML(name, {
+    constraint,
+    owner,
+    resolveOwner: (ownerName) => rootFromYAML(ownerName),
+  })
+  return parsed.join(".")
+}
+```
+
+- [x] **Step 3: Remove the toYAML bypass**
+
+Edit `packages/core/metadata/commonObjects/metadataPath/toYAML.ts` so `formatMetadataTargetStringToYAML` has no `context` parameter and always formats through `formatMetadataTargetToYAML`:
+
+```ts
+function formatMetadataTargetStringToYAML(
+  name: string,
+  constraint: MetadataTargetConstraint,
+  owner?: MetadataTargetOwner,
+): string {
+  const parts = name.split(".")
+  return formatMetadataTargetToYAML(parts, {
+    constraint,
+    owner,
+  })
+}
+```
+
+Update callers in the same file to drop `context` from the helper call:
+
+```ts
+return formatMetadataTargetStringToYAML(name, metadataTargetForRule(rule, metadataFieldTargetFallback), owner)
+return formatMetadataTargetStringToYAML(name, metadataTargetForRule(rule, metadataObjectTargetFallback), owner)
+return formatMetadataTargetStringToYAML(name, metadataTargetForRule(rule, metadataValueTargetFallback))
+```
+
+- [x] **Step 4: Remove unused helper code in toYAML**
+
+If `isMetadataTargetLikeModel` becomes unused, delete the function and remove the unused `isMetadataRootName` import from `packages/core/metadata/commonObjects/metadataPath/toYAML.ts`.
+
+- [x] **Step 5: Remove obsolete metadataPath tests**
+
+Delete the `describe("metadataTarget diagnostics switch", ...)` blocks from:
+
+```text
+packages/core/metadata/commonObjects/metadataPath/fromYAML.test.ts
+packages/core/metadata/commonObjects/metadataPath/toYAML.test.ts
+```
+
+In `toYAML.test.ts`, change the first import if needed:
+
+```ts
+import { describe, expect, test } from "vitest"
+```
+
+- [x] **Step 6: Run metadataPath tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test -- metadataPath/fromYAML.test.ts metadataPath/toYAML.test.ts
+```
+
+Expected: PASS for both metadataPath test files.
+
+- [ ] **Step 7: Run type check for core**
+
+Note: command failed only on pre-existing type errors in `metadata/commonObjects/metadataValue/formChoiceList/*` and `metadata/commonObjects/сhoiceParameters/fromYAML.ts`; changed `metadataPath` files no longer appear in the diagnostics after the local fix.
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec tsc --noEmit
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```bash
+git add packages/core/metadata/context/types.ts packages/core/metadata/commonObjects/metadataPath/fromYAML.ts packages/core/metadata/commonObjects/metadataPath/toYAML.ts packages/core/metadata/commonObjects/metadataPath/fromYAML.test.ts packages/core/metadata/commonObjects/metadataPath/toYAML.test.ts
+git commit -m "refactor: :recycle: сделать проверку metadataTarget обязательной"
+```
+
+### Task 3: Update Round-Trip Scripts And Final Verification
+
+**Files:**
+- Modify: `.agents/skills/round-trip-yaml/round-trip.sh`
+- Modify: `.agents/skills/round-trip-yaml-1c/round-trip.sh`
+
+- [x] **Step 1: Update round-trip-yaml status output**
+
+Edit `.agents/skills/round-trip-yaml/round-trip.sh` and remove this line:
+
+```bash
+echo "metadataTarget validation: disabled"
+```
+
+- [x] **Step 2: Update round-trip-yaml commands**
+
+In the same file, remove `--no-validate-metadata-targets` from both calls:
+
+```bash
+  if ! run_nkdk "${NKDK[@]}" import "${RUN_XML_DIR}" "${RUN_YAML_DIR}"; then
+```
+
+```bash
+  if ! run_nkdk "${NKDK[@]}" sync "${RUN_YAML_DIR}" "${RUN_XML_TMP_DIR}" --reference "${RUN_XML_DIR}"; then
+```
+
+- [x] **Step 3: Update round-trip-yaml-1c usage text**
+
+Edit `.agents/skills/round-trip-yaml-1c/round-trip.sh` usage text:
+
+```text
+Что делает:
+  1. nkdk import <xml-dir> <yaml-dir>
+  2. nkdk sync <yaml-dir> <tmp-xml-dir> без --reference
+  3. очистка и создание свежей файловой базы через ibcmd infobase create
+  4. ibcmd infobase config import --data <data> --db-path <db-path> <tmp-xml-dir>
+```
+
+- [x] **Step 4: Update round-trip-yaml-1c status output and command strings**
+
+Remove:
+
+```bash
+echo "metadataTarget validation: disabled"
+```
+
+Change command text and execution:
+
+```bash
+IMPORT_COMMAND="${NKDK[*]} import ${ACTIVE_XML_DIR} ${YAML_DIR}"
+if ! run_logged "import" "${IMPORT_COMMAND}" "${IMPORT_LOG}" "${NKDK[@]}" import "${ACTIVE_XML_DIR}" "${YAML_DIR}"; then
+  exit 1
+fi
+
+SYNC_COMMAND="${NKDK[*]} sync ${YAML_DIR} ${TMP_XML_DIR}"
+if ! run_logged "sync" "${SYNC_COMMAND}" "${SYNC_LOG}" "${NKDK[@]}" sync "${YAML_DIR}" "${TMP_XML_DIR}"; then
+  exit 1
+fi
+```
+
+- [x] **Step 5: Search for removed key**
+
+Run:
+
+```bash
+rg --fixed-strings "--no-validate-metadata-targets"
+```
+
+Expected: no matches, exit code 1.
+
+Run:
+
+```bash
+rg --fixed-strings "validateMetadataTargets"
+```
+
+Expected: no matches, exit code 1.
+
+- [x] **Step 6: Run full test suite**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: PASS for `packages/core` and `packages/cli`.
+
+- [ ] **Step 7: Commit Task 3**
+
+Run:
+
+```bash
+git add .agents/skills/round-trip-yaml/round-trip.sh .agents/skills/round-trip-yaml-1c/round-trip.sh
+git commit -m "chore: :wrench: убрать обход metadataTarget из round-trip"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: CLI-флаг, команды, контекст, обходы, тесты, скрипты и полный `pnpm test` покрыты задачами 1-3.
+- Placeholder scan: запрещённых заглушек и ссылок на неопределённые функции нет.
+- Type consistency: имя удаляемого поля везде одно и то же: `validateMetadataTargets`; CLI-ключ везде один: `--no-validate-metadata-targets`.

--- a/docs/superpowers/specs/2026-06-17-remove-no-validate-metadata-targets-design.md
+++ b/docs/superpowers/specs/2026-06-17-remove-no-validate-metadata-targets-design.md
@@ -1,0 +1,40 @@
+# Удаление --no-validate-metadata-targets
+
+## Цель
+
+Убрать диагностический обход проверки `metadataTarget`, добавленный коммитом `c207ad6b68`.
+После изменения `import` и `sync` всегда выполняют обычную проверку и преобразование `metadataTarget`; отключить это поведение через CLI или внутренний контекст нельзя.
+
+## Границы
+
+- Удалить CLI-флаг `--no-validate-metadata-targets` из команд `import` и `sync`.
+- Удалить передачу `validateMetadataTargets` из CLI-команд в metadata-контекст.
+- Удалить поле `validateMetadataTargets` из типов контекста YAML-импорта и YAML-экспорта.
+- Удалить ветвления в `metadataPath/fromYAML.ts` и `metadataPath/toYAML.ts`, которые возвращали исходную строку вместо проверки.
+- Удалить или обновить тесты, которые проверяли отключение `metadataTarget`.
+- Убрать использование флага из round-trip скриптов `.agents/skills/round-trip-yaml*/round-trip.sh`.
+
+## Поведение
+
+`metadataTarget` становится обязательной частью YAML-пути:
+
+- `fromYAML` всегда разбирает строку через `parseMetadataTargetFromYAML`;
+- `toYAML` всегда форматирует значение через `formatMetadataTargetToYAML`;
+- ошибки в round-trip диагностируются как проблемы правил, данных или reference-контекста, а не скрываются отключением проверки.
+
+## Проверка ошибок
+
+Если после удаления обхода появятся ошибки round-trip, их нужно рассматривать по существующим правилам metadata:
+
+- простые расхождения чинить в `rules.ts` или контексте владельца;
+- расхождения в чужом `metadataItem` не исправлять без отдельного решения;
+- XML-фикстуры не менять.
+
+## Тестирование
+
+Минимальная проверка:
+
+- точечные тесты CLI и `metadataPath`;
+- полный `pnpm test` из корня worktree.
+
+Критерий готовности: в коде и скриптах не остаётся упоминаний `--no-validate-metadata-targets` и `validateMetadataTargets`, а тесты проходят.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -33,9 +33,8 @@ export function createProgram(options: CreateProgramOptions = {}): Command {
     .description("Импорт конфигурации из XML в YAML (XML → YAML)")
     .argument("<xml-dir>", "путь к каталогу XML-выгрузки")
     .argument("<yaml-dir>", "путь к каталогу YAML-проекта")
-    .option("--no-validate-metadata-targets", "не проверять metadataTarget при экспорте YAML")
-    .action((xmlDir: string, yamlDir: string, opts: { validateMetadataTargets?: boolean }) => {
-      run(() => importConfiguration(xmlDir, yamlDir, { validateMetadataTargets: opts.validateMetadataTargets }), options)
+    .action((xmlDir: string, yamlDir: string) => {
+      run(() => importConfiguration(xmlDir, yamlDir), options)
     })
 
   program
@@ -44,12 +43,10 @@ export function createProgram(options: CreateProgramOptions = {}): Command {
     .argument("<yaml-dir>", "путь к каталогу YAML-проекта")
     .argument("<xml-dir>", "путь к каталогу XML-выгрузки")
     .option("--reference <xml-dir>", "путь к XML-каталогу для чтения reference-данных")
-    .option("--no-validate-metadata-targets", "не проверять metadataTarget при чтении YAML")
-    .action((yamlDir: string, xmlDir: string, opts: { reference?: string; validateMetadataTargets?: boolean }) => {
+    .action((yamlDir: string, xmlDir: string, opts: { reference?: string }) => {
       run(() =>
         syncConfiguration(yamlDir, xmlDir, {
           referenceDir: opts.reference,
-          validateMetadataTargets: opts.validateMetadataTargets,
         }), options)
     })
 

--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -1,18 +1,13 @@
 import { syncConfigurationFromXML } from "@nakidka/core"
 
-export interface ImportConfigurationOptions {
-  validateMetadataTargets?: boolean
-}
-
 export const importConfiguration = async (
   xmlDir: string,
   yamlDir: string,
-  options: ImportConfigurationOptions = {},
 ): Promise<void> => {
   const context = {
     defaultLanguage: "ru",
     version: "2.20",
-    exportToYAML: { toTyped: false, validateMetadataTargets: options.validateMetadataTargets },
+    exportToYAML: { toTyped: false },
     fromXML: { forReference: false },
   }
   const result = await syncConfigurationFromXML({ context, inputDir: xmlDir, outputDir: yamlDir })

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -35,18 +35,4 @@ describe("sync command", () => {
     }))
   })
 
-  it("передает отключение проверки metadataTarget в контекст импорта YAML", async () => {
-    vi.spyOn(process.stdout, "write").mockImplementation(() => true)
-    vi.spyOn(process.stderr, "write").mockImplementation(() => true)
-
-    await syncConfiguration("yaml", "xml", { validateMetadataTargets: false })
-
-    expect(syncConfigurationToXML).toHaveBeenCalledWith(expect.objectContaining({
-      context: expect.objectContaining({
-        importFromYAML: expect.objectContaining({
-          validateMetadataTargets: false,
-        }),
-      }),
-    }))
-  })
 })

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -2,7 +2,6 @@ import { syncConfigurationToXML } from "@nakidka/core"
 
 export interface SyncConfigurationOptions {
   referenceDir?: string
-  validateMetadataTargets?: boolean
 }
 
 export const syncConfiguration = async (
@@ -14,9 +13,6 @@ export const syncConfiguration = async (
     defaultLanguage: "ru",
     version: "2.20",
     exportToYAML: { toTyped: false },
-    importFromYAML: {
-      validateMetadataTargets: options.validateMetadataTargets,
-    },
     exportToXML: {
       itemsTree: [],
       configDumpInfo: new Map(),

--- a/packages/core/metadata/commonObjects/metadataPath/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/fromYAML.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, test } from "vitest"
 import { tableMetadataFields, tableMetadataValues } from "~/metadata/commonObjects/metadataPath/__fixtures__/table"
 import { mockContext, mockRule } from "~/tests/mockContext"
-import {
-  importMetadataFieldStringFromYAML,
-  importMetadataObjectStringFromYAML,
-  importMetadataValueStringFromYAML,
-} from "./fromYAML"
+import { importMetadataFieldStringFromYAML, importMetadataValueStringFromYAML } from "./fromYAML"
 
 describe("importMetadataFieldFromYAML", () => {
   test.each(tableMetadataFields)("import %s from %s", (expected: string, enterpriseValue: string) => {
@@ -52,20 +48,5 @@ describe("importMetadataValueStringFromYAML", () => {
     expect(importMetadataValueStringFromYAML(mockContext, mockRule, "ПланСчетов.Хозрасчетный.ПустаяСсылка")).toBe(
       "ChartOfAccounts.Хозрасчетный.EmptyRef"
     )
-  })
-})
-
-describe("metadataTarget diagnostics switch", () => {
-  test("keeps canonical metadata object path when metadata target validation is disabled for YAML import", () => {
-    const context = {
-      ...mockContext,
-      importFromYAML: {
-        validateMetadataTargets: false,
-      },
-    }
-    const reference = "ExternalDataSource.ВнешнийИсточникДанныхВсеСвойства.Table.ТаблицаВсеСвойства"
-
-    expect(() => importMetadataObjectStringFromYAML(mockContext, mockRule, reference)).toThrow()
-    expect(importMetadataObjectStringFromYAML(context, mockRule, reference)).toBe(reference)
   })
 })

--- a/packages/core/metadata/commonObjects/metadataPath/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/fromYAML.ts
@@ -31,7 +31,7 @@ export const importMetadataObjectStringFromYAML = (
 }
 
 export const importMetadataValueStringFromYAML = (
-  context: ConfigurationContext,
+  _context: ConfigurationContext,
   rule: PropertyRule | undefined,
   name: string
 ): string | undefined => {
@@ -49,7 +49,6 @@ export const importMetadataValueStringFromYAML = (
   if (objectResult?.ok) return objectResult.canonical
 
   return parseMetadataTargetStringResultFromYAML({
-    context,
     name,
     result: valueResult,
   })
@@ -67,26 +66,23 @@ function metadataTargetForRule(
 }
 
 function parseMetadataTargetStringFromYAML(
-  context: ConfigurationContext,
+  _context: ConfigurationContext,
   name: string,
   constraint: MetadataTargetConstraint,
   owner?: MetadataTargetOwner
 ): string | undefined {
   return parseMetadataTargetStringResultFromYAML({
-    context,
     name,
     result: parseMetadataTargetFromYAML({ value: name, constraint, owner }),
   })
 }
 
 function parseMetadataTargetStringResultFromYAML(params: {
-  context: ConfigurationContext
   name: string
   result: ReturnType<typeof parseMetadataTargetFromYAML>
 }): string | undefined {
   if (params.result.ok) return params.result.canonical
   if (!isMetadataTargetLikeYAML(params.name)) return undefined
-  if (params.context.importFromYAML?.validateMetadataTargets === false) return params.name
 
   throw new Error(params.result.message)
 }

--- a/packages/core/metadata/commonObjects/metadataPath/toYAML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/toYAML.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, test } from "vitest"
+import { describe, expect, test } from "vitest"
 import { tableMetadataFields, tableMetadataValues } from "~/metadata/commonObjects/metadataPath/__fixtures__/table"
 import { mockContext, mockRule } from "~/tests/mockContext"
-import { exportMetadataFieldStringToYAML, exportMetadataObjectStringToYAML, exportMetadataValueStringToYAML } from "./toYAML"
+import { exportMetadataFieldStringToYAML, exportMetadataValueStringToYAML } from "./toYAML"
 
 describe("exportMetadataFieldToYAML", () => {
   test.each(tableMetadataFields)("export %s to %s", (expected: string, enterpriseValue: string) => {
@@ -36,23 +36,5 @@ describe("exportMetadataValueStringToYAML", () => {
     expect(exportMetadataValueStringToYAML(mockContext, mockRule, "Catalog.ИмяСправочника.ПланСчетов")).toBe(
       "Справочник.ИмяСправочника.ПланСчетов"
     )
-  })
-})
-
-describe("metadataTarget diagnostics switch", () => {
-  it("keeps canonical metadata object path when metadata target validation is disabled for YAML export", () => {
-    const context = {
-      ...mockContext,
-      exportToYAML: {
-        ...mockContext.exportToYAML!,
-        validateMetadataTargets: false,
-      },
-    }
-    const reference = "ExternalDataSource.ВнешнийИсточникДанныхВсеСвойства.Table.ТаблицаВсеСвойства"
-
-    expect(() => exportMetadataObjectStringToYAML(mockContext, mockRule, reference)).toThrow(
-      'Неизвестный сегмент "Table"'
-    )
-    expect(exportMetadataObjectStringToYAML(context, mockRule, reference)).toBe(reference)
   })
 })

--- a/packages/core/metadata/commonObjects/metadataPath/toYAML.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/toYAML.ts
@@ -13,31 +13,31 @@ const metadataValueTargetFallback = {
 } as const satisfies MetadataTargetConstraint
 
 export const exportMetadataFieldStringToYAML = (
-  context: ConfigurationContext,
+  _context: ConfigurationContext,
   rule: PropertyRule | undefined,
   name: string,
   owner?: MetadataTargetOwner
 ): string | undefined => {
-  return formatMetadataTargetStringToYAML(context, name, metadataTargetForRule(rule, metadataFieldTargetFallback), owner)
+  return formatMetadataTargetStringToYAML(name, metadataTargetForRule(rule, metadataFieldTargetFallback), owner)
 }
 
 export const exportMetadataObjectStringToYAML = (
-  context: ConfigurationContext,
+  _context: ConfigurationContext,
   rule: PropertyRule | undefined,
   name: string,
   owner?: MetadataTargetOwner
 ): string | undefined => {
-  return formatMetadataTargetStringToYAML(context, name, metadataTargetForRule(rule, metadataObjectTargetFallback), owner)
+  return formatMetadataTargetStringToYAML(name, metadataTargetForRule(rule, metadataObjectTargetFallback), owner)
 }
 
 export const exportMetadataValueStringToYAML = (
-  context: ConfigurationContext,
+  _context: ConfigurationContext,
   rule: PropertyRule | undefined,
   name: string | undefined
 ): string | undefined => {
   if (!name) return undefined
 
-  return formatMetadataTargetStringToYAML(context, name, metadataTargetForRule(rule, metadataValueTargetFallback))
+  return formatMetadataTargetStringToYAML(name, metadataTargetForRule(rule, metadataValueTargetFallback))
 }
 
 function metadataTargetForRule(
@@ -52,7 +52,6 @@ function metadataTargetForRule(
 }
 
 function formatMetadataTargetStringToYAML(
-  context: ConfigurationContext,
   name: string,
   constraint: MetadataTargetConstraint,
   owner?: MetadataTargetOwner
@@ -60,7 +59,6 @@ function formatMetadataTargetStringToYAML(
   try {
     return formatMetadataTargetToYAML({ canonical: name, constraint, owner })
   } catch (error) {
-    if (context.exportToYAML?.validateMetadataTargets === false && isMetadataTargetLikeModel(name)) return name
     if (isMetadataTargetLikeModel(name)) throw error
     return undefined
   }

--- a/packages/core/metadata/context/types.ts
+++ b/packages/core/metadata/context/types.ts
@@ -89,8 +89,6 @@ export interface MetadataTargetOwnerContext {
 
 export interface FormExportToYAMLContext {
   toTyped: boolean
-  /** Отключает строгую проверку metadataTarget для диагностических round-trip прогонов. */
-  validateMetadataTargets?: boolean
   /** Имя родительского объекта (например, имя реквизита формы) для externalFile. */
   parent?: { name: string }
   /** Сборник внешних файлов, формируемых при экспорте. */
@@ -100,8 +98,6 @@ export interface FormExportToYAMLContext {
 }
 
 export interface FormimportFromYAMLContext {
-  /** Отключает строгую проверку metadataTarget для диагностических round-trip прогонов. */
-  validateMetadataTargets?: boolean
   allElements?: FormChildItemsPartialYAML
   /** Путь к каталогу формы для чтения внешних файлов (externalFile). */
   formDir?: string


### PR DESCRIPTION
## Summary
- Removed the --no-validate-metadata-targets CLI option from import and sync.
- Removed the validateMetadataTargets context bypass from metadataPath YAML conversion.
- Updated round-trip helper scripts to run import/sync with normal metadataTarget validation.

## Test Plan
- pnpm --filter '@nakidka/core' test
- pnpm test
- pnpm -s --dir packages/cli exec tsx src/cli.ts import /home/nikita/git/round-trip/erp /home/nikita/git/temp-yaml