### PR TITLE
Исправить round-trip-yaml-fast

### DIFF
--- a/.agents/skills/round-trip-yaml-fast/SKILL.md
+++ b/.agents/skills/round-trip-yaml-fast/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: round-trip-yaml-fast
+description: Use when diagnosing metadata XML -> YAML text -> XML round-trip diffs quickly, especially before the full round-trip-yaml workflow or when external files are intentionally out of scope.
+---
+
+# round-trip-yaml-fast
+
+Быстрая диагностика metadata round-trip без записи YAML/XML-деревьев:
+
+```text
+XML text -> parsed XML -> модель -> YAML-текст -> модель -> XML text
+```
+
+Перед анализом metadata обязательно прочитай:
+
+1. `.agents/knowledge/metadata/INDEX.md`
+2. `.agents/knowledge/metadata/sources-of-truth.md`
+3. `.agents/knowledge/metadata/round-trip-cycle.md`
+4. `.agents/knowledge/metadata/yaml-contract.md`
+
+## Когда использовать
+
+- Нужно быстро найти расхождения YAML-слоя по XML-файлам верхнего уровня.
+- Внешние `.bsl`, `.txt`, `.bin`, `.png` не важны для текущей проверки.
+- Нужен single diff или triage-пачка без создания reproducer.
+
+Не используй для проверки внешних файлов, форм, модулей, шаблонов и полного sync-поведения. Для этого запускай `round-trip-yaml`.
+
+## Запуск
+
+Из корня `nkdk`:
+
+```bash
+./.agents/skills/round-trip-yaml-fast/round-trip.sh
+./.agents/skills/round-trip-yaml-fast/round-trip.sh --diff-index 3
+./.agents/skills/round-trip-yaml-fast/round-trip.sh --triage --batch-size 5 --start-index 6
+```
+
+Скрипт читает `.env`: `NKDK_XML_REPO` обязателен, `NKDK_XML_DIR` опционален. Если `NKDK_XML_DIR` не задан, проверяется `NKDK_XML_REPO`.
+
+## Ответ после запуска
+
+Если вывод содержит `=== Round-trip YAML fast чистый: диффов нет ===`, остановись: анализировать нечего.
+
+В single-режиме дай краткий разбор:
+
+```text
+XML-файл: <SELECTED_XML_FILE_ABS>
+XML-каталог: <ACTIVE_XML_DIR>
+Diff: <SELECTED_DIFF_FILE>
+Вероятный модуль: packages/core/metadata/<...> или неизвестно
+Категория: потеря пустого тега / порядок XML-узлов / лишний default / потеря атрибута / потеря xsi:type / потеря id или ссылки / YAML-default / YAML-исключение / неизвестно
+Описание: <что изменилось>
+Diff:
+<фрагмент или полный diff>
+```
+
+В triage-режиме перечисли каждый `=== TRIAGE_DIFF ===` отдельно. Не исправляй код, не создавай ветку, тест, план, коммит или PR в рамках этого skill.

--- a/.agents/skills/round-trip-yaml-fast/round-trip.sh
+++ b/.agents/skills/round-trip-yaml-fast/round-trip.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+MODE="single"
+DIFF_INDEX="1"
+BATCH_SIZE="5"
+START_INDEX="1"
+DIFF_INDEX_SET="0"
+BATCH_SIZE_SET="0"
+START_INDEX_SET="0"
+
+usage() {
+  cat <<'USAGE'
+Использование:
+  ./.agents/skills/round-trip-yaml-fast/round-trip.sh
+  ./.agents/skills/round-trip-yaml-fast/round-trip.sh --diff-index N
+  ./.agents/skills/round-trip-yaml-fast/round-trip.sh --triage [--batch-size N] [--start-index K]
+
+Параметры:
+  --diff-index N   Показать один diff по 1-based номеру.
+  --triage         Показать пачку diff'ов.
+  --batch-size N   Размер triage-пачки. По умолчанию 5.
+  --start-index K  1-based номер первого diff'а в triage-пачке. По умолчанию 1.
+  -h, --help       Показать эту справку.
+USAGE
+}
+
+die() {
+  echo "Ошибка: $*" >&2
+  exit 1
+}
+
+is_positive_integer() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --diff-index)
+      [ "$#" -ge 2 ] || die "--diff-index требует значение"
+      is_positive_integer "$2" || die "--diff-index должен быть положительным целым числом"
+      DIFF_INDEX="$2"
+      DIFF_INDEX_SET="1"
+      shift 2
+      ;;
+    --triage)
+      MODE="triage"
+      shift
+      ;;
+    --batch-size)
+      [ "$#" -ge 2 ] || die "--batch-size требует значение"
+      is_positive_integer "$2" || die "--batch-size должен быть положительным целым числом"
+      BATCH_SIZE="$2"
+      BATCH_SIZE_SET="1"
+      shift 2
+      ;;
+    --start-index)
+      [ "$#" -ge 2 ] || die "--start-index требует значение"
+      is_positive_integer "$2" || die "--start-index должен быть положительным целым числом"
+      START_INDEX="$2"
+      START_INDEX_SET="1"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "неизвестный параметр: $1"
+      ;;
+  esac
+done
+
+if [ "${MODE}" = "triage" ] && [ "${DIFF_INDEX_SET}" = "1" ]; then
+  die "--diff-index нельзя использовать вместе с --triage"
+fi
+
+if [ "${MODE}" = "single" ] && [ "${BATCH_SIZE_SET}" = "1" ]; then
+  die "--batch-size доступен только вместе с --triage"
+fi
+
+if [ "${MODE}" = "single" ] && [ "${START_INDEX_SET}" = "1" ]; then
+  die "--start-index доступен только вместе с --triage"
+fi
+
+if [ -f "${REPO_DIR}/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${REPO_DIR}/.env"
+  set +a
+fi
+
+if [ -z "${NKDK_XML_REPO:-}" ]; then
+  die "переменная NKDK_XML_REPO не задана (ни в окружении, ни в .env)"
+fi
+
+NKDK_XML_DIR="${NKDK_XML_DIR:-${NKDK_XML_REPO}}"
+if [ ! -d "${NKDK_XML_DIR}" ]; then
+  die "NKDK_XML_DIR ('${NKDK_XML_DIR}') не существует или не каталог"
+fi
+NKDK_XML_DIR="$(cd "${NKDK_XML_DIR}" && pwd)"
+NKDK_XML_REPO="$(cd "${NKDK_XML_REPO}" && pwd)"
+
+if command -v nkdk &>/dev/null; then
+  NKDK=(nkdk)
+elif [ -f "${REPO_DIR}/packages/cli/src/cli.ts" ]; then
+  NKDK=(pnpm -s --dir "${REPO_DIR}/packages/cli" exec tsx src/cli.ts)
+else
+  die "команда nkdk не найдена"
+fi
+
+OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/round-trip-yaml-fast.XXXXXX")"
+trap 'rm -f "${OUTPUT_FILE}"' EXIT
+
+echo "=== round-trip-yaml-fast.sh ==="
+echo "XML репо:    ${NKDK_XML_REPO}"
+echo "XML каталог: ${NKDK_XML_DIR}"
+echo "nkdk:        ${NKDK[*]}"
+echo "mode:        ${MODE}"
+if [ "${MODE}" = "single" ]; then
+  echo "diff index:  ${DIFF_INDEX}"
+else
+  echo "batch size:  ${BATCH_SIZE}"
+  echo "start index: ${START_INDEX}"
+fi
+echo ""
+
+if ! "${NKDK[@]}" round-trip-yaml-fast "${NKDK_XML_DIR}" >"${OUTPUT_FILE}"; then
+  cat "${OUTPUT_FILE}"
+  exit 1
+fi
+
+DIFF_COUNT="$(
+  awk '
+    $0 == "=== DIFF_COUNT ===" { getline; print; exit }
+  ' "${OUTPUT_FILE}"
+)"
+DIFF_COUNT="${DIFF_COUNT:-0}"
+is_positive_integer "${DIFF_COUNT}" || [ "${DIFF_COUNT}" = "0" ] || die "не удалось прочитать DIFF_COUNT"
+
+echo "=== ACTIVE_XML_DIR ==="
+echo "${NKDK_XML_DIR}"
+echo ""
+echo "=== DIFF_COUNT ==="
+echo "${DIFF_COUNT}"
+
+if [ "${DIFF_COUNT}" -eq 0 ]; then
+  echo ""
+  echo "=== Round-trip YAML fast чистый: диффов нет ==="
+  exit 0
+fi
+
+emit_single_diff() {
+  local index="$1"
+
+  awk -v target="${index}" -v active_dir="${NKDK_XML_DIR}" '
+    $0 == "=== DIFF ===" {
+      current += 1
+      selected = current == target
+      if (selected) {
+        print ""
+        print "=== SELECTED_DIFF_INDEX ==="
+        print target
+        print ""
+        print "=== SELECTED_DIFF ==="
+      }
+      next
+    }
+    selected && /^file: / {
+      file = substr($0, 7)
+      print "=== SELECTED_DIFF_FILE ==="
+      print file
+      print ""
+      print "=== SELECTED_XML_FILE_ABS ==="
+      print active_dir "/" file
+      print ""
+      print "=== FULL_DIFF ==="
+      next
+    }
+    selected && /^xmlFileAbs: / { next }
+    selected { print }
+  ' "${OUTPUT_FILE}"
+}
+
+emit_triage_diffs() {
+  local start="$1"
+  local end="$2"
+
+  awk -v start="${start}" -v end="${end}" -v active_dir="${NKDK_XML_DIR}" '
+    $0 == "=== DIFF ===" {
+      current += 1
+      selected = current >= start && current <= end
+      if (selected) {
+        print ""
+        print "=== TRIAGE_DIFF ==="
+        print "INDEX: " current
+      }
+      next
+    }
+    selected && /^file: / {
+      file = substr($0, 7)
+      print "FILE: " file
+      print "XML_FILE_ABS: " active_dir "/" file
+      print "--- DIFF ---"
+      next
+    }
+    selected && /^xmlFileAbs: / { next }
+    selected { print }
+  ' "${OUTPUT_FILE}"
+}
+
+if [ "${MODE}" = "single" ]; then
+  if [ "${DIFF_INDEX}" -gt "${DIFF_COUNT}" ]; then
+    die "--diff-index ${DIFF_INDEX} выходит за пределы списка diff'ов (${DIFF_COUNT})"
+  fi
+
+  emit_single_diff "${DIFF_INDEX}"
+  exit 0
+fi
+
+TRIAGE_START="${START_INDEX}"
+TRIAGE_END="$((START_INDEX + BATCH_SIZE - 1))"
+if [ "${TRIAGE_END}" -gt "${DIFF_COUNT}" ]; then
+  TRIAGE_END="${DIFF_COUNT}"
+fi
+
+echo ""
+echo "=== TRIAGE_RANGE ==="
+echo "${TRIAGE_START}-${TRIAGE_END}"
+
+if [ "${TRIAGE_START}" -gt "${DIFF_COUNT}" ]; then
+  echo ""
+  echo "=== TRIAGE_EMPTY ==="
+  echo "--start-index ${TRIAGE_START} выходит за пределы списка diff'ов (${DIFF_COUNT})"
+  exit 0
+fi
+
+emit_triage_diffs "${TRIAGE_START}" "${TRIAGE_END}"

