### PR TITLE
fix: исправить ошибки TypeScript

### DIFF
--- a/packages/core/metadata/commonObjects/metadataTargets/schema.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/schema.ts
@@ -291,6 +291,7 @@ function objectSegmentName(kind: MetadataObjectPathKind): string {
   if (kind === "Cube") return "ИмяКуба"
   if (kind === "DimensionTable") return "ИмяТаблицыИзмерения"
   if (kind === "Function") return "ИмяФункции"
+  throw new Error(`Unsupported metadata object path kind: ${kind}`)
 }
 
 function exactMemberPathPatterns(

--- a/packages/core/metadata/commonObjects/recalculation/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/recalculation/toJSONSchema.test.ts
@@ -7,12 +7,15 @@ const compileSchema = () => {
   const exportToJSONSchema = getTypeRule("Recalculations", "exportToJSONSchema")
   expect(exportToJSONSchema).toBeDefined()
   if (exportToJSONSchema === undefined) throw new Error("Recalculations JSON schema export is not registered")
+  const schema = exportToJSONSchema({
+    context: mockContext,
+    rule: { type: "Recalculations", yaml: "Перерасчеты" },
+    value: undefined,
+  })
+  if (schema === undefined) throw new Error("Recalculations JSON schema export returned undefined")
+
   return TypeCompiler.Compile(
-    exportToJSONSchema({
-      context: mockContext,
-      rule: { type: "Recalculations", yaml: "Перерасчеты" },
-      value: undefined,
-    })
+    schema
   )
 }
 

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/fromXML.test.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/fromXML.test.ts
@@ -42,8 +42,8 @@ describe("importWebSocketClientHeadersFromXML", () => {
     const result = importWebSocketClientHeadersFromXML(mockContextFromXML(), mockRule, xml)
 
     expect(result).toEqual([
-      { key: "Authorization", value: "first" },
-      { key: "Authorization", value: "second" },
+      { Ключ: "Authorization", Значение: "first" },
+      { Ключ: "Authorization", Значение: "second" },
     ])
   })
 })

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/fromXML.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/fromXML.ts
@@ -13,8 +13,8 @@ export const importWebSocketClientHeadersFromXML: ImportFromXMLFunction = (
   const items = Array.isArray(xml["xr:Item"]) ? xml["xr:Item"] : [xml["xr:Item"]]
 
   return items.map((item) => ({
-    key: item["xr:Value"]["v8:Key"]["#text"] ?? "",
-    value: item["xr:Value"]["v8:Value"]["#text"] ?? "",
+    Ключ: item["xr:Value"]["v8:Key"]["#text"] ?? "",
+    Значение: item["xr:Value"]["v8:Value"]["#text"] ?? "",
   }))
 }
 

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/fromYAML.test.ts
@@ -12,8 +12,8 @@ describe("importWebSocketClientHeadersFromYAML", () => {
     ])
 
     expect(result).toEqual([
-      { key: "X-Test", value: "1" },
-      { key: "X-Test", value: "2" },
+      { Ключ: "X-Test", Значение: "1" },
+      { Ключ: "X-Test", Значение: "2" },
     ])
   })
 })

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/fromYAML.ts
@@ -8,7 +8,7 @@ export const importWebSocketClientHeadersFromYAML: importFromYAMLFunction = (
   value: WebSocketClientHeadersYAML | undefined
 ): WebSocketClientHeaders | undefined => {
   if (value === undefined) return undefined
-  return value.map((item) => ({ key: item.Ключ, value: item.Значение }))
+  return value.map((item) => ({ Ключ: item.Ключ, Значение: item.Значение }))
 }
 
 registerTypeRule("WebSocketClientHeaders", "importFromYAML", importWebSocketClientHeadersFromYAML)

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/toJSONSchema.test.ts
@@ -7,7 +7,9 @@ const schema = TypeCompiler.Compile(
     context: {} as never,
     rule: { type: "WebSocketClientHeaders" },
     value: undefined,
-  })
+  }) ?? (() => {
+    throw new Error("WebSocketClientHeaders JSON schema export returned undefined")
+  })()
 )
 
 describe("exportWebSocketClientHeadersToJSONSchema", () => {

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/toXML.test.ts
@@ -13,8 +13,8 @@ describe("exportWebSocketClientHeadersToXML", () => {
 
   it("preserves duplicate header keys", () => {
     const result = exportWebSocketClientHeadersToXML(mockContextToXML(), mockRule, [
-      { key: "Authorization", value: "first" },
-      { key: "Authorization", value: "second" },
+      { Ключ: "Authorization", Значение: "first" },
+      { Ключ: "Authorization", Значение: "second" },
     ])
 
     expect(result).toEqual({

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/toXML.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/toXML.ts
@@ -18,8 +18,8 @@ export const exportWebSocketClientHeadersToXML: ExportToXMLFunction = (
             "xr:CheckState": 0,
             "xr:Value": {
               "_xsi:type": "v8:KeyAndValue",
-              "v8:Key": { "_xsi:type": "xs:string", "#text": item.key },
-              "v8:Value": { "_xsi:type": "xs:string", "#text": item.value },
+              "v8:Key": { "_xsi:type": "xs:string", "#text": item.Ключ },
+              "v8:Value": { "_xsi:type": "xs:string", "#text": item.Значение },
             },
           })),
         }

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/toYAML.test.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/toYAML.test.ts
@@ -7,8 +7,8 @@ const rule = { type: "WebSocketClientHeaders", yaml: "Заголовки" } as c
 describe("exportWebSocketClientHeadersToYAML", () => {
   it("preserves order and duplicate keys", () => {
     const result = exportWebSocketClientHeadersToYAML(mockContextToYAML, rule, [
-      { key: "X-Test", value: "1" },
-      { key: "X-Test", value: "2" },
+      { Ключ: "X-Test", Значение: "1" },
+      { Ключ: "X-Test", Значение: "2" },
     ])
 
     expect(result).toEqual([

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/toYAML.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/toYAML.ts
@@ -8,7 +8,7 @@ export const exportWebSocketClientHeadersToYAML: ExportToYAMLFunction = (
   value: WebSocketClientHeaders | undefined
 ): WebSocketClientHeadersYAML | undefined => {
   if (value === undefined) return undefined
-  return value.map((item) => ({ Ключ: item.key, Значение: item.value }))
+  return value.map((item) => ({ Ключ: item.Ключ, Значение: item.Значение }))
 }
 
 registerTypeRule("WebSocketClientHeaders", "exportToYAML", exportWebSocketClientHeadersToYAML)

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromYAML.test.ts
@@ -410,7 +410,7 @@ describe("importFormAttributesFromYAML", () => {
       ]
     )
 
-    expect(result?.[0]?.columns[0]?.title).toEqual({
+    expect(result?.[0]?.columns?.[0]?.title).toEqual({
       items: {
         en: "Column sent",
       },

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toXML.ts
@@ -70,7 +70,7 @@ const exportFormAttributeToXML = (
     rule: FormAttributeRules,
   })
 
-  const columns = exportColumnsToXML(context, data.columns, referenceData?.columns, data)
+  const columns = exportColumnsToXML(context, data.columns ?? [], referenceData?.columns, data)
   const additionalColumns = exportAdditionalColumnsToXML(
     context,
     (data as FormAttributeWithAdditionalColumns).additionalColumns ?? [],

--- a/packages/core/metadata/forms/elements/autoCommandBar/helper.ts
+++ b/packages/core/metadata/forms/elements/autoCommandBar/helper.ts
@@ -7,7 +7,7 @@ export const getAutoCommandBarName = (parentElement: { name: string }): string =
 const EXCLUDED_FIELDS = ["name", "itemType", "childItems"]
 
 export const isHasContent = (data: AutoCommandBar): boolean => {
-  if (data.childItems.length != 0) return true
+  if ((data.childItems?.length ?? 0) != 0) return true
 
   const keys = Object.keys(data)
   const hasOtherFields = keys.some(

--- a/packages/core/metadata/forms/elements/contextMenu/helper.ts
+++ b/packages/core/metadata/forms/elements/contextMenu/helper.ts
@@ -7,7 +7,7 @@ export const getContextMenuName = (parentElement: { name: string }): string => {
 export const isHasContent = (data: ContextMenu | undefined): boolean => {
   if (!data) return false
 
-  if (data.childItems.length > 0) return true
+  if ((data.childItems?.length ?? 0) > 0) return true
 
   const keys = Object.keys(data)
   const hasOtherFields = keys.some((key) => key !== "childItems")

--- a/packages/core/metadata/forms/elements/searchControlAddition/helper.ts
+++ b/packages/core/metadata/forms/elements/searchControlAddition/helper.ts
@@ -5,6 +5,6 @@ export const getSearchControlAdditionName = (parentElement: { name: string }): s
 }
 
 export const isHasContent = (data: SingleSearchControlAddition): boolean => {
-  if (data.childItems.length > 0) return true
+  if ((data.childItems?.length ?? 0) > 0) return true
   return Object.keys(data).filter((key) => key !== "childItems" && key !== "itemType").length > 0
 }

--- a/packages/core/metadata/orchestration/property/toJSONSchemaRequired.test.ts
+++ b/packages/core/metadata/orchestration/property/toJSONSchemaRequired.test.ts
@@ -10,7 +10,7 @@ import type { MetadataItemRule, PropertyRule } from "./types"
 describe("exportPropertiesToJSONSchema required YAML properties", () => {
   it("keeps required YAML properties non-optional", () => {
     const rule = {
-      itemType: "RequiredYamlFixture",
+      itemType: "Button",
       properties: {
         name: { yaml: "Имя", type: "string", required: true },
         comment: { yaml: "Комментарий", type: "string" },

--- a/packages/core/metadata/validation/dataPath/formIndex.test.ts
+++ b/packages/core/metadata/validation/dataPath/formIndex.test.ts
@@ -276,10 +276,10 @@ function attribute(name: string, type: TypeDescription, columns: FormAttribute["
   } as FormAttribute
 }
 
-function column(name: string, type: TypeDescription): FormAttribute["columns"][number] {
+function column(name: string, type: TypeDescription): NonNullable<FormAttribute["columns"]>[number] {
   return {
     itemType: "FormAttributeColumn",
     name,
     type,
-  } as FormAttribute["columns"][number]
+  } as NonNullable<FormAttribute["columns"]>[number]
 }

--- a/packages/core/metadata/validation/dataPath/resolver.test.ts
+++ b/packages/core/metadata/validation/dataPath/resolver.test.ts
@@ -2513,12 +2513,12 @@ function attribute(name: string, type: TypeDescription | undefined, columns: For
   } as FormAttribute
 }
 
-function column(name: string, type: TypeDescription): FormAttribute["columns"][number] {
+function column(name: string, type: TypeDescription): NonNullable<FormAttribute["columns"]>[number] {
   return {
     itemType: "FormAttributeColumn",
     name,
     type,
-  } as FormAttribute["columns"][number]
+  } as NonNullable<FormAttribute["columns"]>[number]
 }
 
 function ownerCache(owners: OwnerMetadata[]): OwnerMetadataCache {

--- a/packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts
+++ b/packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts
@@ -81,7 +81,7 @@ export function typeboxErrorsToDiagnostics(
       col,
       message:
         error.type === ValueErrorType.ObjectRequiredProperty && keys.length > 0
-          ? `Отсутствует обязательное свойство "${String(keys.at(-1))}"`
+          ? `Отсутствует обязательное свойство "${String(keys[keys.length - 1])}"`
           : error.message,
       severity: "error",
       source: "structure",


### PR DESCRIPTION
## Что сделано
- Исправлены ошибки TypeScript после строгой проверки типов.
- WebSocketClientHeaders приведён к объявленной форме с ключами Ключ/Значение.
- Добавлены явные проверки необязательных значений в тестах и помощниках.

## Проверка
- pnpm --filter '@nakidka/core' test