### PR TITLE
feat: добавить AJV-компиляцию схем

### DIFF
--- a/packages/core/metadata/appliedObjects/metadataCommand/fromYAML.test.ts
+++ b/packages/core/metadata/appliedObjects/metadataCommand/fromYAML.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { importMetadataItemFromYAML } from "../../orchestration"
 import { exportMetadataItemToJSONSchema } from "../../orchestration/metadataItem/toJSONSchema"
@@ -9,7 +9,7 @@ import { MetadataCommandRules } from "./rules"
 
 describe("MetadataCommand YAML", () => {
   it("rejects scalar command group shorthand in JSON Schema", () => {
-    const schema = Schema.Compile(
+    const schema = compileValidationSchema(
       exportMetadataItemToJSONSchema({ context: mockContext, rule: MetadataCommandRules })
     )
 
@@ -17,7 +17,7 @@ describe("MetadataCommand YAML", () => {
   })
 
   it("accepts command group property in JSON Schema", () => {
-    const schema = Schema.Compile(
+    const schema = compileValidationSchema(
       exportMetadataItemToJSONSchema({ context: mockContext, rule: MetadataCommandRules })
     )
 

--- a/packages/core/metadata/appliedObjects/metadataEnumeration/fromYAML.test.ts
+++ b/packages/core/metadata/appliedObjects/metadataEnumeration/fromYAML.test.ts
@@ -1,5 +1,5 @@
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
-import Schema from "typebox/schema"
 import { testExportAppliedObjectToYAML } from "../../../tests/appliedObject"
 import { mockContext } from "../../../tests/mockContext"
 import { full, fullYAML } from "./__fixtures__/full"
@@ -52,7 +52,7 @@ describe("import MetadataEnumeration from YAML", () => {
   })
 
   it("accepts enum values whose name is taken from the YAML key in JSON Schema", () => {
-    const schema = Schema.Compile(exportMetadataEnumerationToJSONSchema({ context: mockContext }))
+    const schema = compileValidationSchema(exportMetadataEnumerationToJSONSchema({ context: mockContext }))
 
     expect(schema.Check({ Значения: { Значение1: {} } })).toBe(true)
     expect(schema.Check({ Значения: { Значение1: { Синоним: "Синоним" } } })).toBe(true)
@@ -60,7 +60,7 @@ describe("import MetadataEnumeration from YAML", () => {
   })
 
   it("rejects invalid enum value properties in JSON Schema", () => {
-    const schema = Schema.Compile(exportMetadataEnumerationToJSONSchema({ context: mockContext }))
+    const schema = compileValidationSchema(exportMetadataEnumerationToJSONSchema({ context: mockContext }))
 
     expect(schema.Check({ Значения: { Значение1: { Лишнее: "значение" } } })).toBe(false)
     expect(schema.Check({ Значения: { Значение1: { Имя: 1 } } })).toBe(false)

--- a/packages/core/metadata/commonObjects/border/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/border/toJSONSchema.test.ts
@@ -1,9 +1,9 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { BorderJSONSchema } from "./types"
 
 describe("BorderJSONSchema", () => {
-  const schema = Schema.Compile(BorderJSONSchema)
+  const schema = compileValidationSchema(BorderJSONSchema)
 
   it("accepts empty style name", () => {
     expect(schema.Check({ Имя: null, Ширина: 1, ТипРамки: "БезРамки" })).toBe(true)

--- a/packages/core/metadata/commonObjects/choiceList/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/choiceList/toJSONSchema.test.ts
@@ -1,9 +1,9 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { ChoiceListJSONSchema } from "./types"
 
 describe("ChoiceListJSONSchema", () => {
-  const compiled = Schema.Compile(ChoiceListJSONSchema)
+  const compiled = compileValidationSchema(ChoiceListJSONSchema)
 
   it("accepts form choice list objects with presentation or compact value", () => {
     expect(

--- a/packages/core/metadata/commonObjects/color/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/color/toJSONSchema.test.ts
@@ -1,8 +1,8 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { ColorJSONSchema } from "./types"
 
-const compiled = Schema.Compile(ColorJSONSchema)
+const compiled = compileValidationSchema(ColorJSONSchema)
 
 const errorsFor = (value: unknown): string[] => {
   return compiled.Errors(value)[1].map((error) => `${error.instancePath}: ${error.message}`)

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/appearanceFields/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/appearanceFields/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { exportPropertyToJSONSchema } from "../../../orchestration/property/toJSONSchema"
 import { mockContext } from "../../../../tests/mockContext"
@@ -11,7 +11,7 @@ const schemaFor = () => {
     value: undefined,
   })
   if (schema === undefined) throw new Error("schema is undefined")
-  return Schema.Compile(schema)
+  return compileValidationSchema(schema)
 }
 
 describe("AppearanceFields exportToJSONSchema", () => {

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/availableFields/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { exportPropertyToJSONSchema } from "../../../orchestration/property/toJSONSchema"
 import "./toJSONSchema"
@@ -15,7 +15,7 @@ describe("AvailableFields JSON Schema", () => {
       rule: { type: "AvailableFields", yaml: "ДоступныеПоляОтбора" },
       value: undefined,
     })
-    const compiled = Schema.Compile(schema!)
+    const compiled = compileValidationSchema(schema!)
 
     expect(compiled.Check(["Документ", { Поле: "Документ", Использование: "Ложь" }])).toBe(true)
   })
@@ -26,7 +26,7 @@ describe("AvailableFields JSON Schema", () => {
       rule: { type: "AvailableFields", yaml: "ДоступныеПоляОтбора" },
       value: undefined,
     })
-    const compiled = Schema.Compile(schema!)
+    const compiled = compileValidationSchema(schema!)
 
     expect(compiled.Check({ Документ: { Поле: "Документ" } })).toBe(false)
   })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/availableValues/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/availableValues/fromYAML.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { importPropertyFromYAML } from "../../../orchestration"
 import { exportPropertyToJSONSchema } from "../../../orchestration/property/toJSONSchema"
@@ -55,7 +55,7 @@ describe("import DcsAvailableValues from YAML", () => {
   it("accepts string values in JSON Schema", () => {
     const schema = exportPropertyToJSONSchema({ context: mockContext, rule, value: undefined })
     if (schema === undefined) throw new Error("DcsAvailableValues JSON Schema is not registered")
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(compiled.Check([{ Значение: '"Выставлен"', Представление: { ru: "Выставлен" } }])).toBe(true)
   })
@@ -63,7 +63,7 @@ describe("import DcsAvailableValues from YAML", () => {
   it("accepts absent values in JSON Schema", () => {
     const schema = exportPropertyToJSONSchema({ context: mockContext, rule, value: undefined })
     if (schema === undefined) throw new Error("DcsAvailableValues JSON Schema is not registered")
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(compiled.Check([{}])).toBe(true)
   })
@@ -71,7 +71,7 @@ describe("import DcsAvailableValues from YAML", () => {
   it("rejects unsupported available value keys in JSON Schema", () => {
     const schema = exportPropertyToJSONSchema({ context: mockContext, rule, value: undefined })
     if (schema === undefined) throw new Error("DcsAvailableValues JSON Schema is not registered")
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(compiled.Check([{ Значение: '"Выставлен"', НеизвестноеПоле: "x" }])).toBe(false)
   })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/toJSONSchema.test.ts
@@ -1,11 +1,11 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema, type ValidationSchemaValidator } from "./../../../validation/compileValidationSchema"
 import { beforeAll, describe, expect, it } from "vitest"
 import { exportPropertyToJSONSchema } from "../../../orchestration/property/toJSONSchema"
 import { mockContext } from "../../../../tests/mockContext"
 import type { DcsMetadataValuePropertyRule } from "./types"
 import "./toJSONSchema"
 
-const compiledSchemas = new Map<string, ReturnType<typeof Schema.Compile>>()
+const compiledSchemas = new Map<string, ValidationSchemaValidator>()
 
 const schemaFor = (rule: DcsMetadataValuePropertyRule) => {
   const cacheKey = `${rule.valueType}:${rule.yaml}`
@@ -14,7 +14,7 @@ const schemaFor = (rule: DcsMetadataValuePropertyRule) => {
 
   const schema = exportPropertyToJSONSchema({ context: mockContext, rule, value: undefined })
   if (schema === undefined) throw new Error("schema is undefined")
-  const compiled = Schema.Compile(schema)
+  const compiled = compileValidationSchema(schema)
   compiledSchemas.set(cacheKey, compiled)
   return compiled
 }

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/rules.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/rules.ts
@@ -1,4 +1,3 @@
-import type { Static } from "typebox"
 import {
   ConfigurationContext,
   ConfigurationContextFromXML,
@@ -16,7 +15,7 @@ import { exportStandartBeginningDateToXML } from "../../standartBeginningDate/to
 import { exportStandartBeginningDateToYAML } from "../../standartBeginningDate/toYAML"
 import {
   StandartBeginningDate,
-  StandartBeginningDateJSONSchema,
+  type StandartBeginningDateYAML,
   StandartBeginningDateXML,
 } from "../../standartBeginningDate/types"
 import {
@@ -235,7 +234,7 @@ type MetadataValueRule = { type: "MetadataValue"; valueType: [PrimitiveDcsType] 
 const isStringYAML = (yaml: DcsMetadataTypedValueYAML): yaml is string => typeof yaml === "string"
 const isStandardBeginningDateYAML = (
   yaml: DcsMetadataTypedValueYAML
-): yaml is Static<typeof StandartBeginningDateJSONSchema> =>
+): yaml is StandartBeginningDateYAML =>
   typeof yaml === "object" && yaml !== null && !Array.isArray(yaml) && "Вариант" in yaml
 
 const yamlDateTimeToXMLDateTime = (value: string): string => {

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dscMetadataTypedValue/types.ts
@@ -4,12 +4,12 @@ import {
 } from "../../ruleBuilder"
 import type { PropertyRule as WidePropertyRuleBase } from "../../../orchestration/property/types"
 import { Type } from "typebox"
-import type { Static } from "typebox"
 import { BasePropertyRule } from "../../../orchestration"
 import { BooleanJSONSchema } from "../../boolean/types"
 import {
   StandartBeginningDate,
   StandartBeginningDateJSONSchema,
+  StandartBeginningDateYAML,
   StandartBeginningDateXML,
 } from "../../standartBeginningDate/types"
 
@@ -66,7 +66,7 @@ export const DcsMetadataTypedValueJSONSchema = Type.Union([
   StandartBeginningDateJSONSchema,
 ])
 
-export type DcsMetadataTypedValueYAML = Static<typeof DcsMetadataTypedValueJSONSchema>
+export type DcsMetadataTypedValueYAML = "Порядок" | "СписокЗначений" | string | number | StandartBeginningDateYAML
 export type DcsMetadataTypedValueNilArrayItemYAML = Record<string, never>
 export type DcsMetadataTypedValueArrayItemYAML = DcsMetadataTypedValueYAML | DcsMetadataTypedValueNilArrayItemYAML
 

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { exportPropertyToJSONSchema } from "../../../orchestration/property/toJSONSchema"
 import "./types"
@@ -16,7 +16,7 @@ describe("FilterItem JSON Schema", () => {
       value: undefined,
     })
 
-    return Schema.Compile(schema!)
+    return compileValidationSchema(schema!)
   }
 
   it("accepts comparison items", () => {

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/orderItemFields/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/orderItemFields/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { exportPropertyToJSONSchema } from "../../../orchestration/property/toJSONSchema"
 import "./types"
@@ -15,7 +15,7 @@ describe("OrderItemFields JSON Schema", () => {
       rule: { type: "OrderItemFields", yaml: "Элементы" },
       value: undefined,
     })
-    const compiled = Schema.Compile(schema!)
+    const compiled = compileValidationSchema(schema!)
 
     expect(compiled.Check([{ Поле: "Дата" }, "[Авто]"])).toBe(true)
   })
@@ -26,7 +26,7 @@ describe("OrderItemFields JSON Schema", () => {
       rule: { type: "OrderItemFields", yaml: "Элементы" },
       value: undefined,
     })
-    const compiled = Schema.Compile(schema!)
+    const compiled = compileValidationSchema(schema!)
 
     expect(compiled.Check({ Дата: { Поле: "Дата" } })).toBe(false)
   })

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/parameterValue/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/parameterValue/toJSONSchema.test.ts
@@ -1,11 +1,11 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema, type ValidationSchemaValidator } from "./../../../validation/compileValidationSchema"
 import { beforeAll, describe, expect, it } from "vitest"
 import { exportPropertyToJSONSchema } from "../../../orchestration/property/toJSONSchema"
 import { mockContext } from "../../../../tests/mockContext"
 import type { SettingsParameterValuePropertyRule } from "./types"
 import "./toJSONSchema"
 
-const compiledSchemas = new Map<string, ReturnType<typeof Schema.Compile>>()
+const compiledSchemas = new Map<string, ValidationSchemaValidator>()
 
 const schemaFor = (rule: SettingsParameterValuePropertyRule) => {
   const cacheKey = `${rule.valueType}:${rule.yaml}`
@@ -14,7 +14,7 @@ const schemaFor = (rule: SettingsParameterValuePropertyRule) => {
 
   const schema = exportPropertyToJSONSchema({ context: mockContext, rule, value: undefined })
   if (schema === undefined) throw new Error("schema is undefined")
-  const compiled = Schema.Compile(schema)
+  const compiled = compileValidationSchema(schema)
   compiledSchemas.set(cacheKey, compiled)
   return compiled
 }

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/settingsParameterValueCollection/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/settingsParameterValueCollection/fromYAML.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema, type ValidationSchemaValidator } from "./../../../validation/compileValidationSchema"
 import { beforeAll, describe, expect, it } from "vitest"
 import { PropertyRule } from "../../../orchestration"
 import { exportPropertyToJSONSchema } from "../../../orchestration/property/toJSONSchema"
@@ -19,15 +19,15 @@ const rule: PropertyRule = {
   },
 }
 
-let compiledDefaultSchema: ReturnType<typeof Schema.Compile> | undefined
-let compiledExplicitRulesSchema: ReturnType<typeof Schema.Compile> | undefined
+let compiledDefaultSchema: ValidationSchemaValidator | undefined
+let compiledExplicitRulesSchema: ValidationSchemaValidator | undefined
 
-function defaultSchema(): ReturnType<typeof Schema.Compile> {
+function defaultSchema(): ValidationSchemaValidator {
   compiledDefaultSchema ??= compileSchema(rule)
   return compiledDefaultSchema
 }
 
-function explicitRulesSchema(): ReturnType<typeof Schema.Compile> {
+function explicitRulesSchema(): ValidationSchemaValidator {
   compiledExplicitRulesSchema ??= compileSchema({
     type: "SettingsParameterValueCollection",
     defaultItemRule: {
@@ -48,10 +48,10 @@ function explicitRulesSchema(): ReturnType<typeof Schema.Compile> {
   return compiledExplicitRulesSchema
 }
 
-function compileSchema(rule: PropertyRule): ReturnType<typeof Schema.Compile> {
+function compileSchema(rule: PropertyRule): ValidationSchemaValidator {
   const schema = exportPropertyToJSONSchema({ context: mockContext, rule, value: undefined })
   if (schema === undefined) throw new Error("SettingsParameterValueCollection JSON Schema is not registered")
-  return Schema.Compile(schema)
+  return compileValidationSchema(schema)
 }
 
 describe("import SettingsParameterValueCollection from YAML", () => {

--- a/packages/core/metadata/commonObjects/exchangePlanContent/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/exchangePlanContent/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { mockContext } from "../../../tests/mockContext"
 import { exportMetadataItemToJSONSchema } from "../../orchestration/metadataItem/toJSONSchema"
@@ -8,7 +8,7 @@ import "./register"
 
 describe("ExchangePlanContent JSON Schema", () => {
   it("accepts compact content items without implicit Авторегистрация", () => {
-    const schema = Schema.Compile(
+    const schema = compileValidationSchema(
       exportMetadataItemToJSONSchema({
         context: mockContext,
         rule: ExchangePlanContentRules,

--- a/packages/core/metadata/commonObjects/formattedI8nText/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/formattedI8nText/toJSONSchema.test.ts
@@ -1,9 +1,9 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { FormattedI8nTextJSONSchema } from "./types"
 
 describe("FormattedI8nTextJSONSchema", () => {
-  const compiled = Schema.Compile(FormattedI8nTextJSONSchema)
+  const compiled = compileValidationSchema(FormattedI8nTextJSONSchema)
 
   it("accepts plain default-language text", () => {
     expect(compiled.Check({ Текст: "Заголовок" })).toBe(true)

--- a/packages/core/metadata/commonObjects/homePageWorkArea/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/homePageWorkArea/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { exportMetadataItemToJSONSchema } from "../../orchestration/metadataItem/toJSONSchema"
 import { registerCoreMetadata } from "../../register"
@@ -12,7 +12,7 @@ registerCoreMetadata()
 describe("HomePageWorkArea JSON Schema", () => {
   it("accepts working area columns and item visibility", () => {
     const schema = exportMetadataItemToJSONSchema({ context: mockContext, rule: HomePageWorkAreaRules })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(
       compiled.Check({
@@ -44,7 +44,7 @@ describe("HomePageWorkArea JSON Schema", () => {
 
   it("rejects unknown column item properties", () => {
     const schema = exportMetadataItemToJSONSchema({ context: mockContext, rule: HomePageWorkAreaRules })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(
       compiled.Check({

--- a/packages/core/metadata/commonObjects/metadataAttribute/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataAttribute/fromYAML.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import {
   fullMetadataAttributesFromCompactYAML,
@@ -90,7 +90,7 @@ describe("import MetadataAttributes from YAML", () => {
 
   it("should reject scalar values in JSON Schema", () => {
     const schema = exportMetadataAttributesToJSONSchema({ context: mockContext, rule, value: undefined })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(compiled.Check({ Организация: "Справочник.Организации" })).toBe(false)
     expect(compiled.Check({ Организация: { Тип: "Справочник.Организации" } })).toBe(true)

--- a/packages/core/metadata/commonObjects/metadataField/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/metadataField/toJSONSchema.test.ts
@@ -3,6 +3,11 @@ import { getTypeRule } from "../../orchestration"
 import { mockContext, mockRule } from "../../../tests/mockContext"
 import { exportMetadataFieldToJSONSchema } from "./toJSONSchema"
 
+type StringSchemaMetadata = {
+  pattern?: string
+  examples?: unknown[]
+}
+
 describe("exportMetadataFieldToJSONSchema", () => {
   it("uses metadataTarget roots for metadata fields", () => {
     const result = exportMetadataFieldToJSONSchema({
@@ -24,8 +29,9 @@ describe("exportMetadataFieldToJSONSchema", () => {
       type: "string",
       examples: ["Справочник.ИмяСправочника.Реквизит.ИмяРеквизита"],
     })
-    const pattern = new RegExp(String(result?.pattern))
-    const examples = Array.isArray(result?.examples) ? result.examples : []
+    const schema = result as StringSchemaMetadata | undefined
+    const pattern = new RegExp(String(schema?.pattern))
+    const examples = Array.isArray(schema?.examples) ? schema.examples : []
 
     expect(pattern.test("Справочник.ИмяСправочника.Реквизит.ИмяРеквизита")).toBe(true)
     for (const example of examples) expect(pattern.test(String(example))).toBe(true)
@@ -77,8 +83,9 @@ describe("exportMetadataFieldToJSONSchema", () => {
       type: "string",
       examples: ["Справочник.ИмяСправочника.Реквизит.ИмяРеквизита"],
     })
-    expect(new RegExp(String(result?.pattern)).test("Справочник.ИмяСправочника.Реквизит.ИмяРеквизита")).toBe(true)
-    expect(new RegExp(String(result?.pattern)).test("Справочник.ИмяСправочника")).toBe(false)
+    const schema = result as StringSchemaMetadata | undefined
+    expect(new RegExp(String(schema?.pattern)).test("Справочник.ИмяСправочника.Реквизит.ИмяРеквизита")).toBe(true)
+    expect(new RegExp(String(schema?.pattern)).test("Справочник.ИмяСправочника")).toBe(false)
   })
 
   it("uses member fallback for registered metadata fields array schemas", () => {

--- a/packages/core/metadata/commonObjects/metadataRef/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/metadataRef/toJSONSchema.test.ts
@@ -3,6 +3,10 @@ import { getTypeRule } from "../../orchestration"
 import { mockContext, mockRule } from "../../../tests/mockContext"
 import { exportMetadataItemLinkToJSONSchema } from "./toJSONSchema"
 
+type StringSchemaMetadata = {
+  pattern?: string
+}
+
 describe("exportMetadataItemLinkToJSONSchema", () => {
   it("should export metadata item link JSON schema", () => {
     const result = exportMetadataItemLinkToJSONSchema({ context: mockContext, rule: mockRule, value: undefined })
@@ -36,9 +40,10 @@ describe("exportMetadataItemLinkToJSONSchema", () => {
       type: "string",
       examples: ["ИмяСправочника"],
     })
-    expect(new RegExp(String(result?.pattern)).test("ИмяСправочника")).toBe(true)
-    expect(new RegExp(String(result?.pattern)).test("Справочник.ИмяСправочника")).toBe(false)
-    expect(new RegExp(String(result?.pattern)).test("Документ.ИмяДокумента")).toBe(false)
+    const schema = result as StringSchemaMetadata | undefined
+    expect(new RegExp(String(schema?.pattern)).test("ИмяСправочника")).toBe(true)
+    expect(new RegExp(String(schema?.pattern)).test("Справочник.ИмяСправочника")).toBe(false)
+    expect(new RegExp(String(schema?.pattern)).test("Документ.ИмяДокумента")).toBe(false)
   })
 
   it("wraps metadata item link schemas into array items", () => {

--- a/packages/core/metadata/commonObjects/metadataTabularSection/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/metadataTabularSection/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { exportMetadataItemToJSONSchema } from "../../orchestration/metadataItem/toJSONSchema"
 import { mockContext } from "../../../tests/mockContext"
@@ -6,7 +6,7 @@ import { MetadataTabularSectionRules } from "./rules"
 
 describe("MetadataTabularSection JSON Schema", () => {
   const compiled = () =>
-    Schema.Compile(
+    compileValidationSchema(
       exportMetadataItemToJSONSchema({
         context: mockContext,
         rule: MetadataTabularSectionRules,

--- a/packages/core/metadata/commonObjects/metadataTargets/schema.test.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/schema.test.ts
@@ -1,5 +1,5 @@
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
-import Schema from "typebox/schema"
 import type { TSchema } from "typebox"
 import { buildMetadataTargetSchema } from "./index"
 
@@ -278,7 +278,7 @@ describe("buildMetadataTargetSchema", () => {
 
   it("builds local member schema for single current-owner member kind", () => {
     const schema = buildMetadataTargetSchema({ kind: "member", owner: "this", memberKinds: ["Form"] })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(compiled.Check("ФормаДокумента")).toBe(true)
     expect(compiled.Check("Document.АвансовыйОтчет.Form.ФормаДокумента")).toBe(true)
@@ -288,7 +288,7 @@ describe("buildMetadataTargetSchema", () => {
 
   it("keeps member kind in schema when several current-owner member kinds are allowed", () => {
     const schema = buildMetadataTargetSchema({ kind: "member", owner: "this", memberKinds: ["Form", "Template"] })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(compiled.Check("Форма.ФормаДокумента")).toBe(true)
     expect(compiled.Check("Макет.ПечатнаяФорма")).toBe(true)
@@ -297,7 +297,7 @@ describe("buildMetadataTargetSchema", () => {
 
   it("accepts current-owner members through tabular sections", () => {
     const schema = buildMetadataTargetSchema({ kind: "member", owner: "this", memberKinds: ["Attribute"] })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(compiled.Check("ТабличнаяЧасть.Товары.Реквизит.Номенклатура")).toBe(true)
     expect(compiled.Check("Document.АвансовыйОтчет.TabularSection.Товары.Attribute.Номенклатура")).toBe(true)
@@ -310,7 +310,7 @@ describe("buildMetadataTargetSchema", () => {
       roots: ["Document"],
       memberKinds: ["Form"],
     })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(compiled.Check("Document.АвансовыйОтчет.Form.ФормаДокумента")).toBe(true)
     expect(compiled.Check("Catalog.АвансовыйОтчет.Form.ФормаДокумента")).toBe(false)
@@ -323,7 +323,7 @@ describe("buildMetadataTargetSchema", () => {
       roots: ["Document"],
       memberKinds: ["Attribute"],
     })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(compiled.Check("Document.АвансовыйОтчет.Attribute.Организация")).toBe(true)
     expect(compiled.Check("Catalog.АвансовыйОтчет.Attribute.Организация")).toBe(false)

--- a/packages/core/metadata/commonObjects/metadataTargets/schema.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/schema.ts
@@ -12,6 +12,12 @@ import type {
 
 type MetadataPrimitiveType = NonNullable<Extract<MetadataTargetConstraint, { kind: "type" }>["primitives"]>[number]
 
+export type MetadataTargetJSONSchema = TSchema & {
+  pattern?: string
+  examples?: string[]
+  description?: string
+}
+
 const noMatchPattern = "^(?!)$"
 const emptyRefYAML = "ПустаяСсылка"
 
@@ -100,7 +106,7 @@ const primitiveTypeExamples = {
   ValueStorage: "ХранилищеЗначения",
 } as const satisfies Record<MetadataPrimitiveType, string>
 
-export function buildMetadataTargetSchema(constraint: MetadataTargetConstraint): TSchema {
+export function buildMetadataTargetSchema(constraint: MetadataTargetConstraint): MetadataTargetJSONSchema {
   if (constraint.kind === "object") return objectSchema(constraint)
   if (constraint.kind === "member") return memberSchema(constraint)
   if (constraint.kind === "value") return valueSchema(constraint)

--- a/packages/core/metadata/commonObjects/metadataValue/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/metadataValue/toJSONSchema.test.ts
@@ -1,8 +1,12 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { mockContext } from "../../../tests/mockContext"
 import { exportMetadataValueToJSONSchema } from "./toJSONSchema"
 import { MetadataValueJSONSchema } from "./types"
+
+type StringSchemaMetadata = {
+  pattern?: string
+}
 
 describe("exportMetadataValueToJSONSchema", () => {
   it("keeps common MetadataValue schema without metadataTarget", () => {
@@ -16,13 +20,13 @@ describe("exportMetadataValueToJSONSchema", () => {
   })
 
   it("accepts compact formChoiceList object in common MetadataValue schema", () => {
-    const compiled = Schema.Compile(MetadataValueJSONSchema)
+    const compiled = compileValidationSchema(MetadataValueJSONSchema)
 
     expect(compiled.Check({ Значение: "Истина" })).toBe(true)
   })
 
   it("rejects empty and unknown objects in common MetadataValue schema", () => {
-    const compiled = Schema.Compile(MetadataValueJSONSchema)
+    const compiled = compileValidationSchema(MetadataValueJSONSchema)
 
     expect(compiled.Check({})).toBe(false)
     expect(compiled.Check({ Лишнее: "x" })).toBe(false)
@@ -53,9 +57,10 @@ describe("exportMetadataValueToJSONSchema", () => {
         "Справочник.ИмяСправочника.ПустаяСсылка",
       ],
     })
-    expect(String(schema.pattern)).toContain("Справочник")
-    expect(String(schema.pattern)).toContain("Перечисление")
-    expect(new RegExp(String(schema.pattern)).test("Справочник.СтавкиНДС.ПустаяСсылка")).toBe(true)
-    expect(new RegExp(String(schema.pattern)).test("Перечисление.ВидыДоговоров.СПоставщиком")).toBe(true)
+    const stringSchema = schema as StringSchemaMetadata
+    expect(String(stringSchema.pattern)).toContain("Справочник")
+    expect(String(stringSchema.pattern)).toContain("Перечисление")
+    expect(new RegExp(String(stringSchema.pattern)).test("Справочник.СтавкиНДС.ПустаяСсылка")).toBe(true)
+    expect(new RegExp(String(stringSchema.pattern)).test("Перечисление.ВидыДоговоров.СПоставщиком")).toBe(true)
   })
 })

--- a/packages/core/metadata/commonObjects/predefinedItem/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/predefinedItem/fromYAML.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { PropertyRule } from "../../orchestration"
 import { testExportPropertyToYAML } from "../../../tests/property/exportPropertyToYAML"
@@ -63,7 +63,7 @@ describe("import PredefinedItemCollection from YAML", () => {
 })
 
 describe("PredefinedItemCollection JSON Schema", () => {
-  const check = Schema.Compile(exportPredefinedItemCollectionToJSONSchema(mockContext))
+  const check = compileValidationSchema(exportPredefinedItemCollectionToJSONSchema(mockContext))
 
   it("принимает keyed-запись без Кода и Наименования", () => {
     expect(check.Check({ ПредопределенноеЗначение: {} })).toBe(true)

--- a/packages/core/metadata/commonObjects/recalculation/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/recalculation/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { getTypeRule } from "../../orchestration/property/typeRuleRegistry"
 import { mockContext } from "../../../tests/mockContext"
@@ -14,7 +14,7 @@ const compileSchema = () => {
   })
   if (schema === undefined) throw new Error("Recalculations JSON schema export returned undefined")
 
-  return Schema.Compile(schema)
+  return compileValidationSchema(schema)
 }
 
 describe("Recalculations exportToJSONSchema", () => {

--- a/packages/core/metadata/commonObjects/rootCommandInterface/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/rootCommandInterface/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { exportMetadataItemToJSONSchema } from "../../orchestration/metadataItem/toJSONSchema"
 import { registerCoreMetadata } from "../../register"
@@ -10,7 +10,7 @@ registerCoreMetadata()
 describe("RootCommandInterface JSON Schema", () => {
   it("accepts empty subsystem order separators", () => {
     const schema = exportMetadataItemToJSONSchema({ context: mockContext, rule: RootCommandInterfaceRules })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(
       compiled.Check({

--- a/packages/core/metadata/commonObjects/standardPeriod/types.ts
+++ b/packages/core/metadata/commonObjects/standardPeriod/types.ts
@@ -32,6 +32,6 @@ export const StandardPeriodYAMLJSONSchema = Type.Object({
   ДатаОкончания: Type.Optional(Type.String({ pattern: russianDateTimeWithSecondsPattern })),
 })
 
-export interface StandardPeriodYAML extends Static<typeof StandardPeriodYAMLJSONSchema> {
+export interface StandardPeriodYAML extends Omit<Static<typeof StandardPeriodYAMLJSONSchema>, "Вариант"> {
   Вариант: StandardPeriodVariantYAML
 }

--- a/packages/core/metadata/commonObjects/standartBeginningDate/types.ts
+++ b/packages/core/metadata/commonObjects/standartBeginningDate/types.ts
@@ -1,6 +1,9 @@
 import { Type } from "typebox"
-import type { Static } from "typebox"
-import { StandardBeginningDateVariantFromYAML, type StandardBeginningDateVariant } from "../../systemEnumerations/types"
+import {
+  StandardBeginningDateVariantFromYAML,
+  type StandardBeginningDateVariant,
+  type StandardBeginningDateVariantYAML,
+} from "../../systemEnumerations/types"
 
 export interface StandartBeginningDate {
   variant: StandardBeginningDateVariant
@@ -18,7 +21,10 @@ export const StandartBeginningDateJSONSchema = Type.Object({
   Дата: Type.Optional(Type.String({ pattern: russianDateTimePattern })),
 })
 
-export type StandartBeginningDateYAML = Static<typeof StandartBeginningDateJSONSchema>
+export interface StandartBeginningDateYAML {
+  Вариант: StandardBeginningDateVariantYAML
+  Дата?: string
+}
 
 export interface StandartBeginningDateXML {
   "_xsi:type"?: "v8:StandardBeginningDate"

--- a/packages/core/metadata/commonObjects/string/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/string/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { mockContext } from "../../../tests/mockContext"
 import { exportStringToJSONSchema } from "./toJSONSchema"
@@ -13,7 +13,7 @@ describe("exportStringToJSONSchema", () => {
       },
       value: undefined,
     })
-    const compiled = Schema.Compile(schema!)
+    const compiled = compileValidationSchema(schema!)
 
     expect(compiled.Check("ФормаОбъекта")).toBe(true)
     expect(compiled.Check("Справочник.Товары")).toBe(false)

--- a/packages/core/metadata/commonObjects/styleItemValue/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/styleItemValue/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { getTypeRule, type PropertyRule } from "../../orchestration"
 import { registerCoreMetadata } from "../../register"
@@ -18,7 +18,7 @@ describe("StyleItemValue exportToJSONSchema", () => {
     expect(schema).toBeDefined()
     if (schema === undefined) throw new Error("StyleItemValue JSON schema is not registered")
 
-    return Schema.Compile(schema)
+    return compileValidationSchema(schema)
   }
 
   it("accepts supported style item value kinds", () => {

--- a/packages/core/metadata/commonObjects/typeDescription/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/typeDescription/toJSONSchema.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { mockContext } from "../../../tests/mockContext"
 import { exportTypeDescriptionToJSONSchema } from "./toJSONSchema"
@@ -72,7 +72,7 @@ describe("exportTypeDescriptionToJSONSchema", () => {
     if (schema === undefined) {
       throw new Error("Expected TypeDescription JSON schema")
     }
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
     expect(compiled.Check({ ИдентификаторТипа: ["8c1e3694-da12-44d5-8b1f-d134b89a1282"] })).toBe(true)
     expect(compiled.Check({ ИдентификаторТипа: [] })).toBe(false)
     expect(compiled.Check({})).toBe(false)
@@ -145,7 +145,7 @@ describe("exportTypeDescriptionToJSONSchema", () => {
     if (jsonSchema === undefined) {
       throw new Error("Expected TypeDescription JSON schema")
     }
-    const schema = Schema.Compile(jsonSchema)
+    const schema = compileValidationSchema(jsonSchema)
 
     expect(schema.Check("ВнешнийИсточникДанныхВсеСвойства.ТаблицаВсеСвойства")).toBe(true)
     expect(schema.Check("ВнешнийИсточникДанныхВсеСвойства.КубВсеСвойства.ТаблицаИзмеренияВсеСвойства")).toBe(true)
@@ -172,7 +172,7 @@ describe("exportTypeDescriptionToJSONSchema", () => {
     if (jsonSchema === undefined) {
       throw new Error("Expected TypeDescription JSON schema")
     }
-    const schema = Schema.Compile(jsonSchema)
+    const schema = compileValidationSchema(jsonSchema)
 
     expect(schema.Check(["Строка", "Справочник.Контрагенты"])).toBe(true)
     expect(schema.Check(["Строка", "ХранилищеЗначения"])).toBe(false)
@@ -188,7 +188,7 @@ describe("exportTypeDescriptionToJSONSchema", () => {
     if (jsonSchema === undefined) {
       throw new Error("Expected TypeDescription JSON schema")
     }
-    const schema = Schema.Compile(jsonSchema)
+    const schema = compileValidationSchema(jsonSchema)
 
     expect(schema.Check({ ИдентификаторТипа: ["8c1e3694-da12-44d5-8b1f-d134b89a1282"] })).toBe(false)
   })

--- a/packages/core/metadata/commonObjects/userVisible/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/userVisible/toJSONSchema.test.ts
@@ -1,9 +1,9 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { UserVisibleJSONSchema } from "./types"
 
 describe("UserVisibleJSONSchema", () => {
-  const compiled = Schema.Compile(UserVisibleJSONSchema)
+  const compiled = compileValidationSchema(UserVisibleJSONSchema)
 
   it("accepts allow mode without explicit Разрешить", () => {
     expect(compiled.Check({ Роли: { "Role.Администратор": "Ложь" } })).toBe(true)

--- a/packages/core/metadata/commonObjects/webSocketClientHeaders/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/webSocketClientHeaders/toJSONSchema.test.ts
@@ -1,8 +1,8 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { exportWebSocketClientHeadersToJSONSchema } from "./toJSONSchema"
 
-const schema = Schema.Compile(
+const schema = compileValidationSchema(
   exportWebSocketClientHeadersToJSONSchema({
     context: {} as never,
     rule: { type: "WebSocketClientHeaders" },

--- a/packages/core/metadata/commonObjects/сhoiceParameters/toJSONSchema.test.ts
+++ b/packages/core/metadata/commonObjects/сhoiceParameters/toJSONSchema.test.ts
@@ -1,8 +1,8 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { ChoiceParametersJSONSchema } from "./types"
 
-const compiled = Schema.Compile(ChoiceParametersJSONSchema)
+const compiled = compileValidationSchema(ChoiceParametersJSONSchema)
 
 describe("ChoiceParametersJSONSchema", () => {
   it("accepts YAML parser null for an empty choice parameter key", () => {

--- a/packages/core/metadata/forms/commonObjects/formAttribute/toJSONSchema.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/toJSONSchema.ts
@@ -36,7 +36,7 @@ function extendFormAttributeColumnsSchema(schema: TSchema, context: Configuratio
 }
 
 function isObjectSchema(schema: TSchema): schema is TObject<TProperties> {
-  return schema.type === "object" && "properties" in schema
+  return "type" in schema && schema.type === "object" && "properties" in schema
 }
 
 function requiredFormAttributeSchema(context: ConfigurationContext): TSchema {

--- a/packages/core/metadata/helpers/excludeIfEqualNameYAML.test.ts
+++ b/packages/core/metadata/helpers/excludeIfEqualNameYAML.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { FormattedI8nTextJSONSchema } from "../commonObjects/formattedI8nText/types"
 import { I8nTextJSONSchema } from "../commonObjects/i8nText/types"
@@ -85,7 +85,7 @@ describe("applyExcludedEqualNameYAMLToJSONSchema", () => {
 
     expect((schema as { description?: string }).description).toBe(EXCLUDE_IF_EQUAL_NAME_YAML_DESCRIPTION)
 
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
     expect(compiled.Check("Какое то поле")).toBe(true)
     expect(compiled.Check({ ru: "Какое то поле", en: "Some field" })).toBe(true)
     expect(compiled.Check({ en: "Some field" })).toBe(true)
@@ -99,7 +99,7 @@ describe("applyExcludedEqualNameYAMLToJSONSchema", () => {
 
     expect((schema as { description?: string }).description).toBe(EXCLUDE_IF_EQUAL_NAME_YAML_DESCRIPTION)
 
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
     expect(compiled.Check({ Текст: "Какое то поле" })).toBe(true)
     expect(compiled.Check({ Текст: { ru: "Какое то поле", en: "Some field" } })).toBe(true)
     expect(compiled.Check({ Форматированный: "Истина", Текст: { en: "Some field" } })).toBe(true)

--- a/packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
+++ b/packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { importPropertyFromXML, PropertyRule } from ".."
 import { exportPropertyToJSONSchema } from "../property/toJSONSchema"
@@ -145,7 +145,7 @@ describe("registerMetadataItemCollectionRule default toJSONSchema", () => {
 
   it("exports record schema for record YAML collections", () => {
     const schema = exportPropertyToJSONSchema({ context, rule, value: undefined })
-    const compiled = Schema.Compile(schema!)
+    const compiled = compileValidationSchema(schema!)
 
     expect(compiled.Check({ A: { name: "A" } })).toBe(true)
     expect(compiled.Check([{ name: "A" }])).toBe(false)
@@ -153,7 +153,7 @@ describe("registerMetadataItemCollectionRule default toJSONSchema", () => {
 
   it("exports array schema for yamlAsArray collections", () => {
     const schema = exportPropertyToJSONSchema({ context, rule: arrayRule, value: undefined })
-    const compiled = Schema.Compile(schema!)
+    const compiled = compileValidationSchema(schema!)
 
     expect(compiled.Check([{ name: "A" }])).toBe(true)
     expect(compiled.Check({ A: { name: "A" } })).toBe(false)
@@ -161,7 +161,7 @@ describe("registerMetadataItemCollectionRule default toJSONSchema", () => {
 
   it("exports array schema inside recursive yamlAsArray collections", () => {
     const schema = exportPropertyToJSONSchema({ context, rule: recursiveArrayRule, value: undefined })
-    const compiled = Schema.Compile(schema!)
+    const compiled = compileValidationSchema(schema!)
 
     expect(compiled.Check([{ name: "A", children: [] }])).toBe(true)
     expect(compiled.Check([{ name: "A", children: { B: {} } }])).toBe(false)

--- a/packages/core/metadata/orchestration/property/toJSONSchema.ts
+++ b/packages/core/metadata/orchestration/property/toJSONSchema.ts
@@ -1,4 +1,4 @@
-import { TSchema, Type } from "typebox"
+import { TProperties, TSchema, Type } from "typebox"
 import { ConfigurationContext } from "../../context/types"
 import { applyExcludedEqualNameYAMLToJSONSchema } from "../../helpers/excludeIfEqualNameYAML"
 import { getTypeRule } from "./typeRuleRegistry"
@@ -46,10 +46,10 @@ export const exportPropertiesToJSONSchema = <T extends MetadataItem>(params: {
   context: ConfigurationContext
   rule: MetadataItemRule
   metadataItem?: T
-}): TSchema => {
+}): TProperties => {
   const { context, metadataItem, rule } = params
 
-  const result = {} as TSchema
+  const result: TProperties = {}
 
   for (const [key, ruleProp] of Object.entries(rule.properties) as [
     keyof T extends string ? keyof T : never,

--- a/packages/core/metadata/orchestration/property/toJSONSchemaImplicitValue.test.ts
+++ b/packages/core/metadata/orchestration/property/toJSONSchemaImplicitValue.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import "../../commonObjects/boolean/toJSONSchema"
 import "../../commonObjects/number/toJSONSchema"
@@ -16,7 +16,7 @@ describe("exportPropertyToJSONSchema implicitValueYAML", () => {
     })
 
     if (schema === undefined) throw new Error("Expected JSON schema")
-    const check = Schema.Compile(schema)
+    const check = compileValidationSchema(schema)
 
     expect(check.Check("Истина")).toBe(false)
     expect(check.Check("Ложь")).toBe(true)
@@ -30,7 +30,7 @@ describe("exportPropertyToJSONSchema implicitValueYAML", () => {
     })
 
     if (schema === undefined) throw new Error("Expected JSON schema")
-    const check = Schema.Compile(schema)
+    const check = compileValidationSchema(schema)
 
     expect(check.Check("Использовать")).toBe(false)
     expect(check.Check("НеИспользовать")).toBe(true)
@@ -44,7 +44,7 @@ describe("exportPropertyToJSONSchema implicitValueYAML", () => {
     })
 
     if (schema === undefined) throw new Error("Expected JSON schema")
-    const check = Schema.Compile(schema)
+    const check = compileValidationSchema(schema)
 
     expect(check.Check(9)).toBe(false)
     expect(check.Check(8)).toBe(true)
@@ -59,7 +59,7 @@ describe("exportPropertyToJSONSchema implicitValueYAML", () => {
     })
 
     if (schema === undefined) throw new Error("Expected JSON schema")
-    const check = Schema.Compile(schema)
+    const check = compileValidationSchema(schema)
 
     expect(check.Check("")).toBe(false)
     expect(check.Check("значение")).toBe(true)
@@ -74,7 +74,7 @@ describe("exportPropertyToJSONSchema implicitValueYAML", () => {
     })
 
     if (schema === undefined) throw new Error("Expected JSON schema")
-    const check = Schema.Compile(schema)
+    const check = compileValidationSchema(schema)
 
     expect(check.Check("Истина")).toBe(true)
     expect(check.Check("Ложь")).toBe(true)
@@ -88,7 +88,7 @@ describe("exportPropertyToJSONSchema implicitValueYAML", () => {
     })
 
     if (schema === undefined) throw new Error("Expected JSON schema")
-    const check = Schema.Compile(schema)
+    const check = compileValidationSchema(schema)
 
     expect(check.Check("")).toBe(true)
     expect(check.Check("Документ")).toBe(true)

--- a/packages/core/metadata/validation/compileValidationSchema.test.ts
+++ b/packages/core/metadata/validation/compileValidationSchema.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import { Type } from "typebox"
+import { compileValidationSchema } from "./compileValidationSchema"
+
+describe("compileValidationSchema", () => {
+  it("компилирует TypeBox-схему через совместимый интерфейс валидатора", () => {
+    const schema = Type.Object(
+      {
+        Имя: Type.String(),
+      },
+      { additionalProperties: false }
+    )
+
+    const compiled = compileValidationSchema(schema)
+
+    expect(compiled.Check({ Имя: "Документ" })).toBe(true)
+    expect(compiled.Check({ Лишнее: true })).toBe(false)
+    expect(compiled.Schema()).toBe(schema)
+
+    const [, errors] = compiled.Errors({ Лишнее: true })
+    expect(errors).toEqual([
+      expect.objectContaining({
+        keyword: "required",
+        instancePath: "",
+        params: { requiredProperties: ["Имя"] },
+      }),
+      expect.objectContaining({
+        keyword: "additionalProperties",
+        instancePath: "",
+        params: { additionalProperties: ["Лишнее"] },
+      }),
+    ])
+  })
+
+  it("компилирует схему с контекстом ссылок", () => {
+    const context = {
+      Named: Type.Object({ Значение: Type.String() }, { $id: "Named" }),
+    }
+    const compiled = compileValidationSchema(context, Type.Ref("Named"))
+
+    expect(compiled.Check({ Значение: "ok" })).toBe(true)
+    expect(compiled.Check({ Значение: 1 })).toBe(false)
+    expect(compiled.Context()).toBe(context)
+  })
+})

--- a/packages/core/metadata/validation/compileValidationSchema.ts
+++ b/packages/core/metadata/validation/compileValidationSchema.ts
@@ -1,0 +1,267 @@
+import Ajv2020, { type Options } from "ajv/dist/2020"
+import addFormats from "ajv-formats"
+import type { TSchema } from "typebox"
+import Schema from "typebox/schema"
+
+type SchemaContext = Record<string, TSchema>
+
+export interface ValidationSchemaError {
+  keyword: string
+  schemaPath: string
+  instancePath: string
+  params: Record<string, unknown>
+  message: string
+  schema?: TSchema
+  value?: unknown
+}
+
+export interface ValidationSchemaValidator<Type extends TSchema = TSchema> {
+  Check(value: unknown): boolean
+  Errors(value: unknown): [boolean, ValidationSchemaError[]]
+  Schema(): Type
+  Context(): SchemaContext
+}
+
+const ajvOptions: Options = {
+  addUsedSchema: false,
+  allowUnionTypes: true,
+  strict: false,
+  verbose: true,
+}
+
+export function compileValidationSchema<const Type extends TSchema>(schema: Type): ValidationSchemaValidator<Type>
+export function compileValidationSchema<Context extends SchemaContext, const Type extends TSchema>(
+  context: Context,
+  schema: Type
+): ValidationSchemaValidator<Type>
+export function compileValidationSchema(
+  schemaOrContext: TSchema | SchemaContext,
+  maybeSchema?: TSchema
+): ValidationSchemaValidator {
+  const context = maybeSchema === undefined ? {} : (schemaOrContext as SchemaContext)
+  const schema = maybeSchema ?? (schemaOrContext as TSchema)
+  const ajvSchema = prepareSchemaForAjv(schema)
+  const check = createAjv(context, { allErrors: false }).compile(ajvSchema)
+  const useFallbackCheck = hasLocalDefinitions(schema)
+  let fallback: ValidationSchemaValidator | undefined
+  const getFallback = (): ValidationSchemaValidator => {
+    fallback ??= createTypeboxFallback(context, schema, maybeSchema !== undefined)
+    return fallback
+  }
+
+  return {
+    Check(value) {
+      if (useFallbackCheck) return getFallback().Check(value)
+
+      try {
+        return check(value)
+      } catch (caught) {
+        if (!(caught instanceof RangeError)) throw caught
+        return getFallback().Check(value)
+      }
+    },
+    Errors(value) {
+      if (useFallbackCheck) return getFallback().Errors(value)
+
+      try {
+        const valid = check(value)
+        if (valid) return [true, []]
+      } catch (caught) {
+        if (!(caught instanceof RangeError)) throw caught
+      }
+
+      return getFallback().Errors(value)
+    },
+    Schema() {
+      return schema
+    },
+    Context() {
+      return context
+    },
+  }
+}
+
+function createTypeboxFallback(
+  context: SchemaContext,
+  schema: TSchema,
+  hasExplicitContext: boolean
+): ValidationSchemaValidator {
+  const compiled =
+    hasExplicitContext === true
+      ? Schema.Compile(context, schema)
+      : Schema.Compile(schema)
+
+  return {
+    Check(value) {
+      return compiled.Check(value)
+    },
+    Errors(value) {
+      return compiled.Errors(value) as [boolean, ValidationSchemaError[]]
+    },
+    Schema() {
+      return schema
+    },
+    Context() {
+      return context
+    },
+  }
+}
+
+function createAjv(context: SchemaContext, options: Pick<Options, "allErrors">): Ajv2020 {
+  const ajv = new Ajv2020({ ...ajvOptions, ...options })
+  addFormats(ajv)
+
+  for (const schema of Object.values(context)) {
+    ajv.addSchema(prepareSchemaForAjv(schema, { keepRootId: true }))
+  }
+
+  return ajv
+}
+
+interface PrepareSchemaOptions {
+  keepRootId?: boolean
+}
+
+interface RefScope {
+  pointer: string
+  names: Set<string>
+}
+
+interface CurrentDefinition {
+  name: string
+  dataDepth: number
+}
+
+type SchemaMapKind = "defs" | "properties"
+
+function prepareSchemaForAjv(schema: TSchema, options: PrepareSchemaOptions = {}): TSchema {
+  return prepareSchemaNode(schema, {
+    scopes: [],
+    pointer: "",
+    isRoot: true,
+    keepRootId: options.keepRootId === true,
+    dataDepth: 0,
+  }) as TSchema
+}
+
+function prepareSchemaNode(
+  value: unknown,
+  state: {
+    scopes: RefScope[]
+    pointer: string
+    isRoot: boolean
+    keepRootId: boolean
+    dataDepth: number
+    currentDefinition?: CurrentDefinition
+    mapKind?: SchemaMapKind
+  }
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      prepareSchemaNode(item, { ...state, pointer: `${state.pointer}/${index}`, isRoot: false })
+    )
+  }
+  if (value === null || typeof value !== "object") return value
+
+  const record = value as Record<string, unknown>
+  const localScope = localRefScope(record, state.pointer)
+  const scopes = localScope === undefined ? state.scopes : [...state.scopes, localScope]
+  const result: Record<string, unknown> = {}
+
+  for (const [key, entry] of Object.entries(record)) {
+    if (key === "$id" && !(state.isRoot && state.keepRootId)) continue
+    if (key === "type" && entry === "undefined") {
+      result.not = {}
+      continue
+    }
+
+    if (key === "$ref" && typeof entry === "string") {
+      if (isSameDataSelfRef(entry, state)) {
+        result.not = {}
+      } else {
+        result[key] = rewriteLocalRef(entry, scopes) ?? entry
+      }
+      continue
+    }
+
+    result[key] = prepareSchemaNode(entry, {
+      scopes,
+      pointer: `${state.pointer}/${escapeJsonPointerSegment(key)}`,
+      isRoot: false,
+      keepRootId: state.keepRootId,
+      dataDepth: childDataDepth(key, state),
+      currentDefinition: childDefinition(key, state),
+      mapKind: childMapKind(key),
+    })
+  }
+
+  return result
+}
+
+function childDataDepth(key: string, state: { dataDepth: number; mapKind?: SchemaMapKind }): number {
+  if (state.mapKind === "properties") return state.dataDepth + 1
+  if (key === "items" || key === "additionalProperties") return state.dataDepth + 1
+  return state.dataDepth
+}
+
+function childDefinition(
+  key: string,
+  state: { dataDepth: number; currentDefinition?: CurrentDefinition; mapKind?: SchemaMapKind }
+): CurrentDefinition | undefined {
+  if (state.mapKind === "defs") return { name: key, dataDepth: state.dataDepth }
+  return state.currentDefinition
+}
+
+function childMapKind(key: string): SchemaMapKind | undefined {
+  if (key === "$defs") return "defs"
+  if (key === "properties" || key === "patternProperties") return "properties"
+  return undefined
+}
+
+function isSameDataSelfRef(
+  ref: string,
+  state: { currentDefinition?: CurrentDefinition; dataDepth: number }
+): boolean {
+  return state.currentDefinition?.name === ref && state.currentDefinition.dataDepth === state.dataDepth
+}
+
+function hasLocalDefinitions(schema: TSchema): boolean {
+  function visit(value: unknown): boolean {
+    if (Array.isArray(value)) return value.some(visit)
+    if (value === null || typeof value !== "object") return false
+
+    const record = value as Record<string, unknown>
+    if (record.$defs !== undefined) return true
+
+    return Object.values(record).some(visit)
+  }
+
+  return visit(schema)
+}
+
+function localRefScope(record: Record<string, unknown>, pointer: string): RefScope | undefined {
+  const defs = record.$defs
+  if (defs === null || typeof defs !== "object" || Array.isArray(defs)) return undefined
+
+  return {
+    pointer,
+    names: new Set(Object.keys(defs)),
+  }
+}
+
+function rewriteLocalRef(ref: string, scopes: RefScope[]): string | undefined {
+  if (ref.startsWith("#") || ref.includes("://")) return undefined
+
+  for (let index = scopes.length - 1; index >= 0; index -= 1) {
+    const scope = scopes[index]!
+    if (scope.names.has(ref)) {
+      return `#${scope.pointer}/$defs/${escapeJsonPointerSegment(ref)}`
+    }
+  }
+
+  return undefined
+}
+
+function escapeJsonPointerSegment(segment: string): string {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1")
+}

--- a/packages/core/metadata/validation/discriminatedUnionErrors.ts
+++ b/packages/core/metadata/validation/discriminatedUnionErrors.ts
@@ -1,10 +1,11 @@
+import {
+  compileValidationSchema,
+  type ValidationSchemaError,
+  type ValidationSchemaValidator,
+} from "./compileValidationSchema"
 import type { TSchema } from "typebox"
-import Schema, { type Validator } from "typebox/schema"
-import type { TLocalizedValidationError } from "typebox/error"
 
-export type ValidationError = TLocalizedValidationError & {
-  schema?: TSchema
-  value?: unknown
+export type ValidationError = ValidationSchemaError & {
   diagnosticLocation?: "key"
 }
 
@@ -19,7 +20,7 @@ interface BranchSchema extends TSchema {
 
 interface BranchEntry {
   schema: TSchema
-  compiled?: Validator<TSchema>
+  compiled?: ValidationSchemaValidator<TSchema>
 }
 
 interface BranchCache {
@@ -35,7 +36,7 @@ interface ExpansionContext {
 
 const emptyExpansionContext: ExpansionContext = { schemaContext: {}, referenceKey: "" }
 const unionSchemaCache = new WeakMap<TSchema, Map<string, BranchCache>>()
-let expansionContextCache = new WeakMap<Validator<TSchema>, ExpansionContext>()
+let expansionContextCache = new WeakMap<ValidationSchemaValidator<TSchema>, ExpansionContext>()
 let expansionContextBuildCountForTests = 0
 
 function isDiscriminatedUnionSchema(schema: TSchema | undefined): schema is DiscriminatedUnionSchema {
@@ -150,11 +151,11 @@ function getBranchCache(schema: DiscriminatedUnionSchema, context: ExpansionCont
   return cache
 }
 
-function getCompiledBranch(entry: BranchEntry, context: ExpansionContext): Validator<TSchema> | undefined {
+function getCompiledBranch(entry: BranchEntry, context: ExpansionContext): ValidationSchemaValidator<TSchema> | undefined {
   if (entry.compiled !== undefined) return entry.compiled
 
   try {
-    entry.compiled = Schema.Compile(context.schemaContext, entry.schema)
+    entry.compiled = compileValidationSchema(context.schemaContext, entry.schema)
     return entry.compiled
   } catch {
     return undefined
@@ -227,7 +228,8 @@ function isBranchErrorOfDiscriminatedUnion(
   context: ExpansionContext
 ): boolean {
   if (!isDiscriminatedUnionError(unionError, context)) return false
-  if (!error.schemaPath.startsWith(`${unionError.schemaPath}/anyOf/`)) return false
+  const unionSchemaPath = unionError.schemaPath.replace(/\/(?:anyOf|oneOf)$/, "")
+  if (!error.schemaPath.startsWith(`${unionSchemaPath}/anyOf/`)) return false
   return error.instancePath === unionError.instancePath || error.instancePath.startsWith(`${unionError.instancePath}/`)
 }
 
@@ -254,7 +256,7 @@ function collectSchemaContext(schema: TSchema): Record<string, TSchema> {
   return context
 }
 
-function getExpansionContext(schema?: Validator<TSchema>): ExpansionContext {
+function getExpansionContext(schema?: ValidationSchemaValidator<TSchema>): ExpansionContext {
   if (schema === undefined) return emptyExpansionContext
 
   const cached = expansionContextCache.get(schema)
@@ -266,7 +268,7 @@ function getExpansionContext(schema?: Validator<TSchema>): ExpansionContext {
   return context
 }
 
-function createExpansionContext(schema: Validator<TSchema>): ExpansionContext {
+function createExpansionContext(schema: ValidationSchemaValidator<TSchema>): ExpansionContext {
   expansionContextBuildCountForTests += 1
   const root = schema.Schema()
   const schemaContext = collectSchemaContext(root)
@@ -279,7 +281,7 @@ function createExpansionContext(schema: Validator<TSchema>): ExpansionContext {
 }
 
 export function resetDiscriminatedUnionExpansionContextCacheForTests(): void {
-  expansionContextCache = new WeakMap<Validator<TSchema>, ExpansionContext>()
+  expansionContextCache = new WeakMap<ValidationSchemaValidator<TSchema>, ExpansionContext>()
   expansionContextBuildCountForTests = 0
 }
 
@@ -289,7 +291,7 @@ export function getDiscriminatedUnionExpansionContextBuildCountForTests(): numbe
 
 export function expandDiscriminatedUnionErrors(
   errors: ValidationError[],
-  schema?: Validator<TSchema>
+  schema?: ValidationSchemaValidator<TSchema>
 ): ValidationError[] {
   return expandDiscriminatedUnionErrorsWithContext(errors, getExpansionContext(schema))
 }

--- a/packages/core/metadata/validation/projectFileSchema.test.ts
+++ b/packages/core/metadata/validation/projectFileSchema.test.ts
@@ -1,7 +1,7 @@
+import { compileValidationSchema } from "./compileValidationSchema"
 import { mkdtempSync, rmSync } from "fs"
 import { tmpdir } from "os"
 import { join, resolve } from "path"
-import Schema from "typebox/schema"
 import { afterEach, describe, expect, it } from "vitest"
 import { EXCLUDE_IF_EQUAL_NAME_YAML_DESCRIPTION } from "../helpers/excludeIfEqualNameYAML"
 import {
@@ -144,7 +144,7 @@ describe("exportJSONSchemaForProjectFile", () => {
     expect(JSON.stringify(synonymSchema)).not.toContain("Какое то поле")
     expect(JSON.stringify(synonymSchema)).not.toContain('"not"')
 
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
     expect(
       validateFile({
         filePath: "Справочник/КакоеТоПоле/Свойства.yaml",
@@ -229,7 +229,7 @@ describe("exportJSONSchemaForProjectFile", () => {
   })
 
   it("validates catalog attribute TypeDescription with catalog-specific restrictions", () => {
-    const schema = Schema.Compile(
+    const schema = compileValidationSchema(
       exportJSONSchemaForProjectFile({
         context,
         filePath: "Справочник/Товары/Свойства.yaml",
@@ -341,7 +341,7 @@ describe("exportJSONSchemaForProjectFile", () => {
       ].join("\n"),
     },
   ])("validates allowed TypeDescription values for $label", ({ filePath, validText, invalidText }) => {
-    const schema = Schema.Compile(
+    const schema = compileValidationSchema(
       exportJSONSchemaForProjectFile({
         context,
         filePath,
@@ -403,7 +403,7 @@ describe("exportJSONSchemaForSchemaName", () => {
   })
 
   it("keeps generic schema by type name free from concrete object-name restrictions", () => {
-    const schema = Schema.Compile(
+    const schema = compileValidationSchema(
       exportJSONSchemaForSchemaName({
         context,
         name: "MetadataCatalog",

--- a/packages/core/metadata/validation/projectReferenceIndex.ts
+++ b/packages/core/metadata/validation/projectReferenceIndex.ts
@@ -4,6 +4,7 @@ import type {
   MetadataTargetConstraint,
   MetadataTargetFilter,
   MetadataTypeFilterValue,
+  MetadataObjectSegment,
   ParsedMetadataTarget,
 } from "../commonObjects/metadataTargets"
 import { objectPathKindToYAML, rootToYAML } from "../commonObjects/metadataTargets/roots"
@@ -110,17 +111,22 @@ export function projectMemberIndexKey(target: Extract<ParsedMetadataTarget, { ki
 }
 
 export function projectValueIndexKey(target: Extract<ParsedMetadataTarget, { kind: "value" }>): string {
+  const objectSegments = valueTargetObjectSegments(target)
   const base = [
     target.root,
     target.objectName,
-    ...(target.kind === "value" && "objectSegments" in target ? target.objectSegments ?? [] : []).flatMap((segment) => [
-      segment.kind,
-      segment.objectName,
-    ]),
+    ...objectSegments.flatMap((segment) => [segment.kind, segment.objectName]),
     target.valueKind,
   ]
   if ("valueName" in target) return [...base, target.valueName].join(".")
   return base.join(".")
+}
+
+function valueTargetObjectSegments(
+  target: Extract<ParsedMetadataTarget, { kind: "value" }>
+): MetadataObjectSegment[] {
+  if (!("objectSegments" in target)) return []
+  return Array.isArray(target.objectSegments) ? target.objectSegments : []
 }
 
 export function createProjectReferenceSnapshot(params: {

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -1,5 +1,5 @@
+import { compileValidationSchema, type ValidationSchemaValidator } from "./compileValidationSchema"
 import { Type, type TSchema } from "typebox"
-import Schema, { type Validator } from "typebox/schema"
 import fs from "fs"
 import { performance } from "node:perf_hooks"
 import { dirname, join, resolve } from "path"
@@ -35,7 +35,7 @@ import type { Diagnostic } from "./types"
 import { validateParsedFile } from "./validateFile"
 import { validateUniqueNameScopes } from "./uniqueNameScopes"
 
-type CompiledSchema = Validator<TSchema>
+type CompiledSchema = ValidationSchemaValidator<TSchema>
 const formSchemaCache = new Map<string, CompiledSchema>()
 const propertiesSchemaCache = new Map<string, CompiledSchema>()
 
@@ -153,7 +153,7 @@ export function createValidationSchemaCache(context: ConfigurationContext): Vali
       if (existing) return existing
 
       const globalKey = `${context.version}:${context.defaultLanguage}:${spec.dir}`
-      const compiled = propertiesSchemaCache.get(globalKey) ?? Schema.Compile(spec.exportSchema({ context, mode: "inline" }))
+      const compiled = propertiesSchemaCache.get(globalKey) ?? compileValidationSchema(spec.exportSchema({ context, mode: "inline" }))
       propertiesSchemaCache.set(globalKey, compiled)
       propertiesSchemas.set(key, compiled)
 
@@ -173,7 +173,7 @@ function compileRegisteredFormSchema(context: ConfigurationContext): CompiledSch
     mode: "externalRefs",
     includeNestedChildItems: true,
   })
-  const compiled = Schema.Compile(stripExternalRefsForValidation(schema))
+  const compiled = compileValidationSchema(stripExternalRefsForValidation(schema))
   formSchemaCache.set(cacheKey, compiled)
   return compiled
 }
@@ -936,8 +936,4 @@ function importDiagnostic(filePath: string, message: string): Diagnostic {
     source: "structure",
     message,
   }
-}
-
-function exportFormSchema(context: ConfigurationContext) {
-  return exportJSONSchemaForSchemaName({ context, name: "ClientApplicationForm", mode: "inline" })
 }

--- a/packages/core/metadata/validation/projectValidationWorkerPool.ts
+++ b/packages/core/metadata/validation/projectValidationWorkerPool.ts
@@ -160,6 +160,7 @@ export function createProjectValidationWorkerPool(params: { concurrency: number 
           assignedFilePaths.set(worker, filePaths)
           if (filePaths.length === 0) {
             return {
+              index,
               diagnostics: [],
               objectRecords: [],
               objectIndexEntries: [],

--- a/packages/core/metadata/validation/schemaCache.ts
+++ b/packages/core/metadata/validation/schemaCache.ts
@@ -1,5 +1,5 @@
+import { compileValidationSchema, type ValidationSchemaValidator } from "./compileValidationSchema"
 import type { TSchema } from "typebox"
-import Schema, { type Validator } from "typebox/schema"
 import { MetadataAccumulationRegisterRules } from "../appliedObjects/metadataAccumulationRegister/rules"
 import { ConfigurationContext } from "../context/types"
 import { exportMetadataCatalogToJSONSchema } from "../appliedObjects/metadataCatalog/toJSONSchema"
@@ -14,14 +14,14 @@ import { exportMetadataItemToJSONSchema } from "../orchestration/metadataItem/to
 import { MetadataKind } from "./types"
 
 export interface SchemaCache {
-  get(kind: MetadataKind): Validator<TSchema>
+  get(kind: MetadataKind): ValidationSchemaValidator<TSchema>
 }
 
 export function createSchemaCache(context: ConfigurationContext): SchemaCache {
-  const cache = new Map<MetadataKind, Validator<TSchema>>()
+  const cache = new Map<MetadataKind, ValidationSchemaValidator<TSchema>>()
 
   return {
-    get(kind: MetadataKind): Validator<TSchema> {
+    get(kind: MetadataKind): ValidationSchemaValidator<TSchema> {
       const cached = cache.get(kind)
       if (cached) return cached
 
@@ -56,7 +56,7 @@ export function createSchemaCache(context: ConfigurationContext): SchemaCache {
           break
       }
 
-      const compiled = Schema.Compile(schema)
+      const compiled = compileValidationSchema(schema)
       cache.set(kind, compiled)
       return compiled
     },

--- a/packages/core/metadata/validation/schemaRegistry.test.ts
+++ b/packages/core/metadata/validation/schemaRegistry.test.ts
@@ -1,7 +1,7 @@
+import { compileValidationSchema } from "./compileValidationSchema"
 import "../appliedObjects"
 import "../forms"
 import type { TSchema } from "typebox"
-import Schema from "typebox/schema"
 import { beforeEach, describe, expect, it } from "vitest"
 import { MetadataConfigurationRules } from "../appliedObjects/configuration/rules"
 import { MetadataLanguageRules } from "../appliedObjects/metadataLanguage/rules"
@@ -47,7 +47,7 @@ describe("JSON Schema registry", { timeout: 30_000 }, () => {
 
   it("accepts keyed predefined catalog items without explicit code", () => {
     const schema = exportJSONSchemaForSchemaName({ context, name: "MetadataCatalog", mode: "inline" })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(
       compiled.Check({
@@ -70,7 +70,7 @@ describe("JSON Schema registry", { timeout: 30_000 }, () => {
 
     for (const name of schemaNames) {
       const schema = exportJSONSchemaForSchemaName({ context, name })
-      const compiled = Schema.Compile(schema)
+      const compiled = compileValidationSchema(schema)
 
       expect(compiled.Check("Строка")).toBe(false)
       expect(compiled.Check({ Тип: "Строка" })).toBe(true)
@@ -80,7 +80,7 @@ describe("JSON Schema registry", { timeout: 30_000 }, () => {
 
   it("accepts home page work area in configuration schemas", () => {
     const schema = exportMetadataItemToJSONSchema({ context, rule: MetadataConfigurationRules })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(
       compiled.Errors({
@@ -150,8 +150,8 @@ describe("JSON Schema registry", { timeout: 30_000 }, () => {
     const tableInputFieldSchema = exportJSONSchemaForSchemaName({ context, name: "TableInputField" })
     const opaquePath = "1/0:796f500f-c364-45d1-bce6-9e7e8e15b664"
 
-    expect(Schema.Compile(inputFieldSchema).Check({ Вид: "ПолеВвода", ПутьКДанным: opaquePath })).toBe(true)
-    expect(Schema.Compile(tableInputFieldSchema).Check({ Вид: "ПолеВвода", ПутьКДанным: opaquePath })).toBe(false)
+    expect(compileValidationSchema(inputFieldSchema).Check({ Вид: "ПолеВвода", ПутьКДанным: opaquePath })).toBe(true)
+    expect(compileValidationSchema(tableInputFieldSchema).Check({ Вид: "ПолеВвода", ПутьКДанным: opaquePath })).toBe(false)
   })
 
   it("keeps tree YAML button type alias away from Вид discriminator", () => {
@@ -167,7 +167,7 @@ describe("JSON Schema registry", { timeout: 30_000 }, () => {
 
   it("accepts value-based formatted title in label decoration schemas", () => {
     const schema = exportJSONSchemaForSchemaName({ context, name: "LabelDecoration" })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
 
     expect(
       compiled.Check({
@@ -263,7 +263,7 @@ describe("JSON Schema registry", { timeout: 30_000 }, () => {
 
   it("accepts command names in command bar button schemas", () => {
     const schema = exportJSONSchemaForSchemaName({ context, name: "CommandBarButton", mode: "inline" })
-    const compiled = Schema.Compile(schema)
+    const compiled = compileValidationSchema(schema)
     const value = {
       Вид: "КнопкаКоманднойПанели",
       ИмяКоманды: "Form.Command.ВыбратьСтроки",

--- a/packages/core/metadata/validation/sharedValidationBinaryOwners.ts
+++ b/packages/core/metadata/validation/sharedValidationBinaryOwners.ts
@@ -5,7 +5,7 @@ import type { ObjectField, ObjectFieldIndex, ObjectFieldTableSource } from "./da
 import type { DataPathTableInfo, DataPathTypeInfo, DataPathValueKind, OwnerTypeRef } from "./dataPath/types"
 import type { ValidationObjectRecord, ValidationObjectTableSnapshot } from "./projectValidationTypes"
 import { createSharedStringPool, createSharedStringPoolView, type SharedStringPool } from "./sharedStringPool"
-import type { Diagnostic } from "./types"
+import type { Diagnostic, DiagnosticSource } from "./types"
 
 const MAGIC = 0x4e4b444f
 const VERSION = 1
@@ -298,7 +298,7 @@ function createBinaryOwnersView(snapshot: BinarySharedOwnersSnapshot) {
         line: ints[base + 1] ?? 1,
         col: ints[base + 2] ?? 1,
         severity: "error",
-        source: strings.get(ints[base + 3] ?? 0),
+        source: strings.get(ints[base + 3] ?? 0) as DiagnosticSource,
         message: strings.get(ints[base + 4] ?? 0),
       }
     },

--- a/packages/core/metadata/validation/sharedValidationSnapshot.test.ts
+++ b/packages/core/metadata/validation/sharedValidationSnapshot.test.ts
@@ -56,7 +56,7 @@ function catalogRecord(): ValidationObjectRecord {
             name: "Артикул",
             kind: "attribute",
             sourceCollection: "attributes",
-            typeInfo: { kinds: ["string"], nextTypes: [], sourceText: "String" },
+            typeInfo: { kinds: ["scalar"] as const, nextTypes: [], sourceText: "String" },
           },
         ],
         [
@@ -66,7 +66,7 @@ function catalogRecord(): ValidationObjectRecord {
             kind: "tabularSection",
             sourceCollection: "tabularSections",
             typeInfo: {
-              kinds: ["tableSource"],
+              kinds: ["tableSource"] as const,
               nextTypes: [],
               table: { kind: "TabularSection", owner: { kind: "Справочник", name: "Номенклатура" }, name: "Товары" },
             },
@@ -79,7 +79,7 @@ function catalogRecord(): ValidationObjectRecord {
                     name: "Количество",
                     kind: "attribute",
                     sourceCollection: "attributes",
-                    typeInfo: { kinds: ["decimal"], nextTypes: [], sourceText: "Number" },
+                    typeInfo: { kinds: ["scalar"] as const, nextTypes: [], sourceText: "Number" },
                   },
                 ],
               ]),

--- a/packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts
+++ b/packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts
@@ -1,5 +1,5 @@
+import type { ValidationSchemaValidator } from "./compileValidationSchema"
 import type { TSchema } from "typebox"
-import type { Validator } from "typebox/schema"
 import { ParsedYaml } from "../../yaml/parseMetadataYaml"
 import { expandDiscriminatedUnionErrors, type ValidationError } from "./discriminatedUnionErrors"
 import { Diagnostic } from "./types"
@@ -87,7 +87,7 @@ export function typeboxErrorsToDiagnostics(
   errors: ValidationError[],
   parsed: ParsedYaml,
   filePath: string,
-  schema?: Validator<TSchema>
+  schema?: ValidationSchemaValidator<TSchema>
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = []
   const expandedErrors = normalizedErrors(expandDiscriminatedUnionErrors(errors, schema))

--- a/packages/core/metadata/validation/validateFile.test.ts
+++ b/packages/core/metadata/validation/validateFile.test.ts
@@ -1,5 +1,5 @@
+import { compileValidationSchema } from "./compileValidationSchema"
 import { Type } from "typebox"
-import Schema from "typebox/schema"
 import { parseMetadataYaml } from "../../yaml/parseMetadataYaml"
 import { describe, expect, it } from "vitest"
 import {
@@ -11,7 +11,7 @@ import { typeboxErrorsToDiagnostics } from "./typeboxErrorsToDiagnostics"
 import { validateFile, validateParsedFile } from "./validateFile"
 
 // Простая схема для юнит-тестов — не зависит от доменных правил каталогов
-const simpleSchema = Schema.Compile(
+const simpleSchema = compileValidationSchema(
   Type.Object(
     {
       Имя: Type.Optional(Type.String()),
@@ -47,7 +47,7 @@ const simpleSchema = Schema.Compile(
   )
 )
 
-const requiredSchema = Schema.Compile(
+const requiredSchema = compileValidationSchema(
   Type.Object(
     {
       ОбязательноеПоле: Type.String(),
@@ -57,14 +57,14 @@ const requiredSchema = Schema.Compile(
   )
 )
 
-const plainUnionSchema = Schema.Compile(
+const plainUnionSchema = compileValidationSchema(
   Type.Union([
     Type.Object({ Вид: Type.Literal("Первый"), Поле: Type.String() }, { additionalProperties: false }),
     Type.Object({ Вид: Type.Literal("Второй"), Число: Type.Number() }, { additionalProperties: false }),
   ])
 )
 
-const discriminatedUnionSchema = Schema.Compile(
+const discriminatedUnionSchema = compileValidationSchema(
   Type.Union(
     [
       Type.Object({ Вид: Type.Literal("Первый"), Поле: Type.String() }, { additionalProperties: false }),
@@ -74,7 +74,7 @@ const discriminatedUnionSchema = Schema.Compile(
   )
 )
 
-const nestedDiscriminatedUnionSchema = Schema.Compile(
+const nestedDiscriminatedUnionSchema = compileValidationSchema(
   Type.Union(
     [
       Type.Object(
@@ -121,7 +121,7 @@ const childItemsDefinitions = {
   ),
 }
 
-const referencedNestedDiscriminatedUnionSchema = Schema.Compile(
+const referencedNestedDiscriminatedUnionSchema = compileValidationSchema(
   Type.Object(
     {
       Элементы: Type.Cyclic(childItemsDefinitions, "ChildItems"),

--- a/packages/core/metadata/validation/validateFile.ts
+++ b/packages/core/metadata/validation/validateFile.ts
@@ -1,5 +1,5 @@
+import type { ValidationSchemaValidator } from "./compileValidationSchema"
 import type { TSchema } from "typebox"
-import type { Validator } from "typebox/schema"
 import { parseMetadataYaml, type ParsedYaml } from "../../yaml/parseMetadataYaml"
 import { typeboxErrorsToDiagnostics } from "./typeboxErrorsToDiagnostics"
 import { Diagnostic } from "./types"
@@ -7,13 +7,13 @@ import { Diagnostic } from "./types"
 export interface ValidateFileParams {
   filePath: string
   text: string
-  schema: Validator<TSchema>
+  schema: ValidationSchemaValidator<TSchema>
 }
 
 export interface ValidateParsedFileParams {
   filePath: string
   parsed: ParsedYaml
-  schema: Validator<TSchema>
+  schema: ValidationSchemaValidator<TSchema>
 }
 
 export function validateFile({ filePath, text, schema }: ValidateFileParams): Diagnostic[] {

--- a/packages/core/metadata/validation/validateItem.ts
+++ b/packages/core/metadata/validation/validateItem.ts
@@ -1,5 +1,5 @@
+import type { ValidationSchemaValidator } from "./compileValidationSchema"
 import type { TSchema } from "typebox"
-import type { Validator } from "typebox/schema"
 import { existsSync, readdirSync, readFileSync } from "fs"
 import { basename, dirname, join, resolve } from "path"
 import { Diagnostic } from "./types"
@@ -10,7 +10,7 @@ import { createOwnerMetadataCache } from "./dataPath/ownerCache"
 
 export interface ValidateItemParams {
   itemDir: string
-  schema: Validator<TSchema>
+  schema: ValidationSchemaValidator<TSchema>
 }
 
 export function validateItem({ itemDir, schema }: ValidateItemParams): Diagnostic[] {

--- a/packages/core/metadata/validation/validationSnapshotProvider.test.ts
+++ b/packages/core/metadata/validation/validationSnapshotProvider.test.ts
@@ -4,6 +4,7 @@ import { createOwnerMetadataCacheFromValidationTable } from "./dataPath/ownerCac
 import { projectObjectIndexKey } from "./projectReferenceIndex"
 import { createValidationObjectTable } from "./projectValidationObjectTable"
 import type { ValidationObjectRecord } from "./projectValidationTypes"
+import { getValidationProjectSpecByDir } from "./projectSpecs"
 import { createValidationSnapshotProvider } from "./validationSnapshotProvider"
 
 describe("ValidationSnapshotProvider", () => {
@@ -43,6 +44,8 @@ describe("ValidationSnapshotProvider", () => {
       pendingReferences: [],
     })
     const provider = createValidationSnapshotProvider(table.snapshot())
+    const catalogSpec = getValidationProjectSpecByDir("Справочник")
+    if (catalogSpec === undefined) throw new Error("catalog spec expected")
     const index = provider.referenceIndex({
       projectDir: "/project",
       mode: "partial",
@@ -53,6 +56,7 @@ describe("ValidationSnapshotProvider", () => {
           absolutePath: "/project/Справочник/Товары/Свойства.yaml",
           projectPath: "Справочник/Товары/Свойства.yaml",
           kind: "properties",
+          owner: { dir: "Справочник", name: "Товары", spec: catalogSpec },
         },
         requestedBy: "/project/Справочник/Товары/Свойства.yaml",
       }),
@@ -86,7 +90,7 @@ function catalogRecord(): ValidationObjectRecord {
             name: "Артикул",
             kind: "attribute",
             sourceCollection: "attributes",
-            typeInfo: { kinds: ["string"], nextTypes: [], sourceText: "String" },
+            typeInfo: { kinds: ["scalar"] as const, nextTypes: [], sourceText: "String" },
           },
         ],
       ]),

--- a/packages/core/metadata/validation/yamlTypeSchemaRegistration.test.ts
+++ b/packages/core/metadata/validation/yamlTypeSchemaRegistration.test.ts
@@ -1,4 +1,4 @@
-import Schema from "typebox/schema"
+import { compileValidationSchema } from "./compileValidationSchema"
 import { describe, expect, it } from "vitest"
 import { getTypeRule, PropertyRule } from "../orchestration"
 import { registerCoreMetadata } from "../register"
@@ -28,7 +28,7 @@ const schemaFor = (type: SchemaRuleType) => {
   expect(schema).toBeDefined()
   if (schema === undefined) throw new Error(`${type} JSON schema is not registered`)
 
-  return Schema.Compile(schema)
+  return compileValidationSchema(schema)
 }
 
 describe("YAML type JSON Schema registrations", () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,8 @@
     "@node-rs/xxhash": "^1.7.6",
     "date-fns": "^4.4.0",
     "fast-xml-parser": "^5.9.2",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "js-yaml": "^5.2.1",
     "p-limit": "^6.2.0",
     "typebox": "1.3.3",

--- a/packages/core/yaml/export.ts
+++ b/packages/core/yaml/export.ts
@@ -88,7 +88,6 @@ export const exportToYAML = <T>(data: T): string => {
     noRefs: true,
     skipInvalid: false,
     sortKeys: false,
-    quotingType: '"',
     forceQuotes: false,
   })
   return removeDocumentFinalLineEnding(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,12 @@ importers:
       '@node-rs/xxhash':
         specifier: ^1.7.6
         version: 1.7.6
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0


### PR DESCRIPTION
## Что изменилось
- добавлен адаптер compileValidationSchema поверх AJV с TypeBox fallback для сложных схем и диагностик
- validation-код и тесты переведены на общий адаптер компиляции схем
- исправлены существующие ошибки type-check вокруг TSchema, YAML-типов и validation-тестов

## Проверка
- pnpm --filter @nakidka/core type-check
- pnpm test