### PR TITLE
Игнорировать вариантные DataPath при validate

### DIFF
--- a/docs/superpowers/plans/2026-06-17-tilde-datapath-validation.md
+++ b/docs/superpowers/plans/2026-06-17-tilde-datapath-validation.md
@@ -1,0 +1,168 @@
+# Tilde DataPath Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `~` variant form `DataPath` values pass validation without diagnostics while preserving them unchanged.
+
+**Architecture:** Keep the behavior in the existing schema and resolver boundaries. JSON Schema accepts tilde variant paths; the semantic resolver skips them with an `ok` result and no target.
+
+**Tech Stack:** TypeScript, Vitest, TypeBox JSON Schema, existing metadata validation pipeline.
+
+## Global Constraints
+
+- Do not change XML fixtures.
+- Do not add new fromXML/toXML/fromYAML/toYAML rules.
+- Do not transform tilde variant path strings.
+- Do not include indexed `[0]` paths in this change.
+
+---
+
+### Task 1: Add failing tests for tilde variant paths
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/metadataTargets/schema.test.ts`
+- Modify: `packages/core/metadata/validation/dataPath/resolver.test.ts`
+
+**Interfaces:**
+- Consumes: `buildMetadataTargetSchema({ kind: "dataPath", context: "form" })`
+- Consumes: `resolveDataPath` through the local `resolve` helper in `resolver.test.ts`
+- Produces: Failing tests that describe the desired behavior.
+
+- [ ] **Step 1: Update schema test**
+
+In `packages/core/metadata/commonObjects/metadataTargets/schema.test.ts`, in `returns constrained schema for form data paths`, replace the exact `pattern` assertion with behavioral checks:
+
+```ts
+expect(schema).toMatchObject({
+  type: "string",
+  examples: ["ИмяРеквизита", "ИмяТаблицы.ИмяКолонки"],
+})
+expectMatches(schema, "ИмяРеквизита")
+expectMatches(schema, "ИмяТаблицы.ИмяКолонки")
+expectMatches(schema, "~Список.DefaultPicture")
+expectMatches(schema, "~Список.Period~Список.Период")
+expectNotMatches(schema, "Список[0].Поле")
+expect(String(schema.description)).toContain("string")
+```
+
+- [ ] **Step 2: Update resolver tests**
+
+In `packages/core/metadata/validation/dataPath/resolver.test.ts`, replace the two tilde warning tests with:
+
+```ts
+it("skips tilde variant paths without diagnostics", () => {
+  const result = resolve("~Список.Period~Список.Период", {
+    index: indexWithAttributes([]),
+  })
+
+  expect(result).toMatchObject({
+    status: "ok",
+    diagnostics: [],
+  })
+})
+
+it("skips tilde variant paths before table context validation", () => {
+  const result = resolve("~Список.Period~Список.Период", {
+    index: indexWithAttributes([]),
+    tableContext: { dataPath: "Список" },
+  })
+
+  expect(result).toMatchObject({
+    status: "ok",
+    diagnostics: [],
+  })
+})
+```
+
+- [ ] **Step 3: Run tests and verify red**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run --no-isolate metadata/commonObjects/metadataTargets/schema.test.ts metadata/validation/dataPath/resolver.test.ts
+```
+
+Expected: FAIL. The schema test rejects `~...`, and the resolver tests still return `warning`.
+
+### Task 2: Implement tilde path skipping
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/metadataTargets/schema.ts`
+- Modify: `packages/core/metadata/validation/dataPath/resolver.ts`
+
+**Interfaces:**
+- Produces: `dataPathSchema` pattern with regular and tilde branches.
+- Produces: `resolveDataPath` returning `{ status: "ok", diagnostics: [] }` for tilde variant paths.
+
+- [ ] **Step 1: Extend `dataPathSchema`**
+
+In `packages/core/metadata/commonObjects/metadataTargets/schema.ts`, change `dataPathSchema` to build two pattern branches:
+
+```ts
+const simplePathPattern = `${METADATA_NAME_PATTERN}(?:\\.${METADATA_NAME_PATTERN})*`
+const tildeVariantPathPattern = `~${simplePathPattern}(?:~${simplePathPattern})*`
+return Type.String({
+  pattern: `^(?:${simplePathPattern}|${tildeVariantPathPattern})$`,
+  examples: ["ИмяРеквизита", "ИмяТаблицы.ИмяКолонки"],
+  description: `Путь к данным формы: ИмяРеквизита или ИмяТаблицы.ИмяКолонки.${allowedKinds}${composite} Вариантные пути с "~" сохраняются как есть и не проверяются. Реальные поля проверяются validate.`,
+})
+```
+
+- [ ] **Step 2: Change resolver tilde branch**
+
+In `packages/core/metadata/validation/dataPath/resolver.ts`, replace the warning branch:
+
+```ts
+if (isTildeVariantPath(value)) {
+  return { status: "ok", diagnostics: [] }
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify green**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run --no-isolate metadata/commonObjects/metadataTargets/schema.test.ts metadata/validation/dataPath/resolver.test.ts
+```
+
+Expected: PASS.
+
+### Task 3: Verify project validation effect
+
+**Files:**
+- No source files.
+
+**Interfaces:**
+- Consumes: `/home/nikita/git/temp-yaml` imported ERP YAML.
+- Produces: Evidence that `~` paths no longer appear as schema errors or warnings.
+
+- [ ] **Step 1: Run ERP validation**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/cli dev validate /home/nikita/git/temp-yaml > /tmp/erp-validate-after-tilde.log 2>&1
+```
+
+Expected: command still exits non-zero because other validation errors remain.
+
+- [ ] **Step 2: Count tilde diagnostics**
+
+Run:
+
+```bash
+rg 'ПутьКДанным ".*~|Expected string to match' /tmp/erp-validate-after-tilde.log
+```
+
+Expected: no diagnostics for tilde variant paths. `Expected string to match` may remain only for non-tilde cases such as indexed `[0]` paths.
+
+- [ ] **Step 3: Run package test target**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core test -- metadataTargets/schema.test.ts dataPath/resolver.test.ts
+```
+
+Expected: PASS for the changed behavior. If this command runs broader package tests, the relevant changed tests must pass.

--- a/docs/superpowers/specs/2026-06-17-tilde-datapath-validation-design.md
+++ b/docs/superpowers/specs/2026-06-17-tilde-datapath-validation-design.md
@@ -1,0 +1,51 @@
+# Tilde DataPath Validation Design
+
+## Context
+
+ERP import into `/home/nikita/git/temp-yaml` produced `361` schema errors for `DataPath` values that start with `~`, for example `~Список.DefaultPicture` and `~Список.Period~Список.Период`.
+
+These values already exist in XML fixtures and imported YAML. They are raw platform variant paths, not ordinary dotted form paths. The project must preserve them exactly and must not try to normalize them into regular `DataPath` values.
+
+## Goal
+
+Treat `~` variant `DataPath` values as opaque raw strings:
+
+- JSON Schema accepts them as valid `DataPath` values.
+- Form `DataPath` resolver skips them without warnings or errors.
+- Import, YAML output, XML output, and existing string values are not transformed.
+- Non-tilde indexed paths like `Список[0].Поле` remain outside this change.
+
+## Architecture
+
+The change stays inside existing `DataPath` validation boundaries.
+
+`packages/core/metadata/commonObjects/metadataTargets/schema.ts` owns the JSON Schema shape for `DataPath`. It should keep the existing strict dotted-path branch and add a second branch for tilde variant paths.
+
+`packages/core/metadata/validation/dataPath/resolver.ts` owns semantic form-path validation. It already detects `value.includes("~")`; that branch should return `ok` with no target and no diagnostics.
+
+No fromXML/toXML/fromYAML/toYAML rules are added. No XML fixtures are changed.
+
+## Data Flow
+
+When `validate` reads a YAML form:
+
+1. JSON Schema accepts regular dotted paths and tilde variant paths.
+2. Form validation collects `DataPath` occurrences as before.
+3. Resolver sees a tilde variant path and returns `{ status: "ok", diagnostics: [] }`.
+4. Other `DataPath` values continue through current semantic resolution.
+
+## Error Handling
+
+Tilde variant paths are intentionally not diagnosed. They are not warnings, because the requested behavior is to ignore them during validation.
+
+Malformed non-tilde paths keep current schema behavior. Indexed paths with `[0]` are not handled by this spec.
+
+## Testing
+
+Add focused tests:
+
+- JSON Schema accepts `~Список.DefaultPicture`.
+- JSON Schema accepts `~Список.Period~Список.Период`.
+- JSON Schema still rejects `Список[0].Поле`.
+- Resolver returns `ok` and no diagnostics for tilde variant paths.
+- Existing validation tests continue to pass.

--- a/packages/core/metadata/commonObjects/metadataTargets/schema.test.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/schema.test.ts
@@ -214,9 +214,13 @@ describe("buildMetadataTargetSchema", () => {
 
     expect(schema).toMatchObject({
       type: "string",
-      pattern: "^[a-zA-Zа-яА-ЯёЁ_][a-zA-Zа-яА-ЯёЁ0-9_]*(?:\\.[a-zA-Zа-яА-ЯёЁ_][a-zA-Zа-яА-ЯёЁ0-9_]*)*$",
       examples: ["ИмяРеквизита", "ИмяТаблицы.ИмяКолонки"],
     })
+    expectMatches(schema, "ИмяРеквизита")
+    expectMatches(schema, "ИмяТаблицы.ИмяКолонки")
+    expectMatches(schema, "~Список.DefaultPicture")
+    expectMatches(schema, "~Список.Period~Список.Период")
+    expectNotMatches(schema, "Список[0].Поле")
     expect(String(schema.description)).toContain("string")
   })
 

--- a/packages/core/metadata/commonObjects/metadataTargets/schema.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/schema.ts
@@ -267,10 +267,12 @@ function dataPathSchema(constraint: Extract<MetadataTargetConstraint, { kind: "d
       ? ""
       : ` Допустимые виды значения: ${constraint.allowedKinds.join(", ")}.`
   const composite = constraint.allowComposite === true ? " Составные значения разрешены." : " Составные значения запрещены."
+  const simplePathPattern = `${METADATA_NAME_PATTERN}(?:\\.${METADATA_NAME_PATTERN})*`
+  const tildeVariantPathPattern = `~${simplePathPattern}(?:~${simplePathPattern})*`
   return Type.String({
-    pattern: `^${METADATA_NAME_PATTERN}(?:\\.${METADATA_NAME_PATTERN})*$`,
+    pattern: `^(?:${simplePathPattern}|${tildeVariantPathPattern})$`,
     examples: ["ИмяРеквизита", "ИмяТаблицы.ИмяКолонки"],
-    description: `Путь к данным формы: ИмяРеквизита или ИмяТаблицы.ИмяКолонки.${allowedKinds}${composite} Реальные поля проверяются validate.`,
+    description: `Путь к данным формы: ИмяРеквизита или ИмяТаблицы.ИмяКолонки.${allowedKinds}${composite} Вариантные пути с "~" сохраняются как есть и не проверяются. Реальные поля проверяются validate.`,
   })
 }
 

--- a/packages/core/metadata/validation/dataPath/resolver.test.ts
+++ b/packages/core/metadata/validation/dataPath/resolver.test.ts
@@ -708,37 +708,26 @@ describe("resolveDataPath", () => {
     })
   })
 
-  it("returns a warning for unsupported tilde variant paths", () => {
+  it("skips tilde variant paths without diagnostics", () => {
     const result = resolve("~Список.Period~Список.Период", {
       index: indexWithAttributes([]),
     })
 
     expect(result).toMatchObject({
-      status: "warning",
-      diagnostics: [
-        expect.objectContaining({
-          severity: "warning",
-          source: "structure",
-          message: 'ПутьКДанным "~Список.Period~Список.Период": вариантный путь пока не проверяется',
-        }),
-      ],
+      status: "ok",
+      diagnostics: [],
     })
   })
 
-  it("returns a warning for unsupported tilde variant paths before table context validation", () => {
+  it("skips tilde variant paths before table context validation", () => {
     const result = resolve("~Список.Period~Список.Период", {
       index: indexWithAttributes([]),
       tableContext: { dataPath: "Список" },
     })
 
     expect(result).toMatchObject({
-      status: "warning",
-      diagnostics: [
-        expect.objectContaining({
-          severity: "warning",
-          message: 'ПутьКДанным "~Список.Period~Список.Период": вариантный путь пока не проверяется',
-        }),
-      ],
+      status: "ok",
+      diagnostics: [],
     })
   })
 

--- a/packages/core/metadata/validation/dataPath/resolver.ts
+++ b/packages/core/metadata/validation/dataPath/resolver.ts
@@ -70,7 +70,7 @@ export function resolveDataPath(params: ResolveDataPathParams): ResolveDataPathR
   }
 
   if (isTildeVariantPath(value)) {
-    return warning(params, `ПутьКДанным "${value}": вариантный путь пока не проверяется`)
+    return { status: "ok", diagnostics: [] }
   }
 
   const platformSource = getKnownPlatformFormSource(value)

--- a/packages/core/metadata/validation/validateForm.test.ts
+++ b/packages/core/metadata/validation/validateForm.test.ts
@@ -550,7 +550,7 @@ describe("validateForm", () => {
     ])
   })
 
-  it("warns for unsupported tilde variant paths", () => {
+  it("skips tilde variant paths without diagnostics", () => {
     const project = createProject({
       form: [
         "Элементы:",
@@ -560,12 +560,7 @@ describe("validateForm", () => {
       ],
     })
 
-    expect(runValidateForm(project)).toEqual([
-      expect.objectContaining({
-        severity: "warning",
-        message: 'ПутьКДанным "~Список.Period~Список.Период": вариантный путь пока не проверяется',
-      }),
-    ])
+    expect(runValidateForm(project)).toEqual([])
   })
 
   it("validates DataPath values inside singleton element child items", () => {


### PR DESCRIPTION
## Что изменилось
- Добавлена спека и план для обработки вариантных DataPath с ~.
- JSON Schema принимает такие пути как непрозрачные строки.
- Resolver пропускает их без предупреждений и ошибок.

## Проверка
- pnpm --filter '@nakidka/core' test