--- a/docs/superpowers/plans/2026-06-19-functional-options-parameter-root.md
+++ b/docs/superpowers/plans/2026-06-19-functional-options-parameter-root.md
@@ -1,0 +1,199 @@
+# FunctionalOptionsParameter Root Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix subsystem content round-trip so `ПараметрФункциональныхОпций.*` maps to canonical `FunctionalOptionsParameter.*`, not erroneous `FunctionalOptionParameter.*`.
+
+**Architecture:** Keep a single canonical metadata target root, `FunctionalOptionsParameter`, across target parsing, formatting, metadata path typing, and subsystem allowed content paths. Do not change XML fixtures, YAML Russian names, or metadata item rules.
+
+**Tech Stack:** TypeScript, Vitest, pnpm, existing metadata `rules.ts` and metadata target helpers.
+
+---
+
+## File Structure
+
+- Modify `packages/core/metadata/commonObjects/metadataTargets/parse.test.ts`: prove YAML root `ПараметрФункциональныхОпций` parses/formats through canonical `FunctionalOptionsParameter`.
+- Modify `packages/core/metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts`: prove subsystem `Состав` imports YAML functional option parameter links into canonical model links.
+- Modify `packages/core/metadata/commonObjects/metadataTargets/types.ts`: remove erroneous `FunctionalOptionParameter` root from `MetadataRootName`.
+- Modify `packages/core/metadata/commonObjects/metadataTargets/roots.ts`: remove duplicate Russian-root mapping for `FunctionalOptionParameter`.
+- Modify `packages/core/metadata/commonObjects/metadataPath/types.ts`: remove erroneous metadata path root mapping.
+- Modify `packages/core/metadata/appliedObjects/metadataSubsystem/rules.ts`: remove erroneous allowed subsystem content path.
+
+### Task 1: Add Failing Coverage
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/metadataTargets/parse.test.ts`
+- Modify: `packages/core/metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts`
+
+- [ ] **Step 1: Update metadata target parse/format expectation**
+
+In `packages/core/metadata/commonObjects/metadataTargets/parse.test.ts`, change the functional options parameter case in `parses and formats additional top-level roots used by subsystem content` to:
+
+```ts
+[
+  "ПараметрФункциональныхОпций.ПараметрФункциональныхОпцийВсеСвойства",
+  "FunctionalOptionsParameter.ПараметрФункциональныхОпцийВсеСвойства",
+  "FunctionalOptionsParameter",
+],
+```
+
+- [ ] **Step 2: Add subsystem YAML import coverage**
+
+In `packages/core/metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts`, after `exports functional options parameter links from XML model content`, add:
+
+```ts
+it("imports functional options parameter links to XML model content", () => {
+  expect(
+    importMetadataItemFromYAML({
+      context: mockContext,
+      rule: MetadataSubsystemRules,
+      name: "СтандартныеПодсистемы",
+      yaml: {
+        Состав: ["ПараметрФункциональныхОпций.ПараметрФункциональныхОпцийВсеСвойства"],
+      },
+    })
+  ).toMatchObject({
+    content: ["FunctionalOptionsParameter.ПараметрФункциональныхОпцийВсеСвойства"],
+  })
+})
+```
+
+- [ ] **Step 3: Run focused tests and confirm failure**
+
+Run:
+
+```bash
+pnpm --dir packages/core exec vitest run metadata/commonObjects/metadataTargets/parse.test.ts metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts
+```
+
+Expected before implementation: at least the new/updated functional options parameter assertions fail because YAML still resolves to `FunctionalOptionParameter`.
+
+### Task 2: Remove Erroneous Root
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/metadataTargets/types.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataTargets/roots.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataPath/types.ts`
+- Modify: `packages/core/metadata/appliedObjects/metadataSubsystem/rules.ts`
+
+- [ ] **Step 1: Remove root from metadata target type**
+
+In `packages/core/metadata/commonObjects/metadataTargets/types.ts`, remove this union member:
+
+```ts
+| "FunctionalOptionParameter"
+```
+
+- [ ] **Step 2: Remove duplicate metadata target root mapping**
+
+In `packages/core/metadata/commonObjects/metadataTargets/roots.ts`, remove this property:
+
+```ts
+FunctionalOptionParameter: "ПараметрФункциональныхОпций",
+```
+
+Keep:
+
+```ts
+FunctionalOptionsParameter: "ПараметрФункциональныхОпций",
+```
+
+- [ ] **Step 3: Remove metadata path root mapping**
+
+In `packages/core/metadata/commonObjects/metadataPath/types.ts`, remove this property:
+
+```ts
+FunctionalOptionParameter: "ПараметрФункциональныхОпций",
+```
+
+- [ ] **Step 4: Remove erroneous subsystem allowed path**
+
+In `packages/core/metadata/appliedObjects/metadataSubsystem/rules.ts`, remove:
+
+```ts
+["FunctionalOptionParameter"],
+```
+
+Keep:
+
+```ts
+["FunctionalOptionsParameter"],
+```
+
+- [ ] **Step 5: Run focused tests and confirm pass**
+
+Run:
+
+```bash
+pnpm --dir packages/core exec vitest run metadata/commonObjects/metadataTargets/parse.test.ts metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts
+```
+
+Expected: PASS.
+
+### Task 3: Verify Round-Trip Behavior
+
+**Files:**
+- No source edits.
+
+- [ ] **Step 1: Run fast-mode unit tests**
+
+Run:
+
+```bash
+pnpm --dir packages/core exec vitest run metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run `acc` fast round-trip**
+
+Run:
+
+```bash
+NKDK_XML_REPO=/home/nikita/git/round-trip/acc NKDK_XML_DIR=/home/nikita/git/round-trip/acc ./.agents/skills/round-trip-yaml-fast/round-trip.sh
+```
+
+Expected: no `FunctionalOptionsParameter` to `FunctionalOptionParameter` diff. Prefer `DIFF_COUNT=0`; if other unrelated diffs appear, inspect and report them separately.
+
+- [ ] **Step 3: Run full project tests**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: PASS.
+
+### Task 4: Commit
+
+**Files:**
+- Commit all changed files from Tasks 1-3.
+
+- [ ] **Step 1: Inspect diff**
+
+Run:
+
+```bash
+git diff --check
+git diff -- packages/core/metadata/commonObjects/metadataTargets/parse.test.ts packages/core/metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts packages/core/metadata/commonObjects/metadataTargets/types.ts packages/core/metadata/commonObjects/metadataTargets/roots.ts packages/core/metadata/commonObjects/metadataPath/types.ts packages/core/metadata/appliedObjects/metadataSubsystem/rules.ts
+```
+
+Expected: no whitespace errors; diff only removes erroneous singular root and adds canonical import coverage.
+
+- [ ] **Step 2: Commit**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/metadataTargets/parse.test.ts packages/core/metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts packages/core/metadata/commonObjects/metadataTargets/types.ts packages/core/metadata/commonObjects/metadataTargets/roots.ts packages/core/metadata/commonObjects/metadataPath/types.ts packages/core/metadata/appliedObjects/metadataSubsystem/rules.ts docs/superpowers/plans/2026-06-19-functional-options-parameter-root.md
+git commit -m "fix: :bug: исправить root FunctionalOptionsParameter"
+```
+
+Expected: commit succeeds.
+
+## Self-Review
+
+- Spec coverage: the plan removes `FunctionalOptionParameter` from every runtime file listed in the spec, keeps `FunctionalOptionsParameter`, keeps Russian YAML `ПараметрФункциональныхОпций`, and verifies parser, subsystem import/export, fast round-trip, and full tests.
+- Placeholder scan: no `TBD`, `TODO`, “similar”, or unspecified test steps.
+- Type consistency: all planned code uses `FunctionalOptionsParameter` as the canonical root and `ПараметрФункциональныхОпций` as the YAML root.

--- a/docs/superpowers/plans/2026-06-19-round-trip-yaml-fast.md
+++ b/docs/superpowers/plans/2026-06-19-round-trip-yaml-fast.md
@@ -1,0 +1,986 @@
+# Round Trip YAML Fast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `round-trip-yaml-fast`, a fast diagnostic path for `XML -> модель -> YAML-текст -> модель -> XML` metadata diffs without writing YAML/XML output trees.
+
+**Architecture:** Add a focused core module that runs one in-memory round-trip per top-level metadata XML file and returns structured diff/error records. Expose it through a small CLI command, then wrap the CLI with a Codex skill script that provides single and triage workflows. Keep existing `syncConfigurationFromXML`, `syncConfigurationToXML`, and full `round-trip-yaml` untouched.
+
+**Tech Stack:** TypeScript, Vitest, Commander, Bash, existing `@nakidka/core` metadata orchestration, `fast-xml-parser`, `yaml`, `pnpm`.
+
+---
+
+## Scope Check
+
+The spec covers one subsystem with three layers that depend on each other:
+
+- core fast round-trip engine;
+- CLI command over that engine;
+- Codex skill wrapper over the CLI.
+
+This is suitable for one implementation plan. The tasks below keep those layers independently testable.
+
+## File Structure
+
+- Create `packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.ts`.
+  - Responsibility: discover supported top-level metadata XML files, run in-memory XML/YAML/XML round-trip, format small unified diffs, return structured results.
+- Create `packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts`.
+  - Responsibility: prove YAML goes through text, XML is not written, clean/diff/error cases are represented.
+- Modify `packages/core/index.ts`.
+  - Responsibility: export `roundTripYAMLFast` and related result types for CLI use.
+- Create `packages/cli/src/commands/roundTripYAMLFast.ts`.
+  - Responsibility: call core, print machine-readable blocks, set exit code only for processing errors.
+- Create `packages/cli/src/commands/roundTripYAMLFast.test.ts`.
+  - Responsibility: test command output for clean, diff, and error cases through the public command function.
+- Modify `packages/cli/src/cli.ts`.
+  - Responsibility: register `nkdk round-trip-yaml-fast <xml-dir>`.
+- Create `.agents/skills/round-trip-yaml-fast/SKILL.md`.
+  - Responsibility: document how Codex should run and interpret fast diagnostics.
+- Create `.agents/skills/round-trip-yaml-fast/round-trip.sh`.
+  - Responsibility: read `.env`, resolve XML dirs, run CLI, and select single/triage output.
+
+## Task 1: Core Fast Round-Trip Engine
+
+**Files:**
+- Create: `packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.ts`
+- Test: `packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts`
+- Modify: `packages/core/index.ts`
+
+- [ ] **Step 1: Read required metadata knowledge**
+
+Run:
+
+```bash
+sed -n '1,220p' .agents/knowledge/metadata/INDEX.md
+sed -n '1,220p' .agents/knowledge/metadata/sources-of-truth.md
+sed -n '1,220p' .agents/knowledge/metadata/round-trip-cycle.md
+sed -n '1,220p' .agents/knowledge/metadata/yaml-contract.md
+```
+
+Expected: documents are read before editing `packages/core/metadata/**`.
+
+- [ ] **Step 2: Write failing core tests**
+
+Create `packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts`:
+
+```ts
+import fs from "fs"
+import os from "os"
+import { join } from "path"
+import { describe, expect, it } from "vitest"
+import { roundTripYAMLFast } from "./roundTripYAMLFast"
+
+const enumXml = (params: { name: string; choiceMode?: string }): string => `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Enum uuid="d381585b-33ee-4f3e-9362-ae06f761f29d">
+    <Properties>
+      <Name>${params.name}</Name>
+      <Synonym>
+        <v8:item>
+          <v8:lang>ru</v8:lang>
+          <v8:content>${params.name}</v8:content>
+        </v8:item>
+      </Synonym>
+      <Comment/>
+      <UseStandardCommands>false</UseStandardCommands>
+      <QuickChoice>true</QuickChoice>
+      ${params.choiceMode === undefined ? "" : `<ChoiceMode>${params.choiceMode}</ChoiceMode>`}
+      <DefaultListForm/>
+      <DefaultChoiceForm/>
+      <AuxiliaryListForm/>
+      <AuxiliaryChoiceForm/>
+      <ListPresentation/>
+      <ExtendedListPresentation/>
+      <Explanation/>
+      <ChoiceHistoryOnInput>Auto</ChoiceHistoryOnInput>
+    </Properties>
+    <ChildObjects/>
+  </Enum>
+</MetaDataObject>`
+
+const makeXmlProject = (xml: string): string => {
+  const dir = fs.mkdtempSync(join(os.tmpdir(), "nkdk-round-trip-yaml-fast-"))
+  fs.mkdirSync(join(dir, "Enums"), { recursive: true })
+  fs.writeFileSync(join(dir, "Enums", "ВидыСервисовЭДО.xml"), xml, "utf-8")
+  return dir
+}
+
+describe("roundTripYAMLFast", () => {
+  it("returns no diffs for stable metadata xml", async () => {
+    const xmlDir = makeXmlProject(enumXml({ name: "ВидыСервисовЭДО", choiceMode: "BothWays" }))
+    try {
+      const result = await roundTripYAMLFast({ inputDir: xmlDir })
+
+      expect(result.errors).toEqual([])
+      expect(result.diffs).toEqual([])
+      expect(result.checked).toBe(1)
+    } finally {
+      fs.rmSync(xmlDir, { recursive: true, force: true })
+    }
+  })
+
+  it("reports a diff produced by yaml text round-trip", async () => {
+    const xmlDir = makeXmlProject(enumXml({ name: "ВидыСервисовЭДО" }))
+    try {
+      const result = await roundTripYAMLFast({ inputDir: xmlDir })
+
+      expect(result.errors).toEqual([])
+      expect(result.diffs).toHaveLength(1)
+      expect(result.diffs[0]?.file).toBe("Enums/ВидыСервисовЭДО.xml")
+      expect(result.diffs[0]?.xmlFileAbs).toBe(join(xmlDir, "Enums", "ВидыСервисовЭДО.xml"))
+      expect(result.diffs[0]?.diffText).toContain("--- Enums/ВидыСервисовЭДО.xml")
+      expect(result.diffs[0]?.diffText).toContain("+++ Enums/ВидыСервисовЭДО.xml.fast")
+    } finally {
+      fs.rmSync(xmlDir, { recursive: true, force: true })
+    }
+  })
+
+  it("keeps going and records per-file errors", async () => {
+    const xmlDir = makeXmlProject("<MetaDataObject><Enum><Properties><Name>Bad</Name>")
+    try {
+      const result = await roundTripYAMLFast({ inputDir: xmlDir })
+
+      expect(result.checked).toBe(1)
+      expect(result.diffs).toEqual([])
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]?.file).toBe("Enums/ВидыСервисовЭДО.xml")
+      expect(result.errors[0]?.message.length).toBeGreaterThan(0)
+    } finally {
+      fs.rmSync(xmlDir, { recursive: true, force: true })
+    }
+  })
+})
+```
+
+- [ ] **Step 3: Run core tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --dir packages/core exec vitest run metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts
+```
+
+Expected: FAIL with an import error for `./roundTripYAMLFast`.
+
+- [ ] **Step 4: Implement core module**
+
+Create `packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.ts`:
+
+```ts
+import fs from "fs"
+import { basename, join } from "path"
+import { ConfigurationContext, ConfigurationContextFromXML, ConfigurationContextWithExportToXML } from "~/metadata/context/types"
+import { exportMetadataItemToXML, exportMetadataItemToYAML, importMetadataItemFromXML, importMetadataItemFromYAML } from "~/metadata/orchestration"
+import type { MetadataItemRule } from "~/metadata/orchestration"
+import { xmlExport } from "~/xml/export/exporter"
+import { importContentFromXML } from "~/xml/import/importer"
+import { exportToYAML } from "~/yaml/export"
+import { importFromYAML } from "~/yaml/import"
+import { TopLevelMetadataItemRules } from "./topLevelRules"
+
+export interface RoundTripYAMLFastParams {
+  inputDir: string
+}
+
+export interface RoundTripYAMLFastDiff {
+  file: string
+  xmlFileAbs: string
+  diffText: string
+}
+
+export interface RoundTripYAMLFastError {
+  file: string
+  xmlFileAbs: string
+  message: string
+}
+
+export interface RoundTripYAMLFastResult {
+  checked: number
+  diffs: RoundTripYAMLFastDiff[]
+  errors: RoundTripYAMLFastError[]
+}
+
+const makeContextFromXML = (forReference: boolean): ConfigurationContextFromXML => ({
+  defaultLanguage: "ru",
+  version: "2.20",
+  fromXML: { forReference },
+})
+
+const makeContextToYAML = (): ConfigurationContext => ({
+  defaultLanguage: "ru",
+  version: "2.20",
+  exportToYAML: { toTyped: false },
+})
+
+const makeContextFromYAML = (): ConfigurationContext => ({
+  defaultLanguage: "ru",
+  version: "2.20",
+})
+
+const makeContextToXML = (parentName: string): ConfigurationContextWithExportToXML => ({
+  defaultLanguage: "ru",
+  version: "2.20",
+  exportToXML: {
+    itemsTree: [],
+    configDumpInfo: new Map(),
+    version: "2.20",
+    context: {
+      forms: [],
+      templates: [],
+      parentName,
+      metadataForNumbering: [],
+    },
+  },
+})
+
+const normalizeFinalNewline = (text: string): string => text.endsWith("\n") ? text : `${text}\n`
+
+function createUnifiedDiff(params: {
+  file: string
+  original: string
+  generated: string
+}): string {
+  const original = normalizeFinalNewline(params.original).split("\n")
+  const generated = normalizeFinalNewline(params.generated).split("\n")
+  let start = 0
+  while (start < original.length && start < generated.length && original[start] === generated[start]) start += 1
+
+  let originalEnd = original.length - 1
+  let generatedEnd = generated.length - 1
+  while (originalEnd >= start && generatedEnd >= start && original[originalEnd] === generated[generatedEnd]) {
+    originalEnd -= 1
+    generatedEnd -= 1
+  }
+
+  const contextStart = Math.max(0, start - 3)
+  const contextOriginalEnd = Math.min(original.length - 1, originalEnd + 3)
+  const contextGeneratedEnd = Math.min(generated.length - 1, generatedEnd + 3)
+  const originalCount = contextOriginalEnd - contextStart + 1
+  const generatedCount = contextGeneratedEnd - contextStart + 1
+  const lines = [
+    `--- ${params.file}`,
+    `+++ ${params.file}.fast`,
+    `@@ -${contextStart + 1},${originalCount} +${contextStart + 1},${generatedCount} @@`,
+  ]
+
+  for (let index = contextStart; index <= contextOriginalEnd; index += 1) {
+    if (index < start || index > originalEnd) lines.push(` ${original[index] ?? ""}`)
+    else lines.push(`-${original[index] ?? ""}`)
+  }
+  for (let index = contextStart; index <= contextGeneratedEnd; index += 1) {
+    if (index < start || index > generatedEnd) continue
+    lines.push(`+${generated[index] ?? ""}`)
+  }
+
+  return lines.join("\n")
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function setName(model: unknown, name: string): void {
+  if (isObjectRecord(model)) model.name = name
+}
+
+function roundTripOne(params: {
+  rule: MetadataItemRule
+  itemName: string
+  relativeFile: string
+  xmlFileAbs: string
+  xmlText: string
+}): RoundTripYAMLFastDiff | undefined {
+  const parsed = importContentFromXML<{ MetaDataObject: unknown }>(params.xmlText)
+  const model = importMetadataItemFromXML({
+    context: makeContextFromXML(false),
+    xml: parsed.MetaDataObject,
+    rule: params.rule,
+  })
+  const referenceModel = importMetadataItemFromXML({
+    context: makeContextFromXML(true),
+    xml: parsed.MetaDataObject,
+    rule: params.rule,
+  })
+  setName(model, params.itemName)
+  setName(referenceModel, params.itemName)
+
+  const yamlObject = exportMetadataItemToYAML({
+    context: makeContextToYAML(),
+    data: model,
+    rule: params.rule,
+  })
+  const yamlText = yamlObject === undefined ? "" : exportToYAML(yamlObject)
+  const yamlObjectFromText = yamlText === "" ? undefined : importFromYAML(yamlText)
+  const modelFromYAML = importMetadataItemFromYAML({
+    context: makeContextFromYAML(),
+    yaml: yamlObjectFromText,
+    rule: params.rule,
+    source: referenceModel,
+    name: params.itemName,
+  })
+  setName(modelFromYAML, params.itemName)
+
+  const xmlObject = exportMetadataItemToXML({
+    context: makeContextToXML(params.itemName),
+    data: modelFromYAML,
+    referenceData: referenceModel,
+    rule: params.rule,
+  })
+  const xmlText = xmlObject === undefined ? "" : xmlExport(xmlObject)
+
+  if (normalizeFinalNewline(params.xmlText) === normalizeFinalNewline(xmlText)) return undefined
+
+  return {
+    file: params.relativeFile,
+    xmlFileAbs: params.xmlFileAbs,
+    diffText: createUnifiedDiff({
+      file: params.relativeFile,
+      original: params.xmlText,
+      generated: xmlText,
+    }),
+  }
+}
+
+export async function roundTripYAMLFast(params: RoundTripYAMLFastParams): Promise<RoundTripYAMLFastResult> {
+  const result: RoundTripYAMLFastResult = { checked: 0, diffs: [], errors: [] }
+
+  for (const rule of TopLevelMetadataItemRules) {
+    if (rule.xmlDir === undefined || rule.itemTypePrefix === undefined) continue
+    const itemDir = join(params.inputDir, rule.xmlDir)
+    if (!fs.existsSync(itemDir)) continue
+
+    const entries = await fs.promises.readdir(itemDir, { withFileTypes: true })
+    const xmlFiles = entries.filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".xml"))
+
+    for (const entry of xmlFiles) {
+      const itemName = basename(entry.name, ".xml")
+      const relativeFile = `${rule.xmlDir}/${entry.name}`
+      const xmlFileAbs = join(itemDir, entry.name)
+      result.checked += 1
+
+      try {
+        const xmlText = await fs.promises.readFile(xmlFileAbs, "utf-8")
+        const diff = roundTripOne({ rule, itemName, relativeFile, xmlFileAbs, xmlText })
+        if (diff !== undefined) result.diffs.push(diff)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        result.errors.push({ file: relativeFile, xmlFileAbs, message })
+      }
+    }
+  }
+
+  return result
+}
+```
+
+- [ ] **Step 5: Export core API**
+
+Modify `packages/core/index.ts` and add this export near `shortRoundTripXML`:
+
+```ts
+export {
+  roundTripYAMLFast,
+  type RoundTripYAMLFastDiff,
+  type RoundTripYAMLFastError,
+  type RoundTripYAMLFastParams,
+  type RoundTripYAMLFastResult,
+} from "./metadata/appliedObjects/configuration/roundTripYAMLFast"
+```
+
+- [ ] **Step 6: Run core tests and fix only compile/runtime issues in this task**
+
+Run:
+
+```bash
+pnpm --dir packages/core exec vitest run metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts
+```
+
+Expected: PASS. If TypeScript reports `MetadataItemRule` is not exported from `~/metadata/orchestration`, import it from `~/metadata/orchestration/property/types` instead.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.ts packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts packages/core/index.ts
+git commit -m "feat: :sparkles: добавить быстрый YAML round-trip"
+```
+
+## Task 2: CLI Command
+
+**Files:**
+- Create: `packages/cli/src/commands/roundTripYAMLFast.ts`
+- Test: `packages/cli/src/commands/roundTripYAMLFast.test.ts`
+- Modify: `packages/cli/src/cli.ts`
+
+- [ ] **Step 1: Write failing command tests**
+
+Create `packages/cli/src/commands/roundTripYAMLFast.test.ts`:
+
+```ts
+import fs from "fs"
+import os from "os"
+import { join } from "path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { roundTripYAMLFastCommand } from "./roundTripYAMLFast"
+
+const enumXml = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+  <Enum uuid="d381585b-33ee-4f3e-9362-ae06f761f29d">
+    <Properties>
+      <Name>ВидыСервисовЭДО</Name>
+      <Synonym>
+        <v8:item>
+          <v8:lang>ru</v8:lang>
+          <v8:content>ВидыСервисовЭДО</v8:content>
+        </v8:item>
+      </Synonym>
+      <Comment/>
+      <UseStandardCommands>false</UseStandardCommands>
+      <QuickChoice>true</QuickChoice>
+      <DefaultListForm/>
+      <DefaultChoiceForm/>
+      <AuxiliaryListForm/>
+      <AuxiliaryChoiceForm/>
+      <ListPresentation/>
+      <ExtendedListPresentation/>
+      <Explanation/>
+      <ChoiceHistoryOnInput>Auto</ChoiceHistoryOnInput>
+    </Properties>
+    <ChildObjects/>
+  </Enum>
+</MetaDataObject>`
+
+describe("roundTripYAMLFastCommand", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    process.exitCode = undefined
+  })
+
+  it("prints machine-readable diff blocks", async () => {
+    const tmp = fs.mkdtempSync(join(os.tmpdir(), "nkdk-cli-round-trip-yaml-fast-"))
+    const xmlDir = join(tmp, "xml")
+    fs.mkdirSync(join(xmlDir, "Enums"), { recursive: true })
+    fs.writeFileSync(join(xmlDir, "Enums", "ВидыСервисовЭДО.xml"), enumXml, "utf-8")
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+
+    try {
+      await roundTripYAMLFastCommand(xmlDir)
+
+      const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
+      expect(output).toContain("=== DIFF_COUNT ===")
+      expect(output).toContain("=== DIFF ===")
+      expect(output).toContain("FILE: Enums/ВидыСервисовЭДО.xml")
+      expect(output).toContain("XML_FILE_ABS: ")
+      expect(output).toContain("--- DIFF ---")
+      expect(process.exitCode).toBeUndefined()
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it("prints clean marker when there are no supported files", async () => {
+    const tmp = fs.mkdtempSync(join(os.tmpdir(), "nkdk-cli-round-trip-yaml-fast-empty-"))
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+
+    try {
+      await roundTripYAMLFastCommand(tmp)
+
+      const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join("")
+      expect(output).toContain("=== DIFF_COUNT ===")
+      expect(output).toContain("0")
+      expect(output).toContain("=== Round-trip fast чистый: диффов нет ===")
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run command tests and verify they fail**
+
+Run:
+
+```bash
+pnpm --dir packages/cli exec vitest run src/commands/roundTripYAMLFast.test.ts
+```
+
+Expected: FAIL with an import error for `./roundTripYAMLFast`.
+
+- [ ] **Step 3: Implement CLI command function**
+
+Create `packages/cli/src/commands/roundTripYAMLFast.ts`:
+
+```ts
+import { roundTripYAMLFast } from "@nakidka/core"
+
+export const roundTripYAMLFastCommand = async (xmlDir: string): Promise<void> => {
+  const result = await roundTripYAMLFast({ inputDir: xmlDir })
+
+  process.stdout.write("=== ROUND_TRIP_YAML_FAST ===\n")
+  process.stdout.write(`XML_DIR: ${xmlDir}\n`)
+  process.stdout.write(`CHECKED: ${result.checked}\n`)
+  process.stdout.write("\n=== DIFF_COUNT ===\n")
+  process.stdout.write(`${result.diffs.length}\n`)
+
+  for (let i = 0; i < result.diffs.length; i += 1) {
+    const diff = result.diffs[i]!
+    process.stdout.write("\n=== DIFF ===\n")
+    process.stdout.write(`INDEX: ${i + 1}\n`)
+    process.stdout.write(`FILE: ${diff.file}\n`)
+    process.stdout.write(`XML_FILE_ABS: ${diff.xmlFileAbs}\n`)
+    process.stdout.write("--- DIFF ---\n")
+    process.stdout.write(`${diff.diffText}\n`)
+  }
+
+  if (result.errors.length > 0) {
+    process.stdout.write("\n=== ERRORS ===\n")
+    for (const error of result.errors) {
+      process.stdout.write(`FILE: ${error.file}\n`)
+      process.stdout.write(`XML_FILE_ABS: ${error.xmlFileAbs}\n`)
+      process.stdout.write(`MESSAGE: ${error.message}\n`)
+    }
+    process.exitCode = 1
+    return
+  }
+
+  if (result.diffs.length === 0) {
+    process.stdout.write("\n=== Round-trip fast чистый: диффов нет ===\n")
+  }
+}
+```
+
+- [ ] **Step 4: Register CLI command**
+
+Modify `packages/cli/src/cli.ts`.
+
+Add import:
+
+```ts
+import { roundTripYAMLFastCommand } from "./commands/roundTripYAMLFast"
+```
+
+Add command after `short-round-trip-test`:
+
+```ts
+  program
+    .command("round-trip-yaml-fast")
+    .description("Быстрая диагностика metadata round-trip XML → модель → YAML-текст → модель → XML")
+    .argument("<xml-dir>", "путь к каталогу XML-выгрузки")
+    .action((xmlDir: string) => {
+      run(() => roundTripYAMLFastCommand(xmlDir), options)
+    })
+```
+
+- [ ] **Step 5: Run CLI command tests**
+
+Run:
+
+```bash
+pnpm --dir packages/cli exec vitest run src/commands/roundTripYAMLFast.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Add parser smoke test**
+
+Modify `packages/cli/src/cli.test.ts` and add inside `describe("cli", () => { ... })`:
+
+```ts
+  it("registers round-trip-yaml-fast command", () => {
+    const program = createProgram()
+    const commandNames = program.commands.map((command) => command.name())
+
+    expect(commandNames).toContain("round-trip-yaml-fast")
+  })
+```
+
+- [ ] **Step 7: Run CLI tests**
+
+Run:
+
+```bash
+pnpm --dir packages/cli test
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add packages/cli/src/commands/roundTripYAMLFast.ts packages/cli/src/commands/roundTripYAMLFast.test.ts packages/cli/src/cli.ts packages/cli/src/cli.test.ts
+git commit -m "feat: :sparkles: добавить команду round-trip-yaml-fast"
+```
+
+## Task 3: Skill Wrapper
+
+**Files:**
+- Create: `.agents/skills/round-trip-yaml-fast/SKILL.md`
+- Create: `.agents/skills/round-trip-yaml-fast/round-trip.sh`
+
+- [ ] **Step 1: Write skill documentation**
+
+Create `.agents/skills/round-trip-yaml-fast/SKILL.md`:
+
+```md
+---
+name: round-trip-yaml-fast
+description: Быстро диагностирует metadata round-trip XML -> модель -> YAML-текст -> модель -> XML без записи YAML/XML каталогов.
+---
+
+# round-trip-yaml-fast — быстрая диагностика metadata round-trip
+
+Перед диагностикой metadata round-trip обязательно прочитай:
+
+1. `.agents/knowledge/metadata/INDEX.md`
+2. `.agents/knowledge/metadata/sources-of-truth.md`
+3. `.agents/knowledge/metadata/round-trip-cycle.md`
+4. `.agents/knowledge/metadata/yaml-contract.md`
+
+## Что делает скилл
+
+Скилл запускает быстрый цикл:
+
+```text
+XML -> модель -> YAML-текст -> модель -> XML
+```
+
+Он не пишет временный YAML-проект, не пишет временный XML-каталог, не меняет XML-репо и не проверяет внешние файлы `.bsl`, `.txt`, `.bin`, `.png`.
+
+Полный `.agents/skills/round-trip-yaml/round-trip.sh` остаётся источником истины для проверки внешних файлов, удаления файлов и поведения полного файлового sync.
+
+## Режимы
+
+```bash
+./.agents/skills/round-trip-yaml-fast/round-trip.sh
+./.agents/skills/round-trip-yaml-fast/round-trip.sh --diff-index 3
+./.agents/skills/round-trip-yaml-fast/round-trip.sh --triage --batch-size 5
+./.agents/skills/round-trip-yaml-fast/round-trip.sh --triage --batch-size 5 --start-index 6
+```
+
+## Правила ответа
+
+Single-режим показывает:
+
+```text
+XML-файл: <абсолютный локальный путь из XML_FILE_ABS>
+XML-каталог: <значение ACTIVE_XML_DIR>
+Diff: <FILE>
+Категория: YAML-default / потеря пустого тега / порядок XML-узлов / потеря атрибута / неизвестно
+Описание: <что изменилось при fast round-trip>
+Diff:
+<полный diff или релевантный фрагмент>
+Сомнения: <если есть>
+```
+
+Triage-режим показывает каждый diff отдельно и не объединяет похожие пункты.
+
+Если скрипт пишет `=== Round-trip fast чистый: диффов нет ===`, остановись: fast-расхождений нет.
+```
+
+- [ ] **Step 2: Write shell wrapper**
+
+Create `.agents/skills/round-trip-yaml-fast/round-trip.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+MODE="single"
+DIFF_INDEX="1"
+BATCH_SIZE="5"
+START_INDEX="1"
+
+usage() {
+  cat <<'USAGE'
+Использование:
+  ./.agents/skills/round-trip-yaml-fast/round-trip.sh
+  ./.agents/skills/round-trip-yaml-fast/round-trip.sh --diff-index N
+  ./.agents/skills/round-trip-yaml-fast/round-trip.sh --triage [--batch-size N] [--start-index K]
+USAGE
+}
+
+die() {
+  echo "Ошибка: $*" >&2
+  exit 1
+}
+
+is_positive_integer() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+KNOWN_XML_DIRS=("Catalogs" "Documents" "DocumentNumerators" "Sequences" "Enums")
+
+is_config_dir() {
+  local candidate="$1"
+  local xml_dir
+  for xml_dir in "${KNOWN_XML_DIRS[@]}"; do
+    if [ -d "${candidate}/${xml_dir}" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+collect_run_dirs() {
+  local root="$1"
+  local child
+  if is_config_dir "${root}"; then
+    printf '%s\n' "${root}"
+    return 0
+  fi
+  while IFS= read -r child; do
+    if is_config_dir "${child}"; then
+      printf '%s\n' "${child}"
+    fi
+  done < <(find "${root}" -mindepth 1 -maxdepth 1 -type d | sort)
+}
+
+emit_single_diff() {
+  local index="$1"
+  awk -v target="${index}" '
+    /^=== DIFF ===$/ {
+      if (in_block == 1 && block_index == target) {
+        printf "%s", block
+        exit
+      }
+      block = $0 "\n"
+      in_block = 1
+      block_index = 0
+      next
+    }
+    in_block == 1 {
+      block = block $0 "\n"
+      if ($0 ~ /^INDEX: /) {
+        block_index = substr($0, 8) + 0
+      }
+    }
+    END {
+      if (in_block == 1 && block_index == target) {
+        printf "%s", block
+      }
+    }
+  ' <<<"${OUTPUT}"
+}
+
+emit_triage_diffs() {
+  local start="$1"
+  local end="$2"
+  awk -v start="${start}" -v end="${end}" '
+    /^=== DIFF ===$/ {
+      if (in_block == 1 && block_index >= start && block_index <= end) {
+        printf "%s", block
+      }
+      block = $0 "\n"
+      in_block = 1
+      block_index = 0
+      next
+    }
+    in_block == 1 {
+      block = block $0 "\n"
+      if ($0 ~ /^INDEX: /) {
+        block_index = substr($0, 8) + 0
+      }
+    }
+    END {
+      if (in_block == 1 && block_index >= start && block_index <= end) {
+        printf "%s", block
+      }
+    }
+  ' <<<"${OUTPUT}"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --diff-index)
+      [ "$#" -ge 2 ] || die "--diff-index требует значение"
+      is_positive_integer "$2" || die "--diff-index должен быть положительным целым числом"
+      DIFF_INDEX="$2"
+      shift 2
+      ;;
+    --triage)
+      MODE="triage"
+      shift
+      ;;
+    --batch-size)
+      [ "$#" -ge 2 ] || die "--batch-size требует значение"
+      is_positive_integer "$2" || die "--batch-size должен быть положительным целым числом"
+      BATCH_SIZE="$2"
+      shift 2
+      ;;
+    --start-index)
+      [ "$#" -ge 2 ] || die "--start-index требует значение"
+      is_positive_integer "$2" || die "--start-index должен быть положительным целым числом"
+      START_INDEX="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "неизвестный параметр: $1"
+      ;;
+  esac
+done
+
+if [ -f "${REPO_DIR}/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${REPO_DIR}/.env"
+  set +a
+fi
+
+[ -n "${NKDK_XML_REPO:-}" ] || die "переменная NKDK_XML_REPO не задана"
+NKDK_XML_DIR="${NKDK_XML_DIR:-${NKDK_XML_REPO}}"
+[ -d "${NKDK_XML_DIR}" ] || die "NKDK_XML_DIR ('${NKDK_XML_DIR}') не существует"
+NKDK_XML_DIR="$(cd "${NKDK_XML_DIR}" && pwd)"
+
+if command -v nkdk &>/dev/null; then
+  NKDK=(nkdk)
+else
+  NKDK=(pnpm -s --dir "${REPO_DIR}/packages/cli" exec tsx src/cli.ts)
+fi
+
+RUN_DIRS=()
+while IFS= read -r run_dir; do
+  RUN_DIRS+=("${run_dir}")
+done < <(collect_run_dirs "${NKDK_XML_DIR}")
+
+[ "${#RUN_DIRS[@]}" -gt 0 ] || die "в NKDK_XML_DIR не найдено конфигурационных каталогов"
+
+ACTIVE_XML_DIR="${RUN_DIRS[0]}"
+OUTPUT="$("${NKDK[@]}" round-trip-yaml-fast "${ACTIVE_XML_DIR}")"
+DIFF_COUNT="$(printf '%s\n' "${OUTPUT}" | awk '/=== DIFF_COUNT ===/{getline; print; exit}')"
+DIFF_COUNT="${DIFF_COUNT:-0}"
+
+echo "=== ACTIVE_XML_DIR ==="
+echo "${ACTIVE_XML_DIR}"
+echo ""
+echo "=== DIFF_COUNT ==="
+echo "${DIFF_COUNT}"
+
+if [ "${DIFF_COUNT}" -eq 0 ]; then
+  echo ""
+  echo "=== Round-trip fast чистый: диффов нет ==="
+  exit 0
+fi
+
+if [ "${MODE}" = "single" ] && [ "${DIFF_INDEX}" -gt "${DIFF_COUNT}" ]; then
+  die "--diff-index ${DIFF_INDEX} выходит за пределы списка diff'ов (${DIFF_COUNT})"
+fi
+
+if [ "${MODE}" = "single" ]; then
+  echo ""
+  emit_single_diff "${DIFF_INDEX}"
+  exit 0
+fi
+
+if [ "${MODE}" = "triage" ]; then
+  TRIAGE_END="$((START_INDEX + BATCH_SIZE - 1))"
+  if [ "${TRIAGE_END}" -gt "${DIFF_COUNT}" ]; then
+    TRIAGE_END="${DIFF_COUNT}"
+  fi
+  echo ""
+  echo "=== TRIAGE_RANGE ==="
+  echo "${START_INDEX}-${TRIAGE_END}"
+  emit_triage_diffs "${START_INDEX}" "${TRIAGE_END}"
+fi
+```
+
+- [ ] **Step 3: Make wrapper executable and run help**
+
+Run:
+
+```bash
+chmod +x .agents/skills/round-trip-yaml-fast/round-trip.sh
+./.agents/skills/round-trip-yaml-fast/round-trip.sh --help
+```
+
+Expected: output contains `--diff-index`, `--triage`, `--batch-size`, and `--start-index`.
+
+- [ ] **Step 4: Commit Task 3**
+
+```bash
+git add .agents/skills/round-trip-yaml-fast/SKILL.md .agents/skills/round-trip-yaml-fast/round-trip.sh
+git commit -m "docs: :memo: добавить skill round-trip-yaml-fast"
+```
+
+## Task 4: End-to-End Verification and Cleanup
+
+**Files:**
+- Modify if needed: `docs/superpowers/specs/2026-06-19-round-trip-yaml-fast-design.md`
+- Modify if needed: `docs/superpowers/plans/2026-06-19-round-trip-yaml-fast.md`
+
+- [ ] **Step 1: Run targeted core tests**
+
+Run:
+
+```bash
+pnpm --dir packages/core exec vitest run metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run targeted CLI tests**
+
+Run:
+
+```bash
+pnpm --dir packages/cli exec vitest run src/commands/roundTripYAMLFast.test.ts src/cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run type check**
+
+Run:
+
+```bash
+pnpm type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Try CLI on a small fixture directory**
+
+Run:
+
+```bash
+pnpm -s --dir packages/cli exec tsx src/cli.ts round-trip-yaml-fast ../core/metadata/appliedObjects/configuration/__fixtures__/syncConfiguration/xml
+```
+
+Expected: command prints `=== ROUND_TRIP_YAML_FAST ===`, `CHECKED:`, and either `=== Round-trip fast чистый: диффов нет ===` or structured `=== DIFF ===` blocks. It must not create YAML or XML output directories.
+
+- [ ] **Step 6: Review git diff for forbidden changes**
+
+Run:
+
+```bash
+git diff --stat HEAD
+git diff --name-only HEAD
+```
+
+Expected: changed files are limited to core fast module/tests, CLI command/tests, skill files, and documentation. Existing XML fixtures are not modified.
+
+- [ ] **Step 7: Commit final documentation fixes if any**
+
+If Task 4 changed only docs, run:
+
+```bash
+git add docs/superpowers/specs/2026-06-19-round-trip-yaml-fast-design.md docs/superpowers/plans/2026-06-19-round-trip-yaml-fast.md
+git commit -m "docs: :memo: обновить план round-trip-yaml-fast"
+```
+
+If Task 4 changed no files, skip this commit.

--- a/docs/superpowers/specs/2026-06-19-functional-options-parameter-root-design.md
+++ b/docs/superpowers/specs/2026-06-19-functional-options-parameter-root-design.md
@@ -1,0 +1,71 @@
+# FunctionalOptionsParameter Root Design
+
+## Problem
+
+`round-trip-yaml-fast` showed XML diffs where subsystem content references changed from:
+
+```text
+FunctionalOptionsParameter.<name>
+```
+
+to:
+
+```text
+FunctionalOptionParameter.<name>
+```
+
+The singular `FunctionalOptionParameter` root was introduced by mistake. The project metadata item is
+`MetadataFunctionalOptionsParameter`, its XML container is `FunctionalOptionsParameter`, and its XML directory is
+`FunctionalOptionsParameters`.
+
+## Scope
+
+Fix only the metadata target root typo in project code. Do not change XML fixtures, YAML key names, metadata item rules,
+or external file handling.
+
+## Design
+
+Use `FunctionalOptionsParameter` as the only canonical metadata root for functional options parameters.
+
+Remove `FunctionalOptionParameter` from runtime root registries and allowed subsystem content paths:
+
+- `packages/core/metadata/commonObjects/metadataTargets/types.ts`
+- `packages/core/metadata/commonObjects/metadataTargets/roots.ts`
+- `packages/core/metadata/commonObjects/metadataPath/types.ts`
+- `packages/core/metadata/appliedObjects/metadataSubsystem/rules.ts`
+
+Keep the Russian YAML root unchanged:
+
+```text
+ПараметрФункциональныхОпций
+```
+
+That YAML root must parse to canonical model strings with `FunctionalOptionsParameter`, and formatting
+`FunctionalOptionsParameter.<name>` must still produce the same Russian YAML root.
+
+## Tests
+
+Update focused tests so they prove both directions:
+
+- `metadataTargets/parse.test.ts`: `ПараметрФункциональныхОпций.<name>` parses to
+  `FunctionalOptionsParameter.<name>`.
+- `metadataSubsystem/metadataTarget.test.ts`: subsystem `Состав` imports YAML links as
+  `FunctionalOptionsParameter.<name>` and exports the same root back to YAML.
+
+Verification commands:
+
+```bash
+pnpm --dir packages/core exec vitest run metadata/commonObjects/metadataTargets/parse.test.ts metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts
+pnpm --dir packages/core exec vitest run metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts
+NKDK_XML_REPO=/home/nikita/git/round-trip/acc NKDK_XML_DIR=/home/nikita/git/round-trip/acc ./.agents/skills/round-trip-yaml-fast/round-trip.sh
+pnpm test
+```
+
+The `acc` fast round-trip should no longer report a `FunctionalOptionsParameter` to `FunctionalOptionParameter` diff.
+
+## Out Of Scope
+
+- Preserving `FunctionalOptionParameter` as a compatibility alias.
+- Changing YAML Russian names.
+- Changing metadata item implementation for `MetadataFunctionalOptionsParameter`.
+- Fixing unrelated errors such as external data source table parsing.

--- a/docs/superpowers/specs/2026-06-19-round-trip-yaml-fast-design.md
+++ b/docs/superpowers/specs/2026-06-19-round-trip-yaml-fast-design.md
@@ -1,0 +1,154 @@
+# round-trip-yaml-fast design
+
+## Цель
+
+Добавить быстрый диагностический путь `round-trip-yaml-fast` для поиска расхождений в metadata round-trip:
+
+```text
+XML -> модель -> YAML-текст -> модель -> XML
+```
+
+Текущий `round-trip-yaml` остаётся строгой полной проверкой через файловый YAML-проект, временный XML-каталог, замену активного XML-каталога и `git diff`. Новый быстрый путь нужен для ежедневной диагностики правил metadata/YAML, когда важно быстро найти первый diff или triage-пачку без полного файлового цикла.
+
+## Не-цели
+
+- Не заменять полный `.agents/skills/round-trip-yaml/round-trip.sh`.
+- Не проверять содержимое внешних файлов: `.bsl`, `.txt`, `.bin`, `.png` и похожих.
+- Не проверять потерю файлов, которая проявляется только при полном YAML-проекте и замене XML-каталога.
+- Не применять миграции YAML-проекта.
+- Не писать временный XML-каталог и не изменять XML-репо.
+- Не запускать 1С/`ibcmd`.
+
+## Пользовательский вход
+
+Добавляется CLI-команда:
+
+```bash
+nkdk round-trip-yaml-fast <xml-dir>
+```
+
+Команда выводит машинно-читаемые блоки с найденными diff'ами. Поверх неё добавляется skill:
+
+```text
+.agents/skills/round-trip-yaml-fast/
+  SKILL.md
+  round-trip.sh
+```
+
+Skill-скрипт читает `.env`, использует `NKDK_XML_REPO` и `NKDK_XML_DIR`, поддерживает single и triage режимы по образцу полного `round-trip-yaml`, но не требует чистого XML-репо и не оставляет diff'ы в нём.
+
+## Ядро проверки
+
+Для каждого поддержанного metadata XML-файла быстрый путь делает один файловый read и один XML parse. После этого используются две модели из одного parsed XML:
+
+1. обычная модель для экспорта в YAML;
+2. reference-модель через `fromXML.forReference: true` для source/reference при обратном импорте и экспорте XML.
+
+Пайплайн одного объекта:
+
+```text
+read XML text
+parse XML
+importMetadataItemFromXML(parsed, normalContext) -> model
+importMetadataItemFromXML(parsed, referenceContext) -> referenceModel
+exportMetadataItemToYAML(model) -> yamlObject
+exportToYAML(yamlObject) -> yamlText
+importFromYAML(yamlText) -> yamlObjectFromText
+importMetadataItemFromYAML(yamlObjectFromText, source=referenceModel) -> modelFromYAML
+exportMetadataItemToXML(modelFromYAML, referenceData=referenceModel) -> xmlObject
+xmlExport(xmlObject) -> xmlText
+diff(originalXmlText, xmlText)
+```
+
+YAML обязательно проходит через текст. Это проверяет сериализацию YAML, кавычки, пустые значения и восстановление типов после `importFromYAML`.
+
+## Архитектурные границы
+
+Изменения в core должны быть точечными. Не нужно вводить виртуальную файловую систему и протаскивать её через `syncConfigurationFromXML` или `syncConfigurationToXML`.
+
+Новый диагностический модуль может жить рядом с существующим configuration/applied-object кодом и использовать уже чистые преобразователи:
+
+- `importMetadataItemFromXML`;
+- `exportMetadataItemToYAML`;
+- `importMetadataItemFromYAML`;
+- `exportMetadataItemToXML`;
+- `exportToYAML` / `importFromYAML`;
+- `xmlExport`.
+
+Файловая часть ограничена обходом XML-каталогов, чтением исходного XML и построением diff-отчёта. Основные файловые sync-функции остаются без изменений.
+
+## Обход metadata
+
+Первая версия поддерживает те же верхнеуровневые каталоги, которые уже используются в диагностике:
+
+- `Catalogs`;
+- `Documents`;
+- `DocumentNumerators`;
+- `Sequences`;
+- `Enums`.
+
+Команда должна опираться на зарегистрированные `TopLevelMetadataItemRules`, а не на ручную таблицу преобразований. Если у правила нет `xmlDir` или `itemTypePrefix`, оно пропускается.
+
+Файловые дочерние metadata-объекты можно добавлять после основного прохода отдельным расширением. Первая версия фокусируется на верхнеуровневых XML-файлах, чтобы не затянуть в быстрый путь внешние файлы и сложную структуру полного sync.
+
+## Reference/source
+
+Reference-модель строится из того же parsed XML, что и обычная модель. Это важно по двум причинам:
+
+- XML читается и парсится один раз;
+- `exportMetadataItemToXML` получает исходные raw XML-данные, порядок и reference-only атрибуты через уже существующий механизм `forReference`.
+
+Для `importMetadataItemFromYAML` source берётся из reference-модели. Это приближает быстрый путь к поведению полного `sync`, где YAML-значения восстанавливаются с учётом reference.
+
+## Diff
+
+CLI не должен менять исходный XML-каталог. Diff строится между исходной XML-строкой и сгенерированной XML-строкой в памяти.
+
+Формат результата должен быть удобен для skill-оболочки:
+
+```text
+=== DIFF ===
+INDEX: <1-based index>
+FILE: <relative XML path>
+XML_FILE_ABS: <absolute path>
+--- DIFF ---
+<unified diff>
+```
+
+Для чистого результата:
+
+```text
+=== Round-trip fast чистый: диффов нет ===
+```
+
+## Skill-оболочка
+
+`.agents/skills/round-trip-yaml-fast/round-trip.sh` отвечает за удобство диагностики:
+
+- читает `.env`;
+- определяет активные XML-каталоги;
+- вызывает `nkdk round-trip-yaml-fast`;
+- поддерживает `--diff-index`;
+- поддерживает `--triage --batch-size N --start-index K`;
+- в single-режиме показывает один полный diff;
+- в triage-режиме показывает пачку diff'ов.
+
+В отличие от полного `round-trip-yaml`, fast-скрипт не делает `git restore`, не очищает YAML-каталог, не заменяет XML-каталог и не требует чистого XML-репо.
+
+## Ошибки и ограничения
+
+Если XML-файл не поддерживается правилом, команда должна пропустить его или отчитаться как unsupported без падения всего прохода.
+
+Если один объект падает на import/export, команда должна сохранить ошибку с путём файла и продолжить обработку остальных объектов, если это triage/full scan. В single-режиме допустимо остановиться на первой ошибке, если diff ещё не найден.
+
+Отчёт обязан явно писать, что fast-режим не проверяет внешние файлы и не заменяет полный файловый `round-trip-yaml`.
+
+## Проверка готовности
+
+- Добавлена CLI-команда `round-trip-yaml-fast`.
+- Добавлен core-модуль быстрого in-memory round-trip без изменений основных sync-функций.
+- YAML проходит через `exportToYAML` и `importFromYAML` как текст.
+- XML читается один раз на объект, parsed XML используется для normal и reference моделей.
+- Добавлен skill `round-trip-yaml-fast` с single и triage режимами.
+- Есть тесты на чистый проход и на diff после YAML-текстового round-trip.
+- Полный `pnpm test` проходит перед закрытием задачи.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import { resolve } from "path"
 import { pathToFileURL } from "url"
 import { importConfiguration } from "./commands/import"
 import { deleteMigration, generateMigration, renameMigration } from "./commands/migration"
+import { roundTripYAMLFastCommand } from "./commands/roundTripYAMLFast"
 import { normalizeSchemaCommandInput, printSchema, type SchemaCommandOptions } from "./commands/schema"
 import { shortRoundTrip } from "./commands/shortRoundTrip"
 import { syncConfiguration } from "./commands/sync"
@@ -56,6 +57,14 @@ export function createProgram(options: CreateProgramOptions = {}): Command {
     .argument("<xml-dir>", "путь к каталогу XML-выгрузки")
     .action((xmlDir: string) => {
       run(() => shortRoundTrip(xmlDir), options)
+    })
+
+  program
+    .command("round-trip-yaml-fast")
+    .description("Быстрая диагностика round-trip XML → YAML-текст → XML без записи деревьев")
+    .argument("<xml-dir>", "путь к каталогу XML-выгрузки")
+    .action((xmlDir: string) => {
+      run(() => roundTripYAMLFastCommand(xmlDir), options)
     })
 
   program

--- a/packages/cli/src/commands/roundTripYAMLFast.test.ts
+++ b/packages/cli/src/commands/roundTripYAMLFast.test.ts
@@ -1,0 +1,85 @@
+import { roundTripYAMLFast, type RoundTripYAMLFastResult } from "@nakidka/core"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { roundTripYAMLFastCommand } from "./roundTripYAMLFast"
+
+const mocks = vi.hoisted(() => ({
+  roundTripYAMLFast: vi.fn<(_params: { inputDir: string }) => Promise<RoundTripYAMLFastResult>>(async () => ({
+    checked: 0,
+    diffs: [],
+    errors: [],
+  })),
+}))
+
+vi.mock("@nakidka/core", () => ({
+  roundTripYAMLFast: mocks.roundTripYAMLFast,
+}))
+
+describe("roundTripYAMLFast command", () => {
+  const originalExitCode = process.exitCode
+
+  beforeEach(() => {
+    mocks.roundTripYAMLFast.mockReset()
+    mocks.roundTripYAMLFast.mockResolvedValue({ checked: 0, diffs: [], errors: [] })
+  })
+
+  afterEach(() => {
+    process.exitCode = originalExitCode
+    vi.restoreAllMocks()
+  })
+
+  it("prints clean result without setting exit code", async () => {
+    mocks.roundTripYAMLFast.mockResolvedValue({ checked: 2, diffs: [], errors: [] } satisfies RoundTripYAMLFastResult)
+    const stdout = captureStdout()
+
+    await roundTripYAMLFastCommand("xml")
+
+    expect(roundTripYAMLFast).toHaveBeenCalledWith({ inputDir: "xml" })
+    expect(writtenText(stdout)).toBe(
+      ["=== ROUND_TRIP_YAML_FAST ===", "checked: 2", "diffs: 0", "errors: 0", "=== DIFF_COUNT ===", "0", ""].join(
+        "\n",
+      ),
+    )
+    expect(process.exitCode).toBeUndefined()
+  })
+
+  it("prints diffs but keeps zero exit code", async () => {
+    mocks.roundTripYAMLFast.mockResolvedValue({
+      checked: 1,
+      diffs: [{ file: "Enums/Виды.xml", xmlFileAbs: "/tmp/xml/Enums/Виды.xml", diffText: "--- old\n+++ new" }],
+      errors: [],
+    } satisfies RoundTripYAMLFastResult)
+    const stdout = captureStdout()
+
+    await roundTripYAMLFastCommand("xml")
+
+    const text = writtenText(stdout)
+    expect(text).toContain("=== DIFF_COUNT ===\n1\n")
+    expect(text).toContain("=== DIFF ===\nfile: Enums/Виды.xml\nxmlFileAbs: /tmp/xml/Enums/Виды.xml\n--- old\n+++ new\n")
+    expect(text).not.toContain("=== ERRORS ===")
+    expect(process.exitCode).toBeUndefined()
+  })
+
+  it("prints processing errors and sets exit code", async () => {
+    mocks.roundTripYAMLFast.mockResolvedValue({
+      checked: 1,
+      diffs: [],
+      errors: [{ file: "Enums/Bad.xml", xmlFileAbs: "/tmp/xml/Enums/Bad.xml", message: "Failed to parse XML" }],
+    } satisfies RoundTripYAMLFastResult)
+    const stdout = captureStdout()
+
+    await roundTripYAMLFastCommand("xml")
+
+    const text = writtenText(stdout)
+    expect(text).toContain("=== ERRORS ===\n")
+    expect(text).toContain("file: Enums/Bad.xml\nxmlFileAbs: /tmp/xml/Enums/Bad.xml\nFailed to parse XML\n")
+    expect(process.exitCode).toBe(1)
+  })
+})
+
+function captureStdout() {
+  return vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+}
+
+function writtenText(writer: ReturnType<typeof captureStdout>): string {
+  return writer.mock.calls.map(([chunk]) => String(chunk)).join("")
+}

--- a/packages/cli/src/commands/roundTripYAMLFast.ts
+++ b/packages/cli/src/commands/roundTripYAMLFast.ts
@@ -1,0 +1,29 @@
+import { roundTripYAMLFast } from "@nakidka/core"
+
+export const roundTripYAMLFastCommand = async (xmlDir: string): Promise<void> => {
+  const result = await roundTripYAMLFast({ inputDir: xmlDir })
+
+  process.stdout.write("=== ROUND_TRIP_YAML_FAST ===\n")
+  process.stdout.write(`checked: ${result.checked}\n`)
+  process.stdout.write(`diffs: ${result.diffs.length}\n`)
+  process.stdout.write(`errors: ${result.errors.length}\n`)
+  process.stdout.write("=== DIFF_COUNT ===\n")
+  process.stdout.write(`${result.diffs.length}\n`)
+
+  for (const diff of result.diffs) {
+    process.stdout.write("=== DIFF ===\n")
+    process.stdout.write(`file: ${diff.file}\n`)
+    process.stdout.write(`xmlFileAbs: ${diff.xmlFileAbs}\n`)
+    process.stdout.write(`${diff.diffText}\n`)
+  }
+
+  if (result.errors.length > 0) {
+    process.stdout.write("=== ERRORS ===\n")
+    for (const error of result.errors) {
+      process.stdout.write(`file: ${error.file}\n`)
+      process.stdout.write(`xmlFileAbs: ${error.xmlFileAbs}\n`)
+      process.stdout.write(`${error.message}\n`)
+    }
+    process.exitCode = 1
+  }
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -8,6 +8,13 @@ export type { ConfigurationSyncResult } from "./metadata/appliedObjects/configur
 export { syncConfigurationToXML } from "./metadata/appliedObjects/configuration/syncToXML"
 export { shortRoundTripXML } from "./metadata/appliedObjects/configuration/shortRoundTripXML"
 export {
+  roundTripYAMLFast,
+  type RoundTripYAMLFastDiff,
+  type RoundTripYAMLFastError,
+  type RoundTripYAMLFastParams,
+  type RoundTripYAMLFastResult,
+} from "./metadata/appliedObjects/configuration/roundTripYAMLFast"
+export {
   ADD_ACTION,
   DELETE_ACTION,
   applyPendingMigrationFiles,

--- a/packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts
+++ b/packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.test.ts
@@ -1,0 +1,101 @@
+import fs from "fs"
+import os from "os"
+import { join } from "path"
+import { describe, expect, it } from "vitest"
+import { roundTripYAMLFast } from "./roundTripYAMLFast"
+
+const enumXml = (params: { name: string; choiceMode?: string }): string => `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<Enum uuid="d381585b-33ee-4f3e-9362-ae06f761f29d">
+		<Properties>
+			<Name>${params.name}</Name>
+			<Synonym>
+				<v8:item>
+					<v8:lang>ru</v8:lang>
+					<v8:content>${params.name}</v8:content>
+				</v8:item>
+			</Synonym>
+			<Comment/>
+			<UseStandardCommands>false</UseStandardCommands>
+			<QuickChoice>true</QuickChoice>
+			${params.choiceMode === undefined ? "" : `<ChoiceMode>${params.choiceMode}</ChoiceMode>`}
+			<DefaultListForm/>
+			<DefaultChoiceForm/>
+			<AuxiliaryListForm/>
+			<AuxiliaryChoiceForm/>
+			<ListPresentation/>
+			<ExtendedListPresentation/>
+			<Explanation/>
+			<ChoiceHistoryOnInput>Auto</ChoiceHistoryOnInput>
+			<Characteristics/>
+		</Properties>
+		<ChildObjects/>
+		<InternalInfo>
+			<xr:GeneratedType name="EnumRef.${params.name}" category="Ref">
+				<xr:TypeId>b84bb78b-3bc6-4473-9d76-c7e109b970b2</xr:TypeId>
+				<xr:ValueId>b6de8d44-cfa0-4f70-a89f-9f3098045cd4</xr:ValueId>
+			</xr:GeneratedType>
+			<xr:GeneratedType name="EnumManager.${params.name}" category="Manager">
+				<xr:TypeId>ad948a32-45c8-4cc2-9d79-da7d96fd1e19</xr:TypeId>
+				<xr:ValueId>d32b60ed-b5c6-47a3-aa22-f16a7415e1da</xr:ValueId>
+			</xr:GeneratedType>
+			<xr:GeneratedType name="EnumList.${params.name}" category="List">
+				<xr:TypeId>5a2f483e-6883-4f5e-8784-bc2d5e96c4ba</xr:TypeId>
+				<xr:ValueId>976deee1-c599-4271-a10a-ee31d333e68d</xr:ValueId>
+			</xr:GeneratedType>
+		</InternalInfo>
+	</Enum>
+</MetaDataObject>`
+
+const makeXmlProject = (xml: string): string => {
+  const dir = fs.mkdtempSync(join(os.tmpdir(), "nkdk-round-trip-yaml-fast-"))
+  fs.mkdirSync(join(dir, "Enums"), { recursive: true })
+  fs.writeFileSync(join(dir, "Enums", "ВидыСервисовЭДО.xml"), xml, "utf-8")
+  return dir
+}
+
+describe("roundTripYAMLFast", () => {
+  it("returns no diffs for stable metadata xml", async () => {
+    const xmlDir = makeXmlProject(enumXml({ name: "ВидыСервисовЭДО", choiceMode: "BothWays" }))
+    try {
+      const result = await roundTripYAMLFast({ inputDir: xmlDir })
+
+      expect(result.errors).toEqual([])
+      expect(result.diffs).toEqual([])
+      expect(result.checked).toBe(1)
+    } finally {
+      fs.rmSync(xmlDir, { recursive: true, force: true })
+    }
+  })
+
+  it("reports a diff produced by yaml text round-trip", async () => {
+    const xmlDir = makeXmlProject(enumXml({ name: "ВидыСервисовЭДО" }))
+    try {
+      const result = await roundTripYAMLFast({ inputDir: xmlDir })
+
+      expect(result.errors).toEqual([])
+      expect(result.diffs).toHaveLength(1)
+      expect(result.diffs[0]?.file).toBe("Enums/ВидыСервисовЭДО.xml")
+      expect(result.diffs[0]?.xmlFileAbs).toBe(join(xmlDir, "Enums", "ВидыСервисовЭДО.xml"))
+      expect(result.diffs[0]?.diffText).toContain("--- Enums/ВидыСервисовЭДО.xml")
+      expect(result.diffs[0]?.diffText).toContain("+++ Enums/ВидыСервисовЭДО.xml.fast")
+    } finally {
+      fs.rmSync(xmlDir, { recursive: true, force: true })
+    }
+  })
+
+  it("keeps going and records per-file errors", async () => {
+    const xmlDir = makeXmlProject("<MetaDataObject><Enum><Properties><Name>Bad</Name>")
+    try {
+      const result = await roundTripYAMLFast({ inputDir: xmlDir })
+
+      expect(result.checked).toBe(1)
+      expect(result.diffs).toEqual([])
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]?.file).toBe("Enums/ВидыСервисовЭДО.xml")
+      expect(result.errors[0]?.message.length).toBeGreaterThan(0)
+    } finally {
+      fs.rmSync(xmlDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.ts
+++ b/packages/core/metadata/appliedObjects/configuration/roundTripYAMLFast.ts
@@ -1,0 +1,254 @@
+import fs from "fs"
+import { XMLValidator } from "fast-xml-parser"
+import { basename, join, relative } from "path"
+import type {
+  ConfigurationContext,
+  ConfigurationContextFromXML,
+  ConfigurationContextWithExportToXML,
+} from "~/metadata/context/types"
+import {
+  exportMetadataItemToXML,
+  exportMetadataItemToYAML,
+  importMetadataItemFromXML,
+  importMetadataItemFromYAML,
+  type MetadataItemRule,
+  type ToYAML,
+} from "~/metadata/orchestration"
+import { importContentFromXML } from "~/xml/import/importer"
+import { xmlExport } from "~/xml/export/exporter"
+import { exportToYAML } from "~/yaml/export"
+import { importFromYAML } from "~/yaml/import"
+import { CONFIGURATION_XML_FILE } from "./rootIO"
+import { MetadataConfigurationRules } from "./rules"
+import { TopLevelMetadataItemRules } from "./topLevelRules"
+
+export interface RoundTripYAMLFastParams {
+  inputDir: string
+}
+
+export interface RoundTripYAMLFastDiff {
+  file: string
+  xmlFileAbs: string
+  diffText: string
+}
+
+export interface RoundTripYAMLFastError {
+  file: string
+  xmlFileAbs: string
+  message: string
+}
+
+export interface RoundTripYAMLFastResult {
+  checked: number
+  diffs: RoundTripYAMLFastDiff[]
+  errors: RoundTripYAMLFastError[]
+}
+
+type MetadataXMLRoot = { MetaDataObject: unknown }
+
+const makeContextFromXML = (forReference: boolean): ConfigurationContextFromXML => ({
+  defaultLanguage: "ru",
+  version: "2.20",
+  fromXML: { forReference },
+})
+
+const makeContextToYAML = (): ConfigurationContext => ({
+  defaultLanguage: "ru",
+  version: "2.20",
+  exportToYAML: { toTyped: false },
+})
+
+const makeContextFromYAML = (): ConfigurationContext => ({
+  defaultLanguage: "ru",
+  version: "2.20",
+})
+
+const makeContextToXML = (parentName: string): ConfigurationContextWithExportToXML => ({
+  defaultLanguage: "ru",
+  version: "2.20",
+  exportToXML: {
+    itemsTree: [],
+    configDumpInfo: new Map(),
+    version: "2.20",
+    context: {
+      forms: [],
+      templates: [],
+      parentName,
+      metadataForNumbering: [],
+    },
+  },
+})
+
+const formatUnknownError = (err: unknown): string => {
+  if (err instanceof Error) return err.stack ?? err.message
+  return String(err)
+}
+
+const normalizeXMLForCompare = (text: string): string => text.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").trimEnd()
+
+const normalizeFinalNewline = (text: string): string => (text.endsWith("\n") ? text : `${text}\n`)
+
+const toPosixPath = (path: string): string => path.replace(/\\/g, "/")
+
+function createUnifiedDiff(params: { file: string; original: string; generated: string }): string {
+  const original = normalizeFinalNewline(params.original).split("\n")
+  const generated = normalizeFinalNewline(params.generated).split("\n")
+  let start = 0
+  while (start < original.length && start < generated.length && original[start] === generated[start]) start += 1
+
+  let originalEnd = original.length - 1
+  let generatedEnd = generated.length - 1
+  while (originalEnd >= start && generatedEnd >= start && original[originalEnd] === generated[generatedEnd]) {
+    originalEnd -= 1
+    generatedEnd -= 1
+  }
+
+  const contextStart = Math.max(0, start - 3)
+  const contextOriginalEnd = Math.min(original.length - 1, originalEnd + 3)
+  const contextGeneratedEnd = Math.min(generated.length - 1, generatedEnd + 3)
+  const originalCount = contextOriginalEnd - contextStart + 1
+  const generatedCount = contextGeneratedEnd - contextStart + 1
+  const lines = [
+    `--- ${params.file}`,
+    `+++ ${params.file}.fast`,
+    `@@ -${contextStart + 1},${originalCount} +${contextStart + 1},${generatedCount} @@`,
+  ]
+
+  for (let i = contextStart; i <= Math.max(contextOriginalEnd, contextGeneratedEnd); i += 1) {
+    const originalLine = i <= contextOriginalEnd ? original[i] : undefined
+    const generatedLine = i <= contextGeneratedEnd ? generated[i] : undefined
+    if (originalLine === generatedLine && originalLine !== undefined) {
+      lines.push(` ${originalLine}`)
+    } else {
+      if (originalLine !== undefined) lines.push(`-${originalLine}`)
+      if (generatedLine !== undefined) lines.push(`+${generatedLine}`)
+    }
+  }
+
+  return lines.join("\n")
+}
+
+const importMetadataYAMLText = <Rule extends MetadataItemRule>(yamlText: string): ToYAML<Rule["itemType"]> | undefined =>
+  importFromYAML<ToYAML<Rule["itemType"]> | undefined>(yamlText)
+
+const roundTripOne = <Rule extends MetadataItemRule>(params: {
+  inputDir: string
+  file: string
+  xmlFileAbs: string
+  rule: Rule
+  parentName: string
+}): RoundTripYAMLFastDiff | undefined => {
+  const originalXml = fs.readFileSync(params.xmlFileAbs, "utf-8")
+  const validationResult = XMLValidator.validate(originalXml)
+  if (validationResult !== true) {
+    throw new Error(`Failed to parse XML: ${validationResult.err.msg}`)
+  }
+  const parsed = importContentFromXML<MetadataXMLRoot>(originalXml)
+  const model = importMetadataItemFromXML({
+    context: makeContextFromXML(false),
+    xml: parsed.MetaDataObject,
+    rule: params.rule,
+  })
+  const referenceModel = importMetadataItemFromXML({
+    context: makeContextFromXML(true),
+    xml: parsed.MetaDataObject,
+    rule: params.rule,
+  })
+
+  const yamlObject = exportMetadataItemToYAML({
+    context: makeContextToYAML(),
+    data: model,
+    rule: params.rule,
+  })
+  const yamlText = yamlObject === undefined ? "" : exportToYAML(yamlObject)
+  const yamlObjectFromText = importMetadataYAMLText<typeof params.rule>(yamlText)
+  const modelFromYAML = importMetadataItemFromYAML({
+    context: makeContextFromYAML(),
+    yaml: yamlObjectFromText,
+    rule: params.rule,
+    name: params.parentName,
+    source: referenceModel,
+  })
+  const xmlObject = exportMetadataItemToXML({
+    context: makeContextToXML(params.parentName),
+    data: modelFromYAML,
+    referenceData: referenceModel,
+    rule: params.rule,
+  })
+  const generatedXml = xmlObject === undefined ? "" : xmlExport(xmlObject)
+
+  const originalComparable = normalizeXMLForCompare(originalXml)
+  const generatedComparable = normalizeXMLForCompare(generatedXml)
+  if (originalComparable === generatedComparable) return undefined
+
+  return {
+    file: params.file,
+    xmlFileAbs: params.xmlFileAbs,
+    diffText: createUnifiedDiff({
+      file: params.file,
+      original: originalComparable,
+      generated: generatedComparable,
+    }),
+  }
+}
+
+const listRoundTripEntries = (inputDir: string): Array<{
+  file: string
+  xmlFileAbs: string
+  rule: MetadataItemRule
+  parentName: string
+}> => {
+  const entries: Array<{ file: string; xmlFileAbs: string; rule: MetadataItemRule; parentName: string }> = []
+  const configurationPath = join(inputDir, CONFIGURATION_XML_FILE)
+  if (fs.existsSync(configurationPath)) {
+    entries.push({
+      file: CONFIGURATION_XML_FILE,
+      xmlFileAbs: configurationPath,
+      rule: MetadataConfigurationRules,
+      parentName: "",
+    })
+  }
+
+  for (const rule of TopLevelMetadataItemRules) {
+    if (rule.xmlDir === undefined) continue
+    const dir = join(inputDir, rule.xmlDir)
+    if (!fs.existsSync(dir)) continue
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".xml")) continue
+      const xmlFileAbs = join(dir, entry.name)
+      entries.push({
+        file: toPosixPath(relative(inputDir, xmlFileAbs)),
+        xmlFileAbs,
+        rule,
+        parentName: basename(entry.name, ".xml"),
+      })
+    }
+  }
+
+  return entries
+}
+
+export const roundTripYAMLFast = async (params: RoundTripYAMLFastParams): Promise<RoundTripYAMLFastResult> => {
+  const result: RoundTripYAMLFastResult = {
+    checked: 0,
+    diffs: [],
+    errors: [],
+  }
+  if (!fs.existsSync(params.inputDir)) return result
+
+  for (const entry of listRoundTripEntries(params.inputDir)) {
+    result.checked += 1
+    try {
+      const diff = roundTripOne({ inputDir: params.inputDir, ...entry })
+      if (diff !== undefined) result.diffs.push(diff)
+    } catch (err) {
+      result.errors.push({
+        file: entry.file,
+        xmlFileAbs: entry.xmlFileAbs,
+        message: formatUnknownError(err),
+      })
+    }
+  }
+
+  return result
+}

--- a/packages/core/metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts
+++ b/packages/core/metadata/appliedObjects/metadataSubsystem/metadataTarget.test.ts
@@ -67,6 +67,21 @@ describe("MetadataSubsystem metadataTarget", () => {
     })
   })
 
+  it("imports functional options parameter links to XML model content", () => {
+    expect(
+      importMetadataItemFromYAML({
+        context: mockContext,
+        rule: MetadataSubsystemRules,
+        name: "СтандартныеПодсистемы",
+        yaml: {
+          Состав: ["ПараметрФункциональныхОпций.ПараметрФункциональныхОпцийВсеСвойства"],
+        },
+      })
+    ).toMatchObject({
+      content: ["FunctionalOptionsParameter.ПараметрФункциональныхОпцийВсеСвойства"],
+    })
+  })
+
   it("imports and exports sequence links in content", () => {
     expect(
       exportMetadataItemToYAML({

--- a/packages/core/metadata/appliedObjects/metadataSubsystem/rules.ts
+++ b/packages/core/metadata/appliedObjects/metadataSubsystem/rules.ts
@@ -22,7 +22,6 @@ const contentObjectPaths = [
   ["Bot"],
   ["FunctionalOption"],
   ["FunctionalOptionsParameter"],
-  ["FunctionalOptionParameter"],
   ["DefinedType"],
   ["SettingsStorage"],
   ["CommonCommand"],

--- a/packages/core/metadata/commonObjects/metadataPath/types.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/types.ts
@@ -40,7 +40,6 @@ const OtherTypeToYAML = {
   Bot: "Бот",
   ExternalDataSource: "ВнешнийИсточникДанных",
   SessionParameter: "ПараметрСеанса",
-  FunctionalOptionParameter: "ПараметрФункциональныхОпций",
 } as const
 
 export const MetadataTypeToYAML = {

--- a/packages/core/metadata/commonObjects/metadataTargets/parse.test.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/parse.test.ts
@@ -399,8 +399,8 @@ describe("metadataTargets parser", () => {
       ["WSСсылка.WSСсылкаВсеСвойства", "WSReference.WSСсылкаВсеСвойства", "WSReference"],
       [
         "ПараметрФункциональныхОпций.ПараметрФункциональныхОпцийВсеСвойства",
-        "FunctionalOptionParameter.ПараметрФункциональныхОпцийВсеСвойства",
-        "FunctionalOptionParameter",
+        "FunctionalOptionsParameter.ПараметрФункциональныхОпцийВсеСвойства",
+        "FunctionalOptionsParameter",
       ],
     ] as const
 

--- a/packages/core/metadata/commonObjects/metadataTargets/roots.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/roots.ts
@@ -39,7 +39,6 @@ export const rootToYAML = {
   StyleItem: "ЭлементСтиля",
   FunctionalOption: "ФункциональнаяОпция",
   FunctionalOptionsParameter: "ПараметрФункциональныхОпций",
-  FunctionalOptionParameter: "ПараметрФункциональныхОпций",
   DocumentJournal: "ЖурналДокументов",
   HTTPService: "HTTPСервис",
   WebSocketClient: "WebSocketКлиент",

--- a/packages/core/metadata/commonObjects/metadataTargets/types.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/types.ts
@@ -35,7 +35,6 @@ export type MetadataRootName =
   | "StyleItem"
   | "FunctionalOption"
   | "FunctionalOptionsParameter"
-  | "FunctionalOptionParameter"
   | "DocumentJournal"
   | "HTTPService"
   | "WebSocketClient"


### PR DESCRIPTION
## Что сделано
- добавлен быстрый режим round-trip YAML без записи промежуточных файлов
- исправлен canonical root для FunctionalOptionsParameter в metadata target
- добавлены focused-тесты для импорта/экспорта ссылок подсистемы

## Проверка
- pnpm --filter '@nakidka/core' test