### PR TITLE
fix: восстановить reference для FilterItem

### DIFF
--- a/docs/superpowers/plans/2026-06-21-dcs-filter-item-reference-round-trip.md
+++ b/docs/superpowers/plans/2026-06-21-dcs-filter-item-reference-round-trip.md
@@ -1,0 +1,385 @@
+# DCS FilterItem Reference Round-Trip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve `userSettingID` and compact `userSettingPresentation` XML for nested DCS `FilterItemComparison` after YAML round-trip.
+
+**Architecture:** Keep YAML clean: it stores `ИспользоватьПользовательскуюНастройку: Истина`, not GUIDs or XML shape. Fix the common `FilterItem.toXML` reference matcher so it finds an unambiguous reference item and passes it into existing property export; `UserSettingsID.toXML` and `DcsLocalStringType.toXML` already restore the XML details when reference reaches them.
+
+**Tech Stack:** TypeScript, Vitest, metadata rules/property orchestration, XML/YAML round-trip scripts.
+
+---
+
+## File Structure
+
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.test.ts`
+  - Add failing coverage for ambiguous reference matching and `xs:string` presentation restoration.
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.ts`
+  - Replace first-match reference lookup with safe candidate selection.
+  - Normalize DCS field values for matching only.
+  - Use `rightValue` as a tie-breaker when needed.
+- Read before edits: `.agents/knowledge/metadata/INDEX.md`, `.agents/knowledge/metadata/sources-of-truth.md`, `.agents/knowledge/metadata/round-trip-cycle.md`, `.agents/knowledge/metadata/yaml-contract.md`
+  - Required by repository metadata rules.
+- Do not modify XML fixtures.
+
+---
+
+### Task 1: Add Red Tests For Reference Matching
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.test.ts`
+
+- [ ] **Step 1: Add a typed test helper near the existing `guidA/guidB` constants**
+
+Add this helper inside `describe("semantic reference matching", () => { ... })`, after `guidB`:
+
+```ts
+const asReferenceUserSettingID = (value: string): FilterItemComparison["userSettingID"] =>
+  value as FilterItemComparison["userSettingID"]
+```
+
+- [ ] **Step 2: Replace existing `as any` GUID casts in this block**
+
+Change:
+
+```ts
+const refA: FilterItemComparison = { ...itemA, userSettingID: guidA as any }
+const refB: FilterItemComparison = { ...itemB, userSettingID: guidB as any }
+```
+
+to:
+
+```ts
+const refA: FilterItemComparison = { ...itemA, userSettingID: asReferenceUserSettingID(guidA) }
+const refB: FilterItemComparison = { ...itemB, userSettingID: asReferenceUserSettingID(guidB) }
+```
+
+- [ ] **Step 3: Add a failing ambiguity test**
+
+Add this test inside `describe("semantic reference matching", () => { ... })`:
+
+```ts
+it("FilterItemComparison: не подставляет GUID при неоднозначном совпадении", () => {
+  const current: FilterItemComparison = {
+    itemType: "FilterItemComparison",
+    leftValue: { type: "Field", value: "ТипОплаты" },
+    comparisonType: "Equal",
+    userSettingID: true,
+  }
+
+  const firstReference: FilterItemComparison = {
+    ...current,
+    rightValue: { type: "string", value: "Наличные" },
+    userSettingID: asReferenceUserSettingID(guidA),
+  }
+  const secondReference: FilterItemComparison = {
+    ...current,
+    rightValue: { type: "string", value: "Безналичные" },
+    userSettingID: asReferenceUserSettingID(guidB),
+  }
+
+  const { result } = testExportPropertyToXML({
+    rule,
+    value: [current],
+    xmlRootTag: "dcsset:item",
+    referenceMetadata: [firstReference, secondReference],
+  })
+
+  expect(result).not.toContain(guidA)
+  expect(result).not.toContain(guidB)
+})
+```
+
+- [ ] **Step 4: Add coverage for `userSettingPresentation` xs:string restoration**
+
+Add this test inside the same `describe` block:
+
+```ts
+it("FilterItemComparison: сохраняет xs:string userSettingPresentation из reference", () => {
+  const guid = "eeeeeeee-0000-0000-0000-000000000005"
+  const current: FilterItemComparison = {
+    itemType: "FilterItemComparison",
+    leftValue: { type: "Field", value: "ТипОплаты" },
+    comparisonType: "Equal",
+    userSettingID: true,
+    userSettingPresentation: { items: { ru: "Способ оплаты" } },
+  }
+  const reference: FilterItemComparison = {
+    ...current,
+    userSettingID: asReferenceUserSettingID(guid),
+    userSettingPresentation: "Способ оплаты",
+  }
+
+  const { result } = testExportPropertyToXML({
+    rule,
+    value: [current],
+    xmlRootTag: "dcsset:item",
+    referenceMetadata: [reference],
+  })
+
+  expect(result).toContain(`<dcsset:userSettingID>${guid}</dcsset:userSettingID>`)
+  expect(result).toContain(
+    `<dcsset:userSettingPresentation xsi:type="xs:string">Способ оплаты</dcsset:userSettingPresentation>`
+  )
+  expect(result).not.toContain(`xsi:type="v8:LocalStringType"`)
+})
+```
+
+- [ ] **Step 5: Run the focused test and confirm it fails for the ambiguity case**
+
+Run:
+
+```bash
+pnpm --dir packages/core vitest run --no-isolate --sequence.shuffle packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.test.ts
+```
+
+Expected: FAIL on `FilterItemComparison: не подставляет GUID при неоднозначном совпадении`, because current code takes the first matching reference item.
+
+---
+
+### Task 2: Make Reference Matching Safe And Deterministic
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.ts`
+
+- [ ] **Step 1: Replace the comparison match helpers**
+
+Replace:
+
+```ts
+const filterItemComparisonMatchKey = (item: FilterItemComparison): string =>
+  JSON.stringify({ leftValue: item.leftValue, comparisonType: item.comparisonType })
+
+const filterItemGroupMatchKey = (item: FilterItemGroup): string => String(item.groupType ?? "")
+```
+
+with:
+
+```ts
+const normalizeFilterItemMatchValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(normalizeFilterItemMatchValue)
+  if (value === null || typeof value !== "object") return value
+
+  const record = value as Record<string, unknown>
+  if (record.type === "Field" && typeof record.value === "string") {
+    return { ...record, value: record.value.startsWith(".") ? record.value.slice(1) : record.value }
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).map(([key, itemValue]) => [key, normalizeFilterItemMatchValue(itemValue)])
+  )
+}
+
+const filterItemComparisonBaseMatchKey = (item: FilterItemComparison): string =>
+  JSON.stringify({
+    leftValue: normalizeFilterItemMatchValue(item.leftValue),
+    comparisonType: item.comparisonType,
+  })
+
+const filterItemComparisonStrictMatchKey = (item: FilterItemComparison): string =>
+  JSON.stringify({
+    leftValue: normalizeFilterItemMatchValue(item.leftValue),
+    comparisonType: item.comparisonType,
+    rightValue: normalizeFilterItemMatchValue(item.rightValue),
+  })
+
+const filterItemGroupMatchKey = (item: FilterItemGroup): string => String(item.groupType ?? "")
+```
+
+- [ ] **Step 2: Add an exact-one helper**
+
+Add below the match key helpers:
+
+```ts
+const findOnlyIndex = (indices: number[]): number | undefined => (indices.length === 1 ? indices[0] : undefined)
+```
+
+- [ ] **Step 3: Replace `findReferenceFilterItem` with candidate-based matching**
+
+Replace the whole `findReferenceFilterItem` function with:
+
+```ts
+const findReferenceFilterItem = (
+  item: FilterItem[number],
+  referenceItems: FilterItem,
+  usedIndices: Set<number>
+): FilterItem[number] | undefined => {
+  const candidateIndices: number[] = []
+
+  for (let i = 0; i < referenceItems.length; i++) {
+    if (usedIndices.has(i)) continue
+    const refItem = referenceItems[i]
+    if (item.itemType !== refItem.itemType) continue
+
+    if (
+      item.itemType === "FilterItemComparison" &&
+      refItem.itemType === "FilterItemComparison" &&
+      filterItemComparisonBaseMatchKey(item) === filterItemComparisonBaseMatchKey(refItem)
+    ) {
+      candidateIndices.push(i)
+      continue
+    }
+
+    if (
+      item.itemType === "FilterItemGroup" &&
+      refItem.itemType === "FilterItemGroup" &&
+      filterItemGroupMatchKey(item) === filterItemGroupMatchKey(refItem)
+    ) {
+      candidateIndices.push(i)
+    }
+  }
+
+  const onlyCandidateIndex = findOnlyIndex(candidateIndices)
+  if (onlyCandidateIndex !== undefined) {
+    usedIndices.add(onlyCandidateIndex)
+    return referenceItems[onlyCandidateIndex]
+  }
+
+  if (item.itemType !== "FilterItemComparison") return undefined
+
+  const strictCandidateIndices = candidateIndices.filter((index) => {
+    const refItem = referenceItems[index]
+    return (
+      refItem.itemType === "FilterItemComparison" &&
+      filterItemComparisonStrictMatchKey(item) === filterItemComparisonStrictMatchKey(refItem)
+    )
+  })
+
+  const onlyStrictCandidateIndex = findOnlyIndex(strictCandidateIndices)
+  if (onlyStrictCandidateIndex === undefined) return undefined
+
+  usedIndices.add(onlyStrictCandidateIndex)
+  return referenceItems[onlyStrictCandidateIndex]
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```bash
+pnpm --dir packages/core vitest run --no-isolate --sequence.shuffle packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.test.ts
+```
+
+Expected: PASS.
+
+---
+
+### Task 3: Verify Nested FilterItem Round-Trip Behavior
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.test.ts`
+
+- [ ] **Step 1: Add a nested group test**
+
+Add this test inside `describe("semantic reference matching", () => { ... })`:
+
+```ts
+it("FilterItemGroup: передает reference во вложенный FilterItemComparison", () => {
+  const guid = "ffffffff-0000-0000-0000-000000000006"
+  const currentNested: FilterItemComparison = {
+    itemType: "FilterItemComparison",
+    leftValue: { type: "Field", value: "Контрагент" },
+    comparisonType: "Equal",
+    userSettingID: true,
+    userSettingPresentation: { items: { ru: "Контрагент" } },
+  }
+  const referenceNested: FilterItemComparison = {
+    ...currentNested,
+    userSettingID: asReferenceUserSettingID(guid),
+    userSettingPresentation: "Контрагент",
+  }
+  const currentGroup: FilterItemGroup = {
+    itemType: "FilterItemGroup",
+    groupType: "AndGroup",
+    items: [currentNested],
+  }
+  const referenceGroup: FilterItemGroup = {
+    itemType: "FilterItemGroup",
+    groupType: "AndGroup",
+    items: [referenceNested],
+  }
+
+  const { result } = testExportPropertyToXML({
+    rule,
+    value: [currentGroup],
+    xmlRootTag: "dcsset:item",
+    referenceMetadata: [referenceGroup],
+  })
+
+  expect(result).toContain(`<dcsset:userSettingID>${guid}</dcsset:userSettingID>`)
+  expect(result).toContain(
+    `<dcsset:userSettingPresentation xsi:type="xs:string">Контрагент</dcsset:userSettingPresentation>`
+  )
+})
+```
+
+- [ ] **Step 2: Run the focused test**
+
+Run:
+
+```bash
+pnpm --dir packages/core vitest run --no-isolate --sequence.shuffle packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the implementation**
+
+Run:
+
+```bash
+git add packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.ts packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.test.ts
+git commit -m "fix: :bug: восстановить reference для FilterItem"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Full Verification And Round-Trip
+
+**Files:**
+- No code edits expected.
+- External XML repository from `.env` may become dirty after `round-trip-yaml`; keep that diff for analysis unless the user explicitly asks to clean it.
+
+- [ ] **Step 1: Run the full project test suite**
+
+Run from repository root:
+
+```bash
+pnpm test
+```
+
+Expected: all package tests pass.
+
+- [ ] **Step 2: Run YAML round-trip diagnostics**
+
+Run from repository root:
+
+```bash
+./.agents/skills/round-trip-yaml/round-trip.sh
+```
+
+Expected: the previous DCS filter diff no longer removes nested `dcsset:userSettingID` and no longer expands the matched `dcsset:userSettingPresentation xsi:type="xs:string"` into `v8:LocalStringType`.
+
+- [ ] **Step 3: If the XML repository has only expected diagnostic changes, report them**
+
+Run in the XML repository shown by the round-trip script:
+
+```bash
+git status --short
+```
+
+Expected: any remaining files are round-trip diagnostic diffs, not changes in `nkdk`.
+
+- [ ] **Step 4: Confirm `nkdk` working tree state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean, except for intentionally uncommitted plan/spec files if execution started before committing them.
+

--- a/docs/superpowers/specs/2026-06-21-dcs-filter-item-reference-round-trip-design.md
+++ b/docs/superpowers/specs/2026-06-21-dcs-filter-item-reference-round-trip-design.md
@@ -1,0 +1,151 @@
+# DCS FilterItem Reference Round-Trip Design
+
+## Goal
+
+Сохранить исходные XML-детали пользовательских настроек во вложенных элементах DCS filter при YAML round-trip.
+
+Текущий YAML намеренно хранит не служебный GUID, а человекочитаемый флаг:
+
+```yaml
+ИспользоватьПользовательскуюНастройку: Истина
+```
+
+При обратном XML-экспорте этот флаг должен восстановиться по `referenceMetadata` в исходный `<dcsset:userSettingID>...`. Та же reference-связь нужна для `userSettingPresentation`: если в исходном XML была компактная форма `xsi:type="xs:string"`, экспорт должен сохранить именно её, а не разворачивать значение в `v8:LocalStringType`.
+
+## Problem Example
+
+Round-trip diff для вложенного `dcsset:FilterItemComparison`:
+
+```diff
+  <dcsset:item xsi:type="dcsset:FilterItemComparison">
+    <dcsset:use>false</dcsset:use>
+    <dcsset:left xsi:type="dcscor:Field">ТипОплаты</dcsset:left>
+    <dcsset:comparisonType>Equal</dcsset:comparisonType>
+-   <dcsset:userSettingID>6f0e2d67-8181-4539-aaf3-3a925839c031</dcsset:userSettingID>
+-   <dcsset:userSettingPresentation xsi:type="xs:string">Способ оплаты</dcsset:userSettingPresentation>
++   <dcsset:userSettingPresentation xsi:type="v8:LocalStringType">
++     <v8:item>
++       <v8:lang>ru</v8:lang>
++       <v8:content>Способ оплаты</v8:content>
++     </v8:item>
++   </dcsset:userSettingPresentation>
+  </dcsset:item>
+```
+
+Данные не потерялись в YAML. Потеря произошла на этапе XML-экспорта, когда вложенный `FilterItemComparison` не получил подходящий исходный XML-элемент как reference.
+
+## Scope
+
+В границы входит общий слой:
+
+- `packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/*`
+- тесты для `FilterItemComparison` и вложенного filter round-trip
+
+Вне границ:
+
+- изменение XML-фикстур;
+- добавление GUID пользовательских настроек в YAML;
+- добавление XML-формы `userSettingPresentation` в YAML;
+- точечная правка только `DynamicList`;
+- изменение общего договора `UserSettingsID` и `DcsLocalStringType`, если тесты подтвердят, что они уже корректно работают при наличии reference.
+
+## Recommended Approach
+
+Рекомендуемый подход: исправить reference-сопоставление внутри `FilterItem.toXML`, чтобы каждый вложенный `FilterItemComparison` получал свой исходный `referenceMetadata`.
+
+Именно `referenceMetadata` уже содержит обе нужные детали:
+
+- реальный GUID для `UserSettingsID`, когда модель хранит `true`;
+- исходный строковый вид `userSettingPresentation`, когда XML был `xsi:type="xs:string"`.
+
+YAML при этом остаётся стабильным и предметным: он описывает смысл настройки, а не служебные XML-детали.
+
+## Alternatives
+
+### (А) Починить reference-сопоставление в `FilterItem`
+
+Плюсы: закрывает причину, работает для всех потребителей `FilterItemComparison`, сохраняет чистый YAML.
+
+Минусы: нужно аккуратно проверить ключ сопоставления, потому что разные элементы filter могут иметь похожие `left` и `comparisonType`.
+
+### (Б) Сохранять GUID и форму строки в YAML
+
+Плюсы: XML можно восстановить без reference.
+
+Минусы: YAML станет хранить служебные детали исходного XML, появится шум в представлении и риск закрепить нестабильные идентификаторы как часть пользовательского формата.
+
+### (В) Исправить только `DynamicList.filter`
+
+Плюсы: может закрыть текущий первый diff минимальным изменением.
+
+Минусы: проблема находится не в `DynamicList`, а в общем DCS filter item. Следующие похожие места будут проявляться по одному.
+
+## Design
+
+### Architecture
+
+`FilterItem.toXML` должен отвечать за подбор reference для каждого элемента списка. После подбора reference свойства `userSettingID` и `userSettingPresentation` экспортируются обычным механизмом rules/property.
+
+Граница ответственности:
+
+- `FilterItem` сопоставляет текущий элемент модели с исходным XML/reference-элементом;
+- `UserSettingsID.toXML` восстанавливает GUID из reference-строки;
+- `DcsLocalStringType.toXML` сохраняет компактную форму `xs:string`, если reference был строкой;
+- YAML-слой не знает о GUID и XML-представлении локализованной строки.
+
+### Data Flow
+
+1. `fromXML` читает исходный `FilterItemComparison`.
+2. `toYAML` печатает `ИспользоватьПользовательскуюНастройку: Истина` вместо GUID.
+3. `fromYAML` восстанавливает модель с `userSettingID: true`.
+4. `FilterItem.toXML` ищет соответствующий исходный `FilterItemComparison` в `referenceMetadata`.
+5. `UserSettingsID.toXML` получает reference-строку и экспортирует исходный GUID.
+6. `DcsLocalStringType.toXML` получает reference-строку и экспортирует `xsi:type="xs:string"`, если так было в исходном XML.
+
+### Matching Rules
+
+Сопоставление должно использовать стабильные признаки самого filter item, а не `userSettingID`, потому что в модели после YAML хранится только `true`.
+
+Базовые кандидаты для `FilterItemComparison`:
+
+- тип элемента: `FilterItemComparison`;
+- `leftValue`;
+- `comparisonType`;
+- при необходимости `rightValue`, если оно задано и помогает различать элементы;
+- позиционный резерв внутри списка элементов одного типа, если ключ не уникален.
+
+Если ключ неоднозначен, экспорт не должен брать случайный reference. Лучше сохранить существующее поведение без GUID для неоднозначного случая, чем подставить GUID от соседнего условия.
+
+### Error Handling
+
+Если reference не найден или найден неоднозначно, экспорт должен продолжить работу без падения и без подстановки чужого GUID.
+
+Ошибки некорректной структуры YAML или XML остаются в существующих слоях импорта и экспорта. Новая логика не должна расширять набор исключений.
+
+## Testing
+
+Минимальные проверки:
+
+- unit-тест `FilterItemComparison.toXML`: при `userSettingID: true` и reference с GUID экспортируется исходный `<dcsset:userSettingID>...`.
+- unit-тест `FilterItemComparison.toXML`: при `userSettingPresentation` как однострочный `I8nText` и reference `xs:string` экспорт остаётся `xs:string`.
+- тест на неоднозначные элементы: reference не должен подбираться случайно, если два элемента имеют одинаковый ключ.
+- интеграционный тест для filter со вложенными `FilterItemComparison`, который воспроизводит исчезновение `userSettingID` и разворачивание `userSettingPresentation`.
+
+Финальные проверки:
+
+- точечные тесты затронутых common objects;
+- `pnpm test` из корня перед закрытием реализации;
+- повторный `round-trip-yaml`, чтобы убедиться, что класс diff'ов по `userSettingID` и `userSettingPresentation` в DCS filter исчез или существенно сократился.
+
+## Risks
+
+- Слишком слабый ключ сопоставления может подставить GUID от соседнего условия.
+- Слишком строгий ключ может не найти reference после допустимых преобразований YAML.
+- Позиционный резерв полезен только внутри уже суженного набора кандидатов; использовать одну позицию как основной ключ рискованно.
+
+## Success Criteria
+
+- YAML не получает новые служебные поля для GUID или XML-формы строки.
+- Вложенный `FilterItemComparison` восстанавливает исходный `userSettingID`, если reference найден однозначно.
+- `userSettingPresentation` сохраняет исходную компактную форму `xs:string`, если она была в XML.
+- Неоднозначное сопоставление не приводит к подстановке чужого GUID.

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.test.ts
@@ -84,6 +84,9 @@ describe("export FilterItem to XML", () => {
     const guidA = "aaaaaaaa-0000-0000-0000-000000000001"
     const guidB = "bbbbbbbb-0000-0000-0000-000000000002"
 
+    const asReferenceUserSettingID = (value: string): FilterItemComparison["userSettingID"] =>
+      value as FilterItemComparison["userSettingID"]
+
     const itemA: FilterItemComparison = {
       itemType: "FilterItemComparison",
       leftValue: { type: "Field", value: "Ссылка" },
@@ -97,8 +100,8 @@ describe("export FilterItem to XML", () => {
       userSettingID: true,
     }
 
-    const refA: FilterItemComparison = { ...itemA, userSettingID: guidA as any }
-    const refB: FilterItemComparison = { ...itemB, userSettingID: guidB as any }
+    const refA: FilterItemComparison = { ...itemA, userSettingID: asReferenceUserSettingID(guidA) }
+    const refB: FilterItemComparison = { ...itemB, userSettingID: asReferenceUserSettingID(guidB) }
 
     it("FilterItemComparison: сопоставляет по leftValue+comparisonType, а не по индексу", () => {
       // current: [A, B], reference: [B, A] — порядок обратный
@@ -148,6 +151,132 @@ describe("export FilterItem to XML", () => {
       expect(result).toContain(guidOrGroup)
       expect(result).toContain(guidAndGroup)
       expect(result.indexOf(guidOrGroup)).toBeLessThan(result.indexOf(guidAndGroup))
+    })
+
+    it("FilterItemComparison: не подставляет GUID при неоднозначном совпадении", () => {
+      const current: FilterItemComparison = {
+        itemType: "FilterItemComparison",
+        leftValue: { type: "Field", value: "ТипОплаты" },
+        comparisonType: "Equal",
+        userSettingID: true,
+      }
+
+      const firstReference: FilterItemComparison = {
+        ...current,
+        rightValue: { type: "string", value: "Наличные" },
+        userSettingID: asReferenceUserSettingID(guidA),
+      }
+      const secondReference: FilterItemComparison = {
+        ...current,
+        rightValue: { type: "string", value: "Безналичные" },
+        userSettingID: asReferenceUserSettingID(guidB),
+      }
+
+      const { result } = testExportPropertyToXML({
+        rule,
+        value: [current],
+        xmlRootTag: "dcsset:item",
+        referenceMetadata: [firstReference, secondReference],
+      })
+
+      expect(result).not.toContain(guidA)
+      expect(result).not.toContain(guidB)
+    })
+
+    it("FilterItemComparison: сохраняет xs:string userSettingPresentation из reference", () => {
+      const guid = "eeeeeeee-0000-0000-0000-000000000005"
+      const current: FilterItemComparison = {
+        itemType: "FilterItemComparison",
+        leftValue: { type: "Field", value: "ТипОплаты" },
+        comparisonType: "Equal",
+        userSettingID: true,
+        userSettingPresentation: { items: { ru: "Способ оплаты" } },
+      }
+      const reference: FilterItemComparison = {
+        ...current,
+        userSettingID: asReferenceUserSettingID(guid),
+        userSettingPresentation: "Способ оплаты",
+      }
+
+      const { result } = testExportPropertyToXML({
+        rule,
+        value: [current],
+        xmlRootTag: "dcsset:item",
+        referenceMetadata: [reference],
+      })
+
+      expect(result).toContain(`<dcsset:userSettingID>${guid}</dcsset:userSettingID>`)
+      expect(result).toContain(
+        `<dcsset:userSettingPresentation xsi:type="xs:string">Способ оплаты</dcsset:userSettingPresentation>`
+      )
+      expect(result).not.toContain(`xsi:type="v8:LocalStringType"`)
+    })
+
+    it("FilterItemComparison: сопоставляет implicit Equal и поле с точкой из YAML", () => {
+      const guid = "eeeeeeee-0000-0000-0000-000000000007"
+      const current: FilterItemComparison = {
+        itemType: "FilterItemComparison",
+        leftValue: { type: "Field", value: ".ТипОплаты" },
+        userSettingID: true,
+        userSettingPresentation: { items: { ru: "Способ оплаты" } },
+      }
+      const reference: FilterItemComparison = {
+        ...current,
+        leftValue: { type: "Field", value: "ТипОплаты" },
+        comparisonType: "Equal",
+        userSettingID: asReferenceUserSettingID(guid),
+        userSettingPresentation: "Способ оплаты",
+      }
+
+      const { result } = testExportPropertyToXML({
+        rule,
+        value: [current],
+        xmlRootTag: "dcsset:item",
+        referenceMetadata: [reference],
+      })
+
+      expect(result).toContain(`<dcsset:userSettingID>${guid}</dcsset:userSettingID>`)
+      expect(result).toContain(
+        `<dcsset:userSettingPresentation xsi:type="xs:string">Способ оплаты</dcsset:userSettingPresentation>`
+      )
+    })
+
+    it("FilterItemGroup: передает reference во вложенный FilterItemComparison", () => {
+      const guid = "ffffffff-0000-0000-0000-000000000006"
+      const currentNested: FilterItemComparison = {
+        itemType: "FilterItemComparison",
+        leftValue: { type: "Field", value: "Контрагент" },
+        comparisonType: "Equal",
+        userSettingID: true,
+        userSettingPresentation: { items: { ru: "Контрагент" } },
+      }
+      const referenceNested: FilterItemComparison = {
+        ...currentNested,
+        userSettingID: asReferenceUserSettingID(guid),
+        userSettingPresentation: "Контрагент",
+      }
+      const currentGroup: FilterItemGroup = {
+        itemType: "FilterItemGroup",
+        groupType: "AndGroup",
+        items: [currentNested],
+      }
+      const referenceGroup: FilterItemGroup = {
+        itemType: "FilterItemGroup",
+        groupType: "AndGroup",
+        items: [referenceNested],
+      }
+
+      const { result } = testExportPropertyToXML({
+        rule,
+        value: [currentGroup],
+        xmlRootTag: "dcsset:item",
+        referenceMetadata: [referenceGroup],
+      })
+
+      expect(result).toContain(`<dcsset:userSettingID>${guid}</dcsset:userSettingID>`)
+      expect(result).toContain(
+        `<dcsset:userSettingPresentation xsi:type="xs:string">Контрагент</dcsset:userSettingPresentation>`
+      )
     })
   })
 })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toXML.ts
@@ -7,38 +7,88 @@ import { FilterItemComparisonRules, FilterItemGroupRules } from "./rules"
 import "./typedValues"
 import { FilterItem, FilterItemComparison, FilterItemGroup } from "./types"
 
-const filterItemComparisonMatchKey = (item: FilterItemComparison): string =>
-  JSON.stringify({ leftValue: item.leftValue, comparisonType: item.comparisonType })
+const normalizeFilterItemMatchValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(normalizeFilterItemMatchValue)
+  if (value === null || typeof value !== "object") return value
+
+  const record = value as Record<string, unknown>
+  if (record.type === "Field" && typeof record.value === "string") {
+    return { ...record, value: record.value.startsWith(".") ? record.value.slice(1) : record.value }
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).map(([key, itemValue]) => [key, normalizeFilterItemMatchValue(itemValue)])
+  )
+}
+
+const filterItemComparisonBaseMatchKey = (item: FilterItemComparison): string =>
+  JSON.stringify({
+    leftValue: normalizeFilterItemMatchValue(item.leftValue),
+    comparisonType: item.comparisonType ?? "Equal",
+  })
+
+const filterItemComparisonStrictMatchKey = (item: FilterItemComparison): string =>
+  JSON.stringify({
+    leftValue: normalizeFilterItemMatchValue(item.leftValue),
+    comparisonType: item.comparisonType ?? "Equal",
+    rightValue: normalizeFilterItemMatchValue(item.rightValue),
+  })
 
 const filterItemGroupMatchKey = (item: FilterItemGroup): string => String(item.groupType ?? "")
+
+const findOnlyIndex = (indices: number[]): number | undefined => (indices.length === 1 ? indices[0] : undefined)
 
 const findReferenceFilterItem = (
   item: FilterItem[number],
   referenceItems: FilterItem,
   usedIndices: Set<number>
 ): FilterItem[number] | undefined => {
+  const candidateIndices: number[] = []
+
   for (let i = 0; i < referenceItems.length; i++) {
     if (usedIndices.has(i)) continue
     const refItem = referenceItems[i]
     if (item.itemType !== refItem.itemType) continue
+
     if (
       item.itemType === "FilterItemComparison" &&
       refItem.itemType === "FilterItemComparison" &&
-      filterItemComparisonMatchKey(item) === filterItemComparisonMatchKey(refItem)
+      filterItemComparisonBaseMatchKey(item) === filterItemComparisonBaseMatchKey(refItem)
     ) {
-      usedIndices.add(i)
-      return refItem
+      candidateIndices.push(i)
+      continue
     }
+
     if (
       item.itemType === "FilterItemGroup" &&
       refItem.itemType === "FilterItemGroup" &&
       filterItemGroupMatchKey(item) === filterItemGroupMatchKey(refItem)
     ) {
-      usedIndices.add(i)
-      return refItem
+      candidateIndices.push(i)
     }
   }
-  return undefined
+
+  const onlyCandidateIndex = findOnlyIndex(candidateIndices)
+  if (onlyCandidateIndex !== undefined) {
+    usedIndices.add(onlyCandidateIndex)
+    return referenceItems[onlyCandidateIndex]
+  }
+
+  if (item.itemType !== "FilterItemComparison") return undefined
+
+  const strictCandidateIndices = candidateIndices.filter((index) => {
+    const refItem = referenceItems[index]
+    return (
+      refItem.itemType === "FilterItemComparison" &&
+      filterItemComparisonStrictMatchKey(item) === filterItemComparisonStrictMatchKey(refItem)
+    )
+  })
+
+  const onlyStrictCandidateIndex = findOnlyIndex(strictCandidateIndices)
+  if (onlyStrictCandidateIndex === undefined) return undefined
+
+  usedIndices.add(onlyStrictCandidateIndex)
+  return referenceItems[onlyStrictCandidateIndex]
 }
 
 const exportFilterItemElementToXML = (params: {


### PR DESCRIPTION
## Summary
- Восстановлено безопасное сопоставление reference для DCS FilterItemComparison и FilterItemGroup.
- Добавлены проверки неоднозначных совпадений, implicit Equal, xs:string presentation и вложенных FilterItem.

## Test Plan
- pnpm --filter '@nakidka/core' test
- pnpm test
- ./.agents/skills/round-trip-yaml/round-trip.sh