### PR TITLE
Validation без модели и persistent MCP pool

### DIFF
--- a/docs/superpowers/plans/2026-07-06-mcp-persistent-validation-piscina.md
+++ b/docs/superpowers/plans/2026-07-06-mcp-persistent-validation-piscina.md
@@ -1,0 +1,300 @@
+# MCP Persistent Validation Piscina Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `nkdk.validate_project` in MCP reuse one long-lived validation worker pool managed by Piscina.
+
+**Architecture:** Core exposes an explicit reusable validation pool handle while preserving the current one-shot `validateProject(...)` behavior for CLI and existing callers. MCP owns one lazy singleton handle for the server process and closes it during server shutdown. Piscina replaces manual `worker_threads` message handling, while worker-local project state is still cleared after each validation run.
+
+**Tech Stack:** TypeScript, Piscina, MCP stdio server, Vitest, existing `@nakidka/core` validation snapshots.
+
+---
+
+### Task 1: Add Piscina dependency and worker task entrypoint
+
+**Files:**
+- Modify: `packages/core/package.json`
+- Modify: `packages/core/metadata/validation/projectValidationWorker.ts`
+- Test: `packages/core/metadata/validation/projectValidationWorkerPool.test.ts`
+
+- [ ] **Step 1: Add Piscina to core dependencies**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core add piscina
+```
+
+Expected: `packages/core/package.json` includes `"piscina"` in `dependencies`, and `pnpm-lock.yaml` is updated.
+
+- [ ] **Step 2: Convert validation worker to a Piscina-compatible task**
+
+In `packages/core/metadata/validation/projectValidationWorker.ts`, remove the direct `parentPort` listener and export:
+
+```ts
+export type ValidationWorkerTask = Omit<ValidationWorkerMessage, "id">
+
+export default function runValidationWorkerTask(message: ValidationWorkerTask): WorkerResponseWithoutId {
+  if (message.kind === "init") return { kind: "initResult", ...runInit(message) }
+  if (message.kind === "firstPass") return { kind: "firstPassResult", ...runFirstPass(message) }
+  return { kind: "secondPassResult", ...runSecondPass(message) }
+}
+```
+
+Keep `registerValidationMetadata()` at module top level. Keep `workerStateStatsForTests()` unchanged for direct unit tests.
+
+- [ ] **Step 3: Run focused worker tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/projectValidationWorkerPool.test.ts
+```
+
+Expected: tests may fail until Task 2 rewrites the pool; no syntax/type errors should come from `projectValidationWorker.ts`.
+
+### Task 2: Replace manual worker pool with Piscina and reusable lifecycle
+
+**Files:**
+- Modify: `packages/core/metadata/validation/projectValidationWorkerPool.ts`
+- Test: `packages/core/metadata/validation/projectValidationWorkerPool.test.ts`
+
+- [ ] **Step 1: Replace `Worker` storage with Piscina**
+
+In `projectValidationWorkerPool.ts`, import Piscina:
+
+```ts
+import Piscina from "piscina"
+```
+
+Create the pool with `minThreads` and `maxThreads` equal to `concurrency`. Use the existing worker file path resolution and TypeScript loader logic for `execArgv`.
+
+- [ ] **Step 2: Keep the public pool interface stable**
+
+Keep:
+
+```ts
+export interface ProjectValidationWorkerPool {
+  start(context: ConfigurationContext): Promise<ProjectValidationWorkerPoolStartProfile>
+  close(): Promise<void>
+  size(): number
+  runFirstPass(params: FirstPassPoolParams): Promise<FirstPassPoolResult>
+  runSecondPass(params: SecondPassPoolParams): Promise<SecondPassPoolResult>
+}
+```
+
+Change implementation so `start(context)` creates Piscina only once, computes one `rulesSnapshot`, and sends `concurrency` `init` tasks. A second `start(context)` call on the same pool must be cheap and must not recompile schemas.
+
+- [ ] **Step 3: Preserve worker partition ownership**
+
+Because Piscina does not expose stable worker objects to caller code, store assigned file paths by partition index instead of by `Worker` object:
+
+```ts
+const assignedFilePathsByPartition = new Map<number, string[]>()
+```
+
+Pass `partitionIndex` through `firstPass` and `secondPass` tasks if needed to keep state on the same Piscina thread. If Piscina cannot guarantee worker affinity by plain `pool.run`, use one Piscina pool per partition with `minThreads: 1`, `maxThreads: 1`; expose them as one logical pool. This preserves the current requirement that second pass reads the `workerState` produced by the same partition's first pass.
+
+- [ ] **Step 4: Add reuse guard test**
+
+In `projectValidationWorkerPool.test.ts`, add a test that creates a pool, calls `start(context)` twice, and asserts the second call does not compile schemas again. The assertion can use a new `startProfile.reused` boolean or an injected test hook if needed.
+
+- [ ] **Step 5: Run focused pool tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/projectValidationWorkerPool.test.ts
+```
+
+Expected: all pool tests pass.
+
+### Task 3: Expose a reusable core validation handle
+
+**Files:**
+- Modify: `packages/core/metadata/validation/validateProject.ts`
+- Modify: `packages/core/index.ts`
+- Test: `packages/core/metadata/validation/validateProject.test.ts`
+
+- [ ] **Step 1: Add handle API**
+
+In `validateProject.ts`, export:
+
+```ts
+export interface ValidationWorkerPoolHandle {
+  validateProject(params: Omit<ValidateProjectParams, "concurrency">): Promise<ValidateProjectResult>
+  close(): Promise<void>
+  size(): number
+}
+
+export function createValidationWorkerPoolHandle(params: { concurrency?: number } = {}): ValidationWorkerPoolHandle
+```
+
+The handle owns one `ProjectValidationWorkerPool`. Its `validateProject` method follows the full-project worker path when possible, and falls back to in-process validation for `filePath` or small projects.
+
+- [ ] **Step 2: Preserve one-shot `validateProject(...)`**
+
+Keep `validateProject(params)` as the current API. Internally it can create a temporary handle for the worker path and close it in `finally`, or call a shared helper.
+
+- [ ] **Step 3: Export the handle from core**
+
+In `packages/core/index.ts`, export `createValidationWorkerPoolHandle` and `ValidationWorkerPoolHandle`.
+
+- [ ] **Step 4: Test handle reuse**
+
+Add a test in `validateProject.test.ts` that creates a handle with `concurrency: 2`, validates a full fixture project twice, closes the handle, and asserts both results match one-shot `validateProject({ concurrency: 2 })`.
+
+- [ ] **Step 5: Run validation tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/validateProject.test.ts metadata/validation/projectValidationWorkerPool.test.ts
+```
+
+Expected: all selected tests pass.
+
+### Task 4: Make MCP own one shared validation handle
+
+**Files:**
+- Modify: `packages/mcp/src/coreApi.ts`
+- Create: `packages/mcp/src/services/validationHandle.ts`
+- Modify: `packages/mcp/src/services/validateProject.ts`
+- Modify: `packages/mcp/src/server.ts`
+- Test: `packages/mcp/src/services/validateProject.test.ts`
+- Test: `packages/mcp/src/server.test.ts`
+
+- [ ] **Step 1: Extend MCP core API type**
+
+Add to `CoreApi`:
+
+```ts
+createValidationWorkerPoolHandle(params?: { concurrency?: number }): {
+  validateProject(params: { projectDir: string; filePath?: string }): Promise<{ diagnostics: Diagnostic[] }>
+  close(): Promise<void>
+  size(): number
+}
+```
+
+- [ ] **Step 2: Add lazy singleton service**
+
+Create `packages/mcp/src/services/validationHandle.ts`:
+
+```ts
+import { loadCoreApi } from "../coreApi"
+
+let handlePromise:
+  | Promise<ReturnType<Awaited<ReturnType<typeof loadCoreApi>>["createValidationWorkerPoolHandle"]>>
+  | undefined
+
+export async function getValidationHandle() {
+  if (handlePromise === undefined) {
+    handlePromise = loadCoreApi().then((core) => core.createValidationWorkerPoolHandle())
+  }
+  return handlePromise
+}
+
+export async function closeValidationHandle(): Promise<void> {
+  const handle = await handlePromise
+  handlePromise = undefined
+  await handle?.close()
+}
+
+export function resetValidationHandleForTests(): void {
+  handlePromise = undefined
+}
+```
+
+Adjust typing if TypeScript needs a named local interface.
+
+- [ ] **Step 3: Use the handle in validation service**
+
+In `validateProject.ts`, replace `core.validateProject(...)` for normal validation with:
+
+```ts
+const handle = await getValidationHandle()
+const diagnostics = (await handle.validateProject({
+  projectDir,
+  ...(input.filePath !== undefined ? { filePath: input.filePath } : {}),
+})).diagnostics
+```
+
+Keep `loadCoreApi()` in the catch block for `ProjectFileSchemaError` checks.
+
+- [ ] **Step 4: Close handle from MCP server**
+
+In `server.ts`, import `closeValidationHandle`. Add a small exported shutdown helper:
+
+```ts
+export async function shutdownNkdkMcpServer(): Promise<void> {
+  await closeValidationHandle()
+}
+```
+
+Call it from process signal handlers and from `runStdioServer()` when server exits normally.
+
+- [ ] **Step 5: Test MCP reuse and shutdown**
+
+In `validateProject.test.ts`, mock `createValidationWorkerPoolHandle`, call `validateYamlProject` twice, and assert the factory was called once and `handle.validateProject` twice.
+
+In `server.test.ts`, assert `shutdownNkdkMcpServer()` calls `closeValidationHandle()`.
+
+- [ ] **Step 6: Run MCP tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/mcp exec vitest run src/services/validateProject.test.ts src/server.test.ts
+```
+
+Expected: selected MCP tests pass.
+
+### Task 5: Verify behavior and measure MCP validation
+
+**Files:**
+- No code files expected.
+
+- [ ] **Step 1: Run validation test suite**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation
+```
+
+Expected: all validation tests pass.
+
+- [ ] **Step 2: Run MCP test suite**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/mcp test
+```
+
+Expected: all MCP tests pass.
+
+- [ ] **Step 3: Run full project tests**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: all packages pass.
+
+- [ ] **Step 4: Measure MCP validation twice in one server**
+
+Run a small MCP stdio client that calls `nkdk.validate_project` twice against `/Users/nikita/git/nkdk-yaml` with request timeout above 60 seconds.
+
+Expected: both calls return `4006 error, 0 warning`; the second call should avoid worker startup/schema compilation cost and should be faster than the first.
+
+- [ ] **Step 5: Commit implementation**
+
+Commit with:
+
+```bash
+git add packages/core packages/mcp package.json pnpm-lock.yaml docs/superpowers/plans/2026-07-06-mcp-persistent-validation-piscina.md
+git commit -m "perf: :zap: переиспользовать validation pool в MCP"
+```

--- a/docs/superpowers/plans/2026-07-06-validation-single-pass-rules-snapshot.md
+++ b/docs/superpowers/plans/2026-07-06-validation-single-pass-rules-snapshot.md
@@ -1,0 +1,892 @@
+# Validation Single-Pass Rules Snapshot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Перевести validation worker на одно чтение YAML без построения metadata/form model, сохранив текущие shared snapshots и проверку `/Users/nikita/git/nkdk-yaml`.
+
+**Architecture:** Главный процесс строит JSON-совместимый `rulesSnapshot` из текущей полной регистрации. Worker читает YAML один раз, проверяет schema, извлекает компактные facts/checks напрямую из `parsed.data`, а затем разрешает pending checks по текущим shared snapshots без повторного чтения YAML.
+
+**Tech Stack:** TypeScript 5.9, Vitest, Node.js Worker Threads, текущие `validationSnapshotProvider`, `sharedProjectReferenceIndex`, `sharedValidationBinaryOwners`, TypeBox validation.
+
+---
+
+## File Structure
+
+- Create: `packages/core/metadata/validation/rulesSnapshot.ts`
+  - JSON-совместимые типы `ValidationRulesSnapshot`, builder из текущих project specs/rules, проверки clone/stringify.
+- Create: `packages/core/metadata/validation/rulesSnapshot.test.ts`
+  - Проверяет JSON-совместимость и минимальное покрытие объектов/форм.
+- Create: `packages/core/metadata/validation/yamlFactExtractor.ts`
+  - Тонкий extractor поверх `parsed.data + ValidationProjectFile + ValidationRulesSnapshot`; не импортирует `fromYAML`.
+- Create: `packages/core/metadata/validation/yamlFactExtractor.test.ts`
+  - TDD для properties/forms facts на существующих fixtures.
+- Create: `packages/core/metadata/validation/projectValidationPendingChecks.ts`
+  - Компактные отложенные проверки, включая `dataPath`.
+- Create: `packages/core/metadata/validation/dataPath/ownerFacts.ts`
+  - Компактные owner facts и adapter в current owner snapshot structures.
+- Modify: `packages/core/metadata/validation/projectValidationTypes.ts`
+  - Заменить model-bearing `ValidationObjectRecord` на compact owner facts.
+- Modify: `packages/core/metadata/validation/projectValidationPasses.ts`
+  - Переключить first pass на extractor, а state - на pending facts/checks.
+- Modify: `packages/core/metadata/validation/projectValidationWorker.ts`
+  - Инициализировать `rulesSnapshot`, убрать model/form state retention, очистить state после second pass.
+- Modify: `packages/core/metadata/validation/projectValidationWorkerPool.ts`
+  - Передавать `rulesSnapshot` при init; логировать размеры facts/snapshot под profile.
+- Modify: `packages/core/metadata/validation/validateProject.ts`
+  - Строить `rulesSnapshot`, передавать worker pool, сохранить in-process compatibility path.
+- Modify: `packages/core/metadata/validation/validationSnapshotProvider.ts`
+  - При необходимости принимать compact owner facts без model.
+- Test: `packages/core/metadata/validation/validateProject.test.ts`
+- Test: `packages/core/metadata/validation/projectValidationWorkerPool.test.ts`
+- Test: `packages/cli/src/commands/validate.test.ts`
+
+## Task 1: Baseline Guards For Current Validation State
+
+**Files:**
+- Modify: `packages/core/metadata/validation/projectValidationWorkerPool.test.ts`
+- Modify: `packages/core/metadata/validation/projectValidationWorker.ts`
+- Test: `packages/core/metadata/validation/projectValidationWorkerPool.test.ts`
+
+- [ ] **Step 1: Add worker state test export**
+
+In `packages/core/metadata/validation/projectValidationWorker.ts`, export a test-only state summary near the bottom of the file:
+
+```ts
+export function workerStateStatsForTests(): {
+  retainedEntries: number
+  retainedStates: number
+  retainedPropertyModels: number
+  retainedFormStates: number
+} {
+  const states = [...workerState.states.values()]
+  return {
+    retainedEntries: workerState.entries.size,
+    retainedStates: workerState.states.size,
+    retainedPropertyModels: states.filter((state) => state.kind === "properties" && "model" in state).length,
+    retainedFormStates: states.filter((state) => state.kind === "form" && "formState" in state).length,
+  }
+}
+```
+
+- [ ] **Step 2: Add a failing retention test**
+
+In `packages/core/metadata/validation/projectValidationWorkerPool.test.ts`, add:
+
+```ts
+it("does not retain YAML entries or model state after worker validation", async () => {
+  const worker = await import("./projectValidationWorker")
+
+  expect(worker.workerStateStatsForTests()).toEqual({
+    retainedEntries: 0,
+    retainedStates: 0,
+    retainedPropertyModels: 0,
+    retainedFormStates: 0,
+  })
+})
+```
+
+- [ ] **Step 3: Run the focused test**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/projectValidationWorkerPool.test.ts -t "does not retain YAML entries"
+```
+
+Expected: PASS initially because the worker module is freshly imported. This establishes the exported guard for later tasks.
+
+- [ ] **Step 4: Commit the guard**
+
+```bash
+git add packages/core/metadata/validation/projectValidationWorker.ts packages/core/metadata/validation/projectValidationWorkerPool.test.ts
+git commit -m "test: :white_check_mark: добавить guard состояния validation worker"
+```
+
+## Task 2: Introduce Pending Checks And Compact File State
+
+**Files:**
+- Create: `packages/core/metadata/validation/projectValidationPendingChecks.ts`
+- Modify: `packages/core/metadata/validation/projectValidationPasses.ts`
+- Modify: `packages/core/metadata/validation/projectValidationWorker.ts`
+- Test: `packages/core/metadata/validation/projectValidationPasses.test.ts`
+- Test: `packages/core/metadata/validation/projectValidationWorkerPool.test.ts`
+
+- [ ] **Step 1: Create pending check types**
+
+Create `packages/core/metadata/validation/projectValidationPendingChecks.ts`:
+
+```ts
+import type { OwnerTypeRef } from "./dataPath/types"
+import type { Diagnostic } from "./types"
+import type { YamlPath } from "./yamlLocations"
+
+export type ValidationPendingCheck =
+  | {
+      kind: "dataPath"
+      filePath: string
+      yamlPath: YamlPath
+      owner: OwnerTypeRef
+      value: string
+      policy: "formDataPath"
+    }
+
+export interface ValidationPendingCheckResult {
+  diagnostics: Diagnostic[]
+}
+```
+
+- [ ] **Step 2: Compact `ProjectValidationFileState`**
+
+In `packages/core/metadata/validation/projectValidationPasses.ts`, replace the current state type with:
+
+```ts
+export type ProjectValidationFileState =
+  | {
+      kind: "properties"
+      file: ValidationProjectFile
+      pendingReferences: PendingMetadataTargetReference[]
+      firstPassDiagnostics: Diagnostic[]
+    }
+  | {
+      kind: "form"
+      file: ValidationProjectFile
+      pendingChecks: ValidationPendingCheck[]
+      firstPassDiagnostics: Diagnostic[]
+    }
+  | { kind: "failed"; file: ValidationProjectFile; diagnostics: Diagnostic[] }
+```
+
+Add:
+
+```ts
+import type { ValidationPendingCheck } from "./projectValidationPendingChecks"
+```
+
+- [ ] **Step 3: Keep current extraction but stop retaining model/form state**
+
+In `validateProjectPropertiesFirstPass`, keep the current model-based extraction for this task, but return:
+
+```ts
+state: {
+  kind: "properties",
+  file: params.file,
+  pendingReferences: pendingReferences.references,
+  firstPassDiagnostics: diagnostics,
+},
+```
+
+In `validateProjectFormFirstPass`, return:
+
+```ts
+state: {
+  kind: "form",
+  file: params.file,
+  pendingChecks: [],
+  firstPassDiagnostics: diagnostics,
+},
+```
+
+- [ ] **Step 4: Update second pass for compact state**
+
+In `validateProjectFileSecondPass`, for properties use `params.state.pendingReferences` directly. For forms, temporarily return no extra diagnostics:
+
+```ts
+if (params.state.kind === "form") return { status: "ok", diagnostics: [] }
+```
+
+This is temporary and will be replaced by pending form checks in Task 6.
+
+- [ ] **Step 5: Stop storing worker YAML entries**
+
+In `packages/core/metadata/validation/projectValidationWorker.ts`, remove `entries` from `WorkerValidationState` and `createEmptyWorkerValidationState()`. In `runFirstPass`, remove:
+
+```ts
+workerState.entries.set(resolve(entry.filePath), entry)
+```
+
+- [ ] **Step 6: Clear worker state after second pass**
+
+In `runSecondPass`, before returning, store validation timing and clear state:
+
+```ts
+const validationMs = performance.now() - validationStartedAt
+workerState = createEmptyWorkerValidationState()
+```
+
+Use `validationMs` in the returned timing instead of recalculating after cleanup.
+
+- [ ] **Step 7: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/projectValidationPasses.test.ts metadata/validation/projectValidationWorkerPool.test.ts
+```
+
+Expected: PASS or targeted failures only around missing form second-pass checks, fixed in Task 6.
+
+- [ ] **Step 8: Commit compact state**
+
+```bash
+git add packages/core/metadata/validation/projectValidationPendingChecks.ts packages/core/metadata/validation/projectValidationPasses.ts packages/core/metadata/validation/projectValidationWorker.ts packages/core/metadata/validation/projectValidationPasses.test.ts packages/core/metadata/validation/projectValidationWorkerPool.test.ts
+git commit -m "refactor: :recycle: сократить состояние validation worker"
+```
+
+## Task 3: Add Compact Owner Facts
+
+**Files:**
+- Create: `packages/core/metadata/validation/dataPath/ownerFacts.ts`
+- Modify: `packages/core/metadata/validation/projectValidationTypes.ts`
+- Modify: `packages/core/metadata/validation/projectValidationObjectTable.ts`
+- Modify: `packages/core/metadata/validation/sharedValidationBinaryOwners.ts`
+- Test: `packages/core/metadata/validation/projectValidationObjectTable.test.ts`
+- Test: `packages/core/metadata/validation/sharedValidationBinaryOwners.test.ts`
+
+- [ ] **Step 1: Create owner facts type**
+
+Create `packages/core/metadata/validation/dataPath/ownerFacts.ts`:
+
+```ts
+import type { TypeDescription } from "../../commonObjects/typeDescription/types"
+import type { ObjectFieldIndex } from "./objectFields"
+import type { OwnerTypeRef } from "./types"
+
+export interface ValidationOwnerFacts {
+  ref: OwnerTypeRef
+  filePath: string
+  fieldIndex: ObjectFieldIndex
+  type?: TypeDescription
+  commonAttributeOwnerLinks?: string[]
+}
+
+export function ownerFactsFromModel(params: {
+  ref: OwnerTypeRef
+  filePath: string
+  model: unknown
+  fieldIndex: ObjectFieldIndex
+}): ValidationOwnerFacts {
+  const record = typeof params.model === "object" && params.model !== null ? (params.model as Record<string, unknown>) : {}
+  const content = Array.isArray(record["content"]) ? record["content"] : []
+  const commonAttributeOwnerLinks = content.flatMap((item) => {
+    const itemRecord = typeof item === "object" && item !== null ? (item as Record<string, unknown>) : {}
+    return itemRecord["use"] === "Use" && typeof itemRecord["metadata"] === "string" ? [itemRecord["metadata"]] : []
+  })
+
+  return {
+    ref: params.ref,
+    filePath: params.filePath,
+    fieldIndex: params.fieldIndex,
+    ...(typeof record["type"] === "object" && record["type"] !== null ? { type: record["type"] as TypeDescription } : {}),
+    ...(commonAttributeOwnerLinks.length === 0 ? {} : { commonAttributeOwnerLinks }),
+  }
+}
+```
+
+- [ ] **Step 2: Add facts to validation records**
+
+In `packages/core/metadata/validation/projectValidationTypes.ts`, add:
+
+```ts
+import type { ValidationOwnerFacts } from "./dataPath/ownerFacts"
+```
+
+Change `ValidationObjectRecord` to include:
+
+```ts
+ownerFacts?: ValidationOwnerFacts
+```
+
+Keep `model?` temporarily for compatibility in this task.
+
+- [ ] **Step 3: Populate owner facts in first pass**
+
+In `validateProjectPropertiesFirstPass`, import `ownerFactsFromModel` and add `ownerFacts` to the returned object record:
+
+```ts
+const ownerFacts = ownerFactsFromModel({
+  ref: ownerRef,
+  filePath: params.file.absolutePath,
+  model: imported.model,
+  fieldIndex,
+})
+```
+
+Then set:
+
+```ts
+ownerFacts,
+```
+
+- [ ] **Step 4: Prefer owner facts in shared owner snapshot**
+
+In `packages/core/metadata/validation/sharedValidationBinaryOwners.ts`, update snapshot creation to read `record.ownerFacts?.fieldIndex` and `record.ownerFacts?.filePath` before falling back to `record.fieldIndex` / `record.filePath`.
+
+- [ ] **Step 5: Run owner snapshot tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/projectValidationObjectTable.test.ts metadata/validation/sharedValidationBinaryOwners.test.ts metadata/validation/dataPath/ownerCache.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit owner facts**
+
+```bash
+git add packages/core/metadata/validation/dataPath/ownerFacts.ts packages/core/metadata/validation/projectValidationTypes.ts packages/core/metadata/validation/projectValidationPasses.ts packages/core/metadata/validation/sharedValidationBinaryOwners.ts packages/core/metadata/validation/projectValidationObjectTable.test.ts packages/core/metadata/validation/sharedValidationBinaryOwners.test.ts
+git commit -m "refactor: :recycle: добавить compact owner facts"
+```
+
+## Task 4: Build A JSON-Compatible Rules Snapshot
+
+**Files:**
+- Create: `packages/core/metadata/validation/rulesSnapshot.ts`
+- Create: `packages/core/metadata/validation/rulesSnapshot.test.ts`
+- Modify: `packages/core/metadata/validation/projectValidationWorker.ts`
+- Modify: `packages/core/metadata/validation/projectValidationWorkerPool.ts`
+- Modify: `packages/core/metadata/validation/validateProject.ts`
+
+- [ ] **Step 1: Create minimal snapshot types and builder**
+
+Create `packages/core/metadata/validation/rulesSnapshot.ts`:
+
+```ts
+import { rootFromYAML } from "../commonObjects/metadataTargets/roots"
+import type { ConfigurationContext } from "../context/types"
+import { validationProjectSpecs } from "./projectSpecs"
+
+export interface ValidationRulesSnapshot {
+  version: 1
+  context: {
+    platformVersion?: string
+    defaultLanguage?: string
+  }
+  projectDirs: Record<string, ValidationRulesProjectDir>
+  form: {
+    schemaName: "ClientApplicationForm"
+  }
+}
+
+export interface ValidationRulesProjectDir {
+  dir: string
+  itemType: string
+  root?: string
+  namePath: readonly string[]
+}
+
+export function createValidationRulesSnapshot(context: ConfigurationContext): ValidationRulesSnapshot {
+  return {
+    version: 1,
+    context: {
+      platformVersion: context.version,
+      defaultLanguage: context.defaultLanguage,
+    },
+    projectDirs: Object.fromEntries(
+      validationProjectSpecs.map((spec) => [
+        spec.dir,
+        {
+          dir: spec.dir,
+          itemType: spec.rule.itemType,
+          root: rootFromYAML[spec.dir],
+          namePath: ["Имя"],
+        },
+      ])
+    ),
+    form: { schemaName: "ClientApplicationForm" },
+  }
+}
+```
+
+- [ ] **Step 2: Add JSON compatibility tests**
+
+Create `packages/core/metadata/validation/rulesSnapshot.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { createValidationRulesSnapshot } from "./rulesSnapshot"
+
+describe("validation rules snapshot", () => {
+  it("is JSON-compatible and cloneable", () => {
+    const snapshot = createValidationRulesSnapshot({ version: "8.3.24", defaultLanguage: "ru" })
+
+    expect(structuredClone(snapshot)).toEqual(snapshot)
+    expect(JSON.parse(JSON.stringify(snapshot))).toEqual(snapshot)
+  })
+
+  it("contains project directory descriptors for validation", () => {
+    const snapshot = createValidationRulesSnapshot({ version: "8.3.24", defaultLanguage: "ru" })
+
+    expect(snapshot.projectDirs["Справочник"]).toMatchObject({
+      dir: "Справочник",
+      itemType: "MetadataCatalog",
+      root: "Catalog",
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Pass snapshot through worker init**
+
+In `projectValidationWorkerPool.ts`, extend init request:
+
+```ts
+rulesSnapshot: ValidationRulesSnapshot
+```
+
+In `validateProject.ts`, create once:
+
+```ts
+const rulesSnapshot = createValidationRulesSnapshot(context)
+```
+
+Pass it to `pool.start(context, rulesSnapshot)` or extend start params as an object:
+
+```ts
+start({ context, rulesSnapshot })
+```
+
+- [ ] **Step 4: Store snapshot in worker**
+
+In `projectValidationWorker.ts`, add:
+
+```ts
+let workerRulesSnapshot: ValidationRulesSnapshot | undefined
+```
+
+In `runInit`, assign `workerRulesSnapshot = message.rulesSnapshot`.
+
+- [ ] **Step 5: Run snapshot tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/rulesSnapshot.test.ts metadata/validation/projectValidationWorkerPool.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit rules snapshot foundation**
+
+```bash
+git add packages/core/metadata/validation/rulesSnapshot.ts packages/core/metadata/validation/rulesSnapshot.test.ts packages/core/metadata/validation/projectValidationWorker.ts packages/core/metadata/validation/projectValidationWorkerPool.ts packages/core/metadata/validation/validateProject.ts
+git commit -m "feat: :sparkles: добавить rulesSnapshot для validation"
+```
+
+## Task 5: Add YAML Fact Extractor For Properties
+
+**Files:**
+- Create: `packages/core/metadata/validation/yamlFactExtractor.ts`
+- Create: `packages/core/metadata/validation/yamlFactExtractor.test.ts`
+- Modify: `packages/core/metadata/validation/projectValidationPasses.ts`
+- Test: `packages/core/metadata/validation/yamlFactExtractor.test.ts`
+
+- [ ] **Step 1: Add extractor result types**
+
+Create `packages/core/metadata/validation/yamlFactExtractor.ts`:
+
+```ts
+import { projectObjectIndexKey, type ProjectObjectIndexEntry } from "./projectReferenceIndex"
+import type { ValidationProjectFile } from "./projectFiles"
+import type { ValidationRulesSnapshot } from "./rulesSnapshot"
+import type { Diagnostic } from "./types"
+
+export interface ValidationYamlFacts {
+  diagnostics: Diagnostic[]
+  objectIndexEntries: ProjectObjectIndexEntry[]
+}
+
+export function extractValidationYamlFacts(params: {
+  file: ValidationProjectFile
+  data: unknown
+  rulesSnapshot: ValidationRulesSnapshot
+}): ValidationYamlFacts {
+  if (params.file.kind !== "properties" && params.file.kind !== "configuration") {
+    return { diagnostics: [], objectIndexEntries: [] }
+  }
+
+  const dirRules = params.rulesSnapshot.projectDirs[params.file.owner.dir]
+  if (dirRules === undefined || dirRules.root === undefined || params.file.owner.name.length === 0) {
+    return { diagnostics: [], objectIndexEntries: [] }
+  }
+
+  const target = {
+    kind: "object" as const,
+    root: dirRules.root as never,
+    objectName: params.file.owner.name,
+  }
+
+  return {
+    diagnostics: [],
+    objectIndexEntries: [
+      {
+        canonical: projectObjectIndexKey(target),
+        target,
+        result: { ok: true, filePath: params.file.absolutePath },
+      },
+    ],
+  }
+}
+```
+
+- [ ] **Step 2: Test object entry extraction**
+
+Create `packages/core/metadata/validation/yamlFactExtractor.test.ts`:
+
+```ts
+import { resolve } from "path"
+import { describe, expect, it } from "vitest"
+import { createValidationRulesSnapshot } from "./rulesSnapshot"
+import { resolveValidationProjectFile } from "./projectFiles"
+import { extractValidationYamlFacts } from "./yamlFactExtractor"
+
+describe("validation YAML fact extractor", () => {
+  it("extracts catalog object index entry without importing a model", () => {
+    const projectDir = resolve("metadata/validation/__fixtures__/project-with-form")
+    const filePath = resolve(projectDir, "Справочник/СправочникСФормой/Свойства.yaml")
+    const file = resolveValidationProjectFile(projectDir, filePath)
+
+    expect(file).toBeDefined()
+    const facts = extractValidationYamlFacts({
+      file: file!,
+      data: { Имя: "СправочникСФормой" },
+      rulesSnapshot: createValidationRulesSnapshot({ version: "8.3.24", defaultLanguage: "ru" }),
+    })
+
+    expect(facts.objectIndexEntries.map((entry) => entry.canonical)).toContain("Catalog.СправочникСФормой")
+  })
+})
+```
+
+- [ ] **Step 3: Run the extractor test**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/yamlFactExtractor.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Wire extractor as an additive check**
+
+In `validateProjectPropertiesFirstPass`, call the extractor after schema validation using `parsed.data`. For now compare only object index parity in a test, without replacing current model extraction:
+
+```ts
+const yamlFacts = extractValidationYamlFacts({
+  file: params.file,
+  data: parsed.data,
+  rulesSnapshot: params.rulesSnapshot,
+})
+```
+
+This step also requires extending `validateProjectFileFirstPass` params with `rulesSnapshot`.
+
+- [ ] **Step 5: Commit properties extractor foundation**
+
+```bash
+git add packages/core/metadata/validation/yamlFactExtractor.ts packages/core/metadata/validation/yamlFactExtractor.test.ts packages/core/metadata/validation/projectValidationPasses.ts packages/core/metadata/validation/projectValidationWorker.ts packages/core/metadata/validation/validateProject.ts
+git commit -m "feat: :sparkles: извлекать validation facts из YAML"
+```
+
+## Task 6: Move References And Form Checks To YAML Facts
+
+**Files:**
+- Modify: `packages/core/metadata/validation/rulesSnapshot.ts`
+- Modify: `packages/core/metadata/validation/yamlFactExtractor.ts`
+- Modify: `packages/core/metadata/validation/projectValidationPendingChecks.ts`
+- Modify: `packages/core/metadata/validation/projectValidationPasses.ts`
+- Test: `packages/core/metadata/validation/yamlFactExtractor.test.ts`
+- Test: `packages/core/metadata/validation/validateProject.test.ts`
+
+- [ ] **Step 1: Extend snapshot with metadata target paths**
+
+Add to `ValidationRulesProjectDir`:
+
+```ts
+metadataTargetPaths: readonly ValidationYamlPathRule[]
+```
+
+Add:
+
+```ts
+export interface ValidationYamlPathRule {
+  yamlPath: readonly string[]
+  constraint: "metadataTarget"
+}
+```
+
+Initially populate `metadataTargetPaths: []`. Then add explicit paths only through data collected from existing rule registrations; do not hardcode object-specific behavior in the extractor.
+
+- [ ] **Step 2: Add pending reference extraction tests**
+
+In `yamlFactExtractor.test.ts`, add a fixture-driven test that uses a known broken metadata target from `project-with-errors` and expects one `pendingReferences` entry with file path and YAML path.
+
+- [ ] **Step 3: Extend extractor result**
+
+Update `ValidationYamlFacts`:
+
+```ts
+pendingReferences: PendingMetadataTargetReference[]
+memberIndexEntries: ProjectMemberIndexEntry[]
+valueIndexEntries: ProjectValueIndexEntry[]
+pendingChecks: ValidationPendingCheck[]
+```
+
+Return empty arrays for unsupported facts until the rule path is implemented.
+
+- [ ] **Step 4: Add form pending check extraction**
+
+Use existing form traversal behavior as the reference, but extract compact checks from YAML:
+
+```ts
+{
+  kind: "dataPath",
+  filePath: params.file.absolutePath,
+  yamlPath: ["Элементы", elementName, "ПутьКДанным"],
+  owner: { kind: params.file.owner.dir, name: params.file.owner.name },
+  value,
+  policy: "formDataPath",
+}
+```
+
+The actual element paths must come from `rulesSnapshot.form`, not from a hardcoded `Элементы` branch in final code. A temporary test may name the path while the next step moves it into snapshot.
+
+- [ ] **Step 5: Resolve pending checks in second pass**
+
+Add a resolver function in `projectValidationPendingChecks.ts`:
+
+```ts
+export function validatePendingChecks(params: {
+  checks: readonly ValidationPendingCheck[]
+  ownerCache: OwnerMetadataCache
+}): Diagnostic[] {
+  return params.checks.flatMap((check) => {
+    if (check.kind === "dataPath") {
+      return validateDataPathPendingCheck({ check, ownerCache })
+    }
+    return []
+  })
+}
+```
+
+Use existing dataPath resolver APIs for the implementation.
+
+- [ ] **Step 6: Run validation tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/yamlFactExtractor.test.ts metadata/validation/validateProject.test.ts metadata/validation/dataPath/formTraversal.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit YAML references and checks**
+
+```bash
+git add packages/core/metadata/validation/rulesSnapshot.ts packages/core/metadata/validation/yamlFactExtractor.ts packages/core/metadata/validation/projectValidationPendingChecks.ts packages/core/metadata/validation/projectValidationPasses.ts packages/core/metadata/validation/yamlFactExtractor.test.ts packages/core/metadata/validation/validateProject.test.ts
+git commit -m "feat: :sparkles: проверять ссылки через YAML facts"
+```
+
+## Task 7: Remove Model-Based First Pass From Workers
+
+**Files:**
+- Modify: `packages/core/metadata/validation/projectValidationPasses.ts`
+- Modify: `packages/core/metadata/validation/projectValidationWorker.ts`
+- Modify: `packages/core/metadata/validation/projectValidationTypes.ts`
+- Modify: `packages/core/metadata/validation/projectValidationObjectTable.ts`
+- Test: `packages/core/metadata/validation/projectValidationWorkerPool.test.ts`
+- Test: `packages/core/metadata/validation/validateProject.test.ts`
+
+- [ ] **Step 1: Add import boundary test**
+
+In `projectValidationWorkerPool.test.ts`, read `projectValidationWorker.ts` and assert worker no longer imports full metadata registration:
+
+```ts
+it("validation worker does not import fromYAML or full metadata models", async () => {
+  const source = await import("node:fs/promises").then((fs) =>
+    fs.readFile(new URL("./projectValidationWorker.ts", import.meta.url), "utf8")
+  )
+
+  expect(source).not.toContain("fromYAML")
+  expect(source).not.toContain("registerCoreMetadata")
+})
+```
+
+- [ ] **Step 2: Switch first pass to YAML facts**
+
+In `validateProjectPropertiesFirstPass`, remove `importPropertiesModel`, `buildObjectFieldIndex(ownerWithoutIndex)`, `collectMetadataTargetReferencesInModel`, and `validateUniqueNameScopes` calls only after equivalent facts/checks exist in `yamlFactExtractor`.
+
+The return should use `yamlFacts`:
+
+```ts
+return {
+  state: {
+    kind: "properties",
+    file: params.file,
+    pendingReferences: yamlFacts.pendingReferences,
+    firstPassDiagnostics: diagnostics,
+  },
+  diagnostics,
+  objectIndexEntries: yamlFacts.objectIndexEntries,
+  memberIndexEntries: yamlFacts.memberIndexEntries,
+  valueIndexEntries: yamlFacts.valueIndexEntries,
+  pendingReferences: yamlFacts.pendingReferences,
+  objectRecords: yamlFacts.ownerFacts.map(ownerFactsToValidationRecord),
+  profile,
+}
+```
+
+- [ ] **Step 3: Remove model from records**
+
+In `projectValidationTypes.ts`, delete `model?: unknown` from `ValidationObjectRecord`. Keep `ownerFacts` and any compact fields required by shared owner snapshot.
+
+- [ ] **Step 4: Update object table tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/projectValidationObjectTable.test.ts metadata/validation/sharedValidationBinaryOwners.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run worker tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/projectValidationWorkerPool.test.ts metadata/validation/validateProject.test.ts
+```
+
+Expected: PASS, including the import boundary test.
+
+- [ ] **Step 6: Commit worker model removal**
+
+```bash
+git add packages/core/metadata/validation/projectValidationPasses.ts packages/core/metadata/validation/projectValidationWorker.ts packages/core/metadata/validation/projectValidationTypes.ts packages/core/metadata/validation/projectValidationObjectTable.ts packages/core/metadata/validation/projectValidationWorkerPool.test.ts packages/core/metadata/validation/validateProject.test.ts
+git commit -m "refactor: :recycle: убрать model из validation worker"
+```
+
+## Task 8: Add Validation-Only Registration
+
+**Files:**
+- Create: `packages/core/metadata/validation/registerValidationMetadata.ts`
+- Modify: `packages/core/metadata/validation/projectValidationWorker.ts`
+- Test: `packages/core/metadata/validation/projectValidationWorkerPool.test.ts`
+
+- [ ] **Step 1: Add minimal validation registration wrapper**
+
+Create `packages/core/metadata/validation/registerValidationMetadata.ts`:
+
+```ts
+let validationMetadataRegistered = false
+
+export function registerValidationMetadata(): void {
+  if (validationMetadataRegistered) return
+  validationMetadataRegistered = true
+}
+```
+
+Because worker no longer imports `fromYAML` or model rules, this wrapper starts empty. Add imports only if tests prove schema/check execution still needs them.
+
+- [ ] **Step 2: Switch worker registration**
+
+In `projectValidationWorker.ts`, replace `registerCoreMetadata()` with:
+
+```ts
+registerValidationMetadata()
+```
+
+and import it from `./registerValidationMetadata`.
+
+- [ ] **Step 3: Run import boundary test**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation/projectValidationWorkerPool.test.ts -t "validation worker does not import"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit validation registration**
+
+```bash
+git add packages/core/metadata/validation/registerValidationMetadata.ts packages/core/metadata/validation/projectValidationWorker.ts packages/core/metadata/validation/projectValidationWorkerPool.test.ts
+git commit -m "refactor: :recycle: облегчить регистрацию validation worker"
+```
+
+## Task 9: Full Verification And nkdk-yaml Check
+
+**Files:**
+- Modify: code only if verification exposes issues.
+- Test: full repository and `/Users/nikita/git/nkdk-yaml`.
+
+- [ ] **Step 1: Run focused validation suite**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run metadata/validation
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run CLI validation tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/cli exec vitest run src/commands/validate.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full project tests**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4: Run validation on nkdk-yaml**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/cli exec nkdk validate /Users/nikita/git/nkdk-yaml
+```
+
+Expected: command completes without process crash. Record exit code and diagnostics count.
+
+- [ ] **Step 5: Run profiled validation on nkdk-yaml**
+
+Run:
+
+```bash
+NKDK_VALIDATION_PROFILE=1 pnpm --filter @nakidka/cli exec nkdk validate /Users/nikita/git/nkdk-yaml
+```
+
+Expected: command completes or reports validation diagnostics normally. Record profile lines for worker init, first pass, snapshot, second pass, and total time.
+
+- [ ] **Step 6: Commit verification notes if added**
+
+If measurements are written to docs, commit them:
+
+```bash
+git add docs/superpowers/measurements
+git commit -m "docs: :memo: измерить validation без модели"
+```
+
+If no docs are added, do not create an empty commit.
+
+## Self-Review
+
+- Spec coverage: plan covers one YAML read, no worker model retention, `rulesSnapshot`, compact facts/checks, shared snapshot compatibility, full tests, and `/Users/nikita/git/nkdk-yaml` verification.
+- Placeholder scan: plan intentionally leaves no unfinished markers or unspecified test commands. The only staged growth is explicit: unsupported facts return empty arrays until their task implements them.
+- Type consistency: `ValidationRulesSnapshot`, `ValidationYamlFacts`, `ValidationPendingCheck`, and `ValidationOwnerFacts` are introduced before use. Later tasks replace temporary compatibility fields only after tests exist.

--- a/docs/superpowers/specs/2026-07-06-mcp-persistent-validation-piscina-design.md
+++ b/docs/superpowers/specs/2026-07-06-mcp-persistent-validation-piscina-design.md
@@ -1,0 +1,57 @@
+# MCP persistent validation pool на Piscina
+
+## Контекст
+
+`nkdk.validate_project` в MCP сейчас вызывает `core.validateProject(...)`. Для полного YAML-проекта core создаёт validation worker pool, прогревает схемы в worker threads, выполняет first/second pass и затем закрывает pool. Поэтому каждый MCP-вызов заново платит стоимость запуска workers и компиляции validation schema cache.
+
+После перехода validation worker на compact YAML facts проектные данные внутри worker очищаются после second pass. Это делает возможным безопасное переиспользование самих workers между MCP-вызовами, если не сохранять `workerState`, object table, snapshots и pending references между проверками.
+
+## Цель
+
+Сделать MCP-режим validation быстрее на повторных вызовах за счёт постоянного общего pool на процесс MCP-сервера.
+
+Ограничения:
+
+- постоянный pool нужен только MCP-серверу;
+- CLI остаётся одноразовым и не держит workers после завершения команды;
+- общий pool один на MCP-сервер, не отдельный на `projectDir`;
+- проектные данные не должны протекать между вызовами;
+- управление workers переносится с ручного `worker_threads` на Piscina.
+
+## Дизайн
+
+Core получает явный объект жизненного цикла, например `ValidationWorkerPoolHandle`. Он создаётся с `concurrency`, лениво запускает Piscina pool, прогревает каждый worker задачей `init`, а затем предоставляет метод полной validation для проекта.
+
+`validateProject(...)` остаётся публичной одноразовой функцией. Для CLI и существующих вызовов её поведение сохраняется: создать pool, проверить проект, закрыть pool. Для MCP добавляется отдельная точка входа в core, которая создаёт долгоживущий handle и закрывается только при остановке MCP-сервера.
+
+Piscina worker вместо `parentPort.on("message")` экспортирует обработчик задачи. Типы задач остаются теми же по смыслу:
+
+- `init`: создать schema cache и сохранить rulesSnapshot внутри worker;
+- `firstPass`: прочитать назначенные YAML-файлы и вернуть compact facts/diagnostics;
+- `secondPass`: принять shared snapshot, проверить pending references и form checks, затем очистить worker-local project state.
+
+Для гарантированного прогрева всех потоков pool отправляет `concurrency` задач `init`. Последующие validation-запуски не повторяют `init`, пока handle жив. Если context или concurrency изменятся, caller создаёт новый handle.
+
+## MCP-жизненный цикл
+
+MCP-сервер держит один общий validation handle в service layer. Первый вызов `nkdk.validate_project` создаёт handle с default concurrency из core. Следующие вызовы переиспользуют тот же handle.
+
+При завершении stdio-сервера MCP вызывает `close()` у handle. Если отдельного shutdown hook в SDK недостаточно, закрытие можно повесить на `SIGINT`, `SIGTERM`, `beforeExit` и нормальный путь `runStdioServer`.
+
+## Ошибки и состояние
+
+Если validation-задача падает, ошибка возвращается через текущий `toolError("core_error", ...)`. Сам handle не должен молча оставаться в поломанном состоянии после фатальной ошибки worker pool: для ошибок Piscina pool закрывается, ссылка сбрасывается, следующий MCP-вызов создаёт новый pool.
+
+Внутри worker после second pass вызывается очистка `workerState`. First pass всегда начинает с пустого `workerState`. Schema cache и rulesSnapshot остаются между вызовами.
+
+## Тестирование
+
+Нужны focused tests:
+
+- core: pool на Piscina переиспользует workers и не компилирует schema cache повторно на втором запуске;
+- core: после второй проверки worker не удерживает project state;
+- MCP service: два последовательных вызова используют один validation handle;
+- MCP/server: shutdown закрывает handle;
+- существующие validation и MCP тесты остаются зелёными.
+
+Полная проверка перед завершением: `pnpm test`, плюс ручной MCP-замер `nkdk.validate_project` на `/Users/nikita/git/nkdk-yaml`.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -76,9 +76,11 @@ export type { ParsedYaml } from "./yaml/parseMetadataYaml"
 export { importMetadataEnumerationFromYAML } from "./metadata/appliedObjects/metadataEnumeration/fromYAML"
 export type { Diagnostic, DiagnosticSource, DiagnosticSeverity, MetadataKind } from "./metadata/validation/types"
 export {
+  createValidationWorkerPoolHandle,
   validateProject,
   type ValidateProjectParams,
   type ValidateProjectResult,
+  type ValidationWorkerPoolHandle,
 } from "./metadata/validation/validateProject"
 export { validateParsedFile } from "./metadata/validation/validateFile"
 export { validateForm, type ValidateFormParams } from "./metadata/validation/validateForm"

--- a/packages/core/metadata/validation/dataPath/ownerCache.test.ts
+++ b/packages/core/metadata/validation/dataPath/ownerCache.test.ts
@@ -54,7 +54,6 @@ describe("OwnerMetadataCache", () => {
           kind: "properties",
           owner: { dir: "Справочник", name: "Товары" },
           ownerRef: { kind: "Справочник", name: "Товары" },
-          model: { itemType: "MetadataCatalog", name: "Товары" },
           fieldIndex: { fields: new Map(), standardAttributeAliases: new Map(), diagnostics: [] },
           importDiagnostics: [],
         },

--- a/packages/core/metadata/validation/dataPath/ownerCache.ts
+++ b/packages/core/metadata/validation/dataPath/ownerCache.ts
@@ -10,6 +10,7 @@ import type { ProjectYamlCache } from "../projectYamlCache"
 import type { Diagnostic } from "../types"
 import { validateUniqueNameScopes } from "../uniqueNameScopes"
 import { buildObjectFieldIndex, type ObjectFieldIndex } from "./objectFields"
+import { modelStubFromOwnerFacts } from "./ownerFacts"
 import { getDataPathOwnerKind, type DataPathOwnerKindRegistration } from "./registry"
 import type { OwnerTypeRef } from "./types"
 
@@ -118,7 +119,10 @@ function loadOwnerFromValidationTable(params: {
     return { status: "import-error", diagnostics: record.importDiagnostics }
   }
 
-  if (ownerKind === undefined || record.model === undefined || record.fieldIndex === undefined) {
+  const fieldIndex = record.ownerFacts?.fieldIndex ?? record.fieldIndex
+  const model = record.ownerFacts === undefined ? {} : modelStubFromOwnerFacts(record.ownerFacts)
+
+  if (ownerKind === undefined || model === undefined || fieldIndex === undefined) {
     return {
       status: "import-error",
       diagnostics: [
@@ -133,10 +137,10 @@ function loadOwnerFromValidationTable(params: {
     owner: {
       ref: params.ref,
       filePath: record.filePath,
-      model: record.model as MetadataItem,
+      model: model as MetadataItem,
       rule: spec.rule,
       spec,
-      fieldIndex: record.fieldIndex,
+      fieldIndex,
     },
   }
 }

--- a/packages/core/metadata/validation/dataPath/ownerFacts.ts
+++ b/packages/core/metadata/validation/dataPath/ownerFacts.ts
@@ -1,0 +1,59 @@
+import type { TypeDescription } from "../../commonObjects/typeDescription/types"
+import type { MetadataItem } from "../../orchestration/property/types"
+import type { ObjectFieldIndex } from "./objectFields"
+import type { OwnerTypeRef } from "./types"
+
+export interface ValidationOwnerFacts {
+  ref: OwnerTypeRef
+  filePath: string
+  fieldIndex: ObjectFieldIndex
+  type?: TypeDescription
+  commonAttributeOwnerLinks?: string[]
+}
+
+export function createValidationOwnerFacts(params: {
+  ref: OwnerTypeRef
+  filePath: string
+  fieldIndex: ObjectFieldIndex
+  model: MetadataItem
+}): ValidationOwnerFacts {
+  const type = metadataRecord(params.model)["type"]
+  const commonAttributeOwnerLinks = commonAttributeOwnerLinksFromModel(params.model)
+
+  return {
+    ref: params.ref,
+    filePath: params.filePath,
+    fieldIndex: params.fieldIndex,
+    ...(isTypeDescription(type) ? { type } : {}),
+    ...(commonAttributeOwnerLinks.length === 0 ? {} : { commonAttributeOwnerLinks }),
+  }
+}
+
+export function modelStubFromOwnerFacts(facts: ValidationOwnerFacts): unknown {
+  return {
+    ...(facts.type === undefined ? {} : { type: facts.type }),
+    ...(facts.commonAttributeOwnerLinks === undefined
+      ? {}
+      : { content: facts.commonAttributeOwnerLinks.map((metadata) => ({ metadata, use: "Use" })) }),
+  }
+}
+
+function commonAttributeOwnerLinksFromModel(model: MetadataItem): string[] {
+  const content = metadataRecord(model)["content"]
+  if (!Array.isArray(content)) return []
+
+  return content
+    .map((item) => {
+      const record = metadataRecord(item)
+      return record["use"] === "Use" && typeof record["metadata"] === "string" ? record["metadata"] : undefined
+    })
+    .filter((value): value is string => value !== undefined)
+}
+
+function isTypeDescription(value: unknown): value is TypeDescription {
+  return typeof value === "object" && value !== null && "type" in value
+}
+
+function metadataRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {}
+}

--- a/packages/core/metadata/validation/projectValidationObjectTable.test.ts
+++ b/packages/core/metadata/validation/projectValidationObjectTable.test.ts
@@ -76,7 +76,6 @@ function record(owner: { kind: string; name: string }, filePath?: string): Valid
     kind: "properties",
     owner: { dir: owner.kind, name: owner.name },
     ownerRef: { kind: owner.kind, name: owner.name },
-    model: { itemType: owner.kind, name: owner.name },
     importDiagnostics: [],
   }
 }

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -286,7 +286,10 @@ export function validateProjectFileSecondPass(
   if (params.state.kind === "failed") return { status: "ok", diagnostics: [] }
 
   if (params.state.kind === "form") {
-    return validatePendingChecks({ ownerCache: params.ownerCache, checks: params.state.pendingChecks })
+    return {
+      status: "ok",
+      ...validatePendingChecks({ ownerCache: params.ownerCache, checks: params.state.pendingChecks }),
+    }
   }
 
   const collected = params.skipMetadataTargetValidation
@@ -501,14 +504,12 @@ function validateProjectPropertiesFirstPass(params: {
     const ownerModel = (yamlFacts.ownerModelStub ?? {
       itemType: params.file.owner.spec.rule.itemType,
       name: params.file.owner.name,
-    }) as MetadataItem
+    }) as unknown as MetadataItem
     const fieldIndexStartedAt = performance.now()
     const fieldIndex = buildObjectFieldIndex({
       ref: ownerRef,
-      filePath: params.file.absolutePath,
       model: ownerModel,
       rule: params.file.owner.spec.rule,
-      spec: params.file.owner.spec,
     })
     const fieldIndexMs = performance.now() - fieldIndexStartedAt
     const owner: OwnerMetadata = {

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -29,6 +29,7 @@ import {
 import { exportJSONSchemaGraph } from "./projectFileSchema"
 import type { ValidationProjectFile } from "./projectFiles"
 import type { ProjectYamlCache, ProjectYamlEntry } from "./projectYamlCache"
+import type { ValidationPendingCheck } from "./projectValidationPendingChecks"
 import {
   configurationValidationProjectSpec,
   validationProjectSpecs,
@@ -60,14 +61,13 @@ export type ProjectValidationFileState =
   | {
       kind: "properties"
       file: ValidationProjectFile
-      parsed: ParsedYaml
-      model: MetadataItem
+      pendingReferences: PendingMetadataTargetReference[]
       firstPassDiagnostics: Diagnostic[]
     }
   | {
       kind: "form"
       file: ValidationProjectFile
-      formState: unknown
+      pendingChecks: ValidationPendingCheck[]
       firstPassDiagnostics: Diagnostic[]
     }
   | { kind: "failed"; file: ValidationProjectFile; diagnostics: Diagnostic[] }
@@ -283,26 +283,12 @@ export function validateProjectFileSecondPass(
   if (params.state.kind === "failed") return { status: "ok", diagnostics: [] }
 
   if (params.state.kind === "form") {
-    const passes = getRegisteredFormValidationPasses()
-    if (passes === undefined) return { status: "ok", diagnostics: [] }
-    return {
-      status: "ok",
-      diagnostics: passes.secondPass({ state: params.state.formState, ownerCache: params.ownerCache }),
-    }
+    return { status: "ok", diagnostics: [] }
   }
-
-  const ownerRoot = rootFromYAML[params.state.file.owner.dir]
-  const owner = ownerRoot ? { root: ownerRoot, objectName: params.state.file.owner.name } : undefined
 
   const collected = params.skipMetadataTargetValidation
     ? { references: [], diagnostics: [] }
-    : collectMetadataTargetReferencesInModel({
-        filePath: params.state.file.absolutePath,
-        parsed: params.state.parsed,
-        model: params.state.model,
-        rule: params.state.file.owner.spec.rule,
-        owner,
-      })
+    : { references: params.state.pendingReferences, diagnostics: [] }
   const resolved = validatePendingReferencesWithIndex({
     index: params.referenceIndex,
     references: collected.references,
@@ -394,7 +380,7 @@ function validateProjectFormFirstPass(params: {
     state: {
       kind: "form",
       file: params.file,
-      formState: first.state,
+      pendingChecks: [],
       firstPassDiagnostics: diagnostics,
     },
     diagnostics,
@@ -589,8 +575,7 @@ function validateProjectPropertiesFirstPass(params: {
     state: {
       kind: "properties",
       file: params.file,
-      parsed,
-      model: imported.model,
+      pendingReferences: pendingReferences.references,
       firstPassDiagnostics: diagnostics,
     },
     diagnostics,

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -11,6 +11,7 @@ import { metadataTargetOwnerFromRule } from "../orchestration/property/metadataT
 import type { ExternalValidationProperty, MetadataItem } from "../orchestration/property/types"
 import { parseMetadataYaml, type ParsedYaml } from "../../yaml/parseMetadataYaml"
 import { type OwnerMetadata, type OwnerMetadataCache } from "./dataPath/ownerCache"
+import { createValidationOwnerFacts } from "./dataPath/ownerFacts"
 import { buildObjectFieldIndex, type ObjectField, type ObjectFieldKind } from "./dataPath/objectFields"
 import { validateExcludedEqualNameYAML } from "./excludeIfEqualNameYAML"
 import { getRegisteredFormValidationPasses } from "./formValidationRegistry"
@@ -556,6 +557,12 @@ function validateProjectPropertiesFirstPass(params: {
     ...ownerWithoutIndex,
     fieldIndex,
   }
+  const ownerFacts = createValidationOwnerFacts({
+    ref: ownerRef,
+    filePath: params.file.absolutePath,
+    fieldIndex,
+    model: imported.model,
+  })
   const memberIndexStartedAt = performance.now()
   const memberIndexEntries = buildMemberIndexEntries({
     projectDir: params.projectDir,
@@ -590,6 +597,7 @@ function validateProjectPropertiesFirstPass(params: {
         kind: params.file.kind,
         owner: { dir: params.file.owner.dir, name: params.file.owner.name },
         ownerRef,
+        ownerFacts,
         model: imported.model,
         fieldIndex,
         objectIndexEntries,

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -41,6 +41,7 @@ import type { Diagnostic } from "./types"
 import { typeboxErrorsToDiagnostics } from "./typeboxErrorsToDiagnostics"
 import { validateParsedFile } from "./validateFile"
 import { validateUniqueNameScopes } from "./uniqueNameScopes"
+import { extractValidationYamlFacts } from "./yamlFactExtractor"
 
 type CompiledSchema = ValidationSchemaValidator<TSchema>
 const formSchemaCache = new Map<string, CompiledSchema>()
@@ -273,6 +274,7 @@ export function validateProjectFileFirstPass(params: {
   cache: ProjectYamlCache
   context: ConfigurationContext
   schemaCache: ValidationSchemaCache
+  rulesSnapshot?: import("./rulesSnapshot").ValidationRulesSnapshot
 }): ProjectValidationFirstPassResult {
   if (params.file.kind === "form") return validateProjectFormFirstPass(params)
   return validateProjectPropertiesFirstPass(params)
@@ -307,6 +309,7 @@ function validateProjectFormFirstPass(params: {
   cache: ProjectYamlCache
   context: ConfigurationContext
   schemaCache: ValidationSchemaCache
+  rulesSnapshot?: import("./rulesSnapshot").ValidationRulesSnapshot
 }): ProjectValidationFirstPassResult {
   const totalStartedAt = performance.now()
   const schemaStartedAt = performance.now()
@@ -564,6 +567,10 @@ function validateProjectPropertiesFirstPass(params: {
     model: imported.model,
   })
   const memberIndexStartedAt = performance.now()
+  const yamlFacts =
+    params.rulesSnapshot === undefined
+      ? undefined
+      : extractValidationYamlFacts({ file: params.file, data: parsed.data, rulesSnapshot: params.rulesSnapshot })
   const memberIndexEntries = buildMemberIndexEntries({
     projectDir: params.projectDir,
     owner,
@@ -571,8 +578,8 @@ function validateProjectPropertiesFirstPass(params: {
   })
   const memberIndexMs = performance.now() - memberIndexStartedAt
   const objectIndexStartedAt = performance.now()
-  const objectIndexEntry = buildObjectIndexEntry({ owner, file: params.file })
-  const objectIndexEntries = objectIndexEntry ? [objectIndexEntry] : []
+  const modelObjectIndexEntry = buildObjectIndexEntry({ owner, file: params.file })
+  const objectIndexEntries = yamlFacts?.objectIndexEntries ?? (modelObjectIndexEntry ? [modelObjectIndexEntry] : [])
   const objectIndexMs = performance.now() - objectIndexStartedAt
   const valueIndexStartedAt = performance.now()
   const valueIndexEntries = buildValueIndexEntries({ owner })

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -30,7 +30,7 @@ import {
 import { exportJSONSchemaGraph } from "./projectFileSchema"
 import type { ValidationProjectFile } from "./projectFiles"
 import type { ProjectYamlCache, ProjectYamlEntry } from "./projectYamlCache"
-import type { ValidationPendingCheck } from "./projectValidationPendingChecks"
+import { validatePendingChecks, type ValidationPendingCheck } from "./projectValidationPendingChecks"
 import {
   configurationValidationProjectSpec,
   validationProjectSpecs,
@@ -286,7 +286,7 @@ export function validateProjectFileSecondPass(
   if (params.state.kind === "failed") return { status: "ok", diagnostics: [] }
 
   if (params.state.kind === "form") {
-    return { status: "ok", diagnostics: [] }
+    return validatePendingChecks({ ownerCache: params.ownerCache, checks: params.state.pendingChecks })
   }
 
   const collected = params.skipMetadataTargetValidation
@@ -328,6 +328,12 @@ function validateProjectFormFirstPass(params: {
     })
   }
 
+  const entry = params.cache.get(params.file.absolutePath)
+  const yamlFacts =
+    "error" in entry || params.rulesSnapshot === undefined
+      ? undefined
+      : extractValidationYamlFacts({ file: params.file, parsed: entry.parsed, rulesSnapshot: params.rulesSnapshot })
+
   const passes = getRegisteredFormValidationPasses()
   if (passes === undefined) {
     const profile = {
@@ -365,7 +371,7 @@ function validateProjectFormFirstPass(params: {
     suppressFormImportDiagnostics: schemaDiagnostics.length > 0,
   })
   const formImportMs = performance.now() - formImportStartedAt
-  const diagnostics = [...schemaDiagnostics, ...first.diagnostics]
+  const diagnostics = [...schemaDiagnostics, ...first.diagnostics, ...(yamlFacts?.diagnostics ?? [])]
   if (first.status === "failed") {
     return failedFirstPass(params.file, diagnostics, {
       ...emptyFirstPassProfile("form"),
@@ -384,7 +390,7 @@ function validateProjectFormFirstPass(params: {
     state: {
       kind: "form",
       file: params.file,
-      pendingChecks: [],
+      pendingChecks: yamlFacts?.pendingChecks ?? [],
       firstPassDiagnostics: diagnostics,
     },
     diagnostics,
@@ -410,6 +416,7 @@ function validateProjectPropertiesFirstPass(params: {
   cache: ProjectYamlCache
   context: ConfigurationContext
   schemaCache: ValidationSchemaCache
+  rulesSnapshot?: import("./rulesSnapshot").ValidationRulesSnapshot
 }): ProjectValidationFirstPassResult {
   const totalStartedAt = performance.now()
   const cacheStartedAt = performance.now()
@@ -543,7 +550,7 @@ function validateProjectPropertiesFirstPass(params: {
     ...suppressEqualNameSchemaDiagnostics(schemaDiagnostics, equalNameDiagnostics),
     ...equalNameDiagnostics,
     ...uniqueScopeDiagnostics,
-    ...pendingReferences.diagnostics,
+    ...(params.rulesSnapshot === undefined ? pendingReferences.diagnostics : []),
   ]
   const ownerRef = { kind: params.file.owner.dir, name: params.file.owner.name }
   const ownerWithoutIndex = {
@@ -570,7 +577,7 @@ function validateProjectPropertiesFirstPass(params: {
   const yamlFacts =
     params.rulesSnapshot === undefined
       ? undefined
-      : extractValidationYamlFacts({ file: params.file, data: parsed.data, rulesSnapshot: params.rulesSnapshot })
+      : extractValidationYamlFacts({ file: params.file, parsed, rulesSnapshot: params.rulesSnapshot })
   const memberIndexEntries = buildMemberIndexEntries({
     projectDir: params.projectDir,
     owner,
@@ -589,14 +596,14 @@ function validateProjectPropertiesFirstPass(params: {
     state: {
       kind: "properties",
       file: params.file,
-      pendingReferences: pendingReferences.references,
+      pendingReferences: yamlFacts?.pendingReferences ?? pendingReferences.references,
       firstPassDiagnostics: diagnostics,
     },
     diagnostics,
     objectIndexEntries,
     memberIndexEntries,
     valueIndexEntries,
-    pendingReferences: pendingReferences.references,
+    pendingReferences: yamlFacts?.pendingReferences ?? pendingReferences.references,
     objectRecords: [
       {
         filePath: params.file.absolutePath,
@@ -610,7 +617,7 @@ function validateProjectPropertiesFirstPass(params: {
         objectIndexEntries,
         memberIndexEntries,
         valueIndexEntries,
-        pendingReferences: pendingReferences.references,
+        pendingReferences: yamlFacts?.pendingReferences ?? pendingReferences.references,
         importDiagnostics: [],
       },
     ],

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -485,6 +485,99 @@ function validateProjectPropertiesFirstPass(params: {
     })
   }
 
+  if (params.rulesSnapshot !== undefined) {
+    const equalNameValidationName = params.file.kind === "properties" ? params.file.owner.name : undefined
+    const equalNameStartedAt = performance.now()
+    const equalNameDiagnostics = validateExcludedEqualNameYAML({
+      filePath: params.file.absolutePath,
+      parsed,
+      rule: params.file.owner.spec.rule,
+      context: params.context,
+      name: equalNameValidationName,
+    })
+    const equalNameMs = performance.now() - equalNameStartedAt
+    const yamlFacts = extractValidationYamlFacts({ file: params.file, parsed, rulesSnapshot: params.rulesSnapshot })
+    const ownerRef = { kind: params.file.owner.dir, name: params.file.owner.name }
+    const fieldIndexStartedAt = performance.now()
+    const fieldIndex = yamlFacts.fieldIndex ?? { fields: new Map(), standardAttributeAliases: new Map(), diagnostics: [] }
+    const fieldIndexMs = performance.now() - fieldIndexStartedAt
+    const ownerModel = (yamlFacts.ownerModelStub ?? { itemType: params.file.owner.spec.rule.itemType, name: params.file.owner.name }) as MetadataItem
+    const owner: OwnerMetadata = {
+      ref: ownerRef,
+      filePath: params.file.absolutePath,
+      model: ownerModel,
+      rule: params.file.owner.spec.rule,
+      spec: params.file.owner.spec,
+      fieldIndex,
+    }
+    const ownerFacts = createValidationOwnerFacts({
+      ref: ownerRef,
+      filePath: params.file.absolutePath,
+      fieldIndex,
+      model: ownerModel,
+    })
+    const memberIndexStartedAt = performance.now()
+    const memberIndexEntries = buildMemberIndexEntries({
+      projectDir: params.projectDir,
+      owner,
+      hasFile: fs.existsSync,
+    })
+    const memberIndexMs = performance.now() - memberIndexStartedAt
+    const diagnostics = [
+      ...suppressEqualNameSchemaDiagnostics(schemaDiagnostics, equalNameDiagnostics),
+      ...equalNameDiagnostics,
+      ...yamlFacts.diagnostics,
+      ...fieldIndex.diagnostics,
+    ]
+
+    return {
+      state: {
+        kind: "properties",
+        file: params.file,
+        pendingReferences: yamlFacts.pendingReferences,
+        firstPassDiagnostics: diagnostics,
+      },
+      diagnostics,
+      objectIndexEntries: yamlFacts.objectIndexEntries,
+      memberIndexEntries,
+      valueIndexEntries: yamlFacts.valueIndexEntries,
+      pendingReferences: yamlFacts.pendingReferences,
+      objectRecords: [
+        {
+          filePath: params.file.absolutePath,
+          projectPath: params.file.projectPath,
+          kind: params.file.kind,
+          owner: { dir: params.file.owner.dir, name: params.file.owner.name },
+          ownerRef,
+          ownerFacts,
+          fieldIndex,
+          objectIndexEntries: yamlFacts.objectIndexEntries,
+          memberIndexEntries,
+          valueIndexEntries: yamlFacts.valueIndexEntries,
+          pendingReferences: yamlFacts.pendingReferences,
+          importDiagnostics: [],
+        },
+      ],
+      profile: {
+        key: validationFirstPassProfileKey(params.file),
+        totalMs: performance.now() - totalStartedAt,
+        cacheMs,
+        schemaMs,
+        validatorsMs,
+        importMs: 0,
+        equalNameMs,
+        uniqueScopesMs: 0,
+        referencesMs: 0,
+        fieldIndexMs,
+        objectIndexMs: 0,
+        memberIndexMs,
+        valueIndexMs: 0,
+        formImportMs: 0,
+        diagnostics: diagnostics.length,
+      },
+    }
+  }
+
   const importStartedAt = performance.now()
   const imported = importPropertiesModel({
     spec: params.file.owner.spec,
@@ -612,7 +705,6 @@ function validateProjectPropertiesFirstPass(params: {
         owner: { dir: params.file.owner.dir, name: params.file.owner.name },
         ownerRef,
         ownerFacts,
-        model: imported.model,
         fieldIndex,
         objectIndexEntries,
         memberIndexEntries,

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -498,10 +498,19 @@ function validateProjectPropertiesFirstPass(params: {
     const equalNameMs = performance.now() - equalNameStartedAt
     const yamlFacts = extractValidationYamlFacts({ file: params.file, parsed, rulesSnapshot: params.rulesSnapshot })
     const ownerRef = { kind: params.file.owner.dir, name: params.file.owner.name }
+    const ownerModel = (yamlFacts.ownerModelStub ?? {
+      itemType: params.file.owner.spec.rule.itemType,
+      name: params.file.owner.name,
+    }) as MetadataItem
     const fieldIndexStartedAt = performance.now()
-    const fieldIndex = yamlFacts.fieldIndex ?? { fields: new Map(), standardAttributeAliases: new Map(), diagnostics: [] }
+    const fieldIndex = buildObjectFieldIndex({
+      ref: ownerRef,
+      filePath: params.file.absolutePath,
+      model: ownerModel,
+      rule: params.file.owner.spec.rule,
+      spec: params.file.owner.spec,
+    })
     const fieldIndexMs = performance.now() - fieldIndexStartedAt
-    const ownerModel = (yamlFacts.ownerModelStub ?? { itemType: params.file.owner.spec.rule.itemType, name: params.file.owner.name }) as MetadataItem
     const owner: OwnerMetadata = {
       ref: ownerRef,
       filePath: params.file.absolutePath,

--- a/packages/core/metadata/validation/projectValidationPendingChecks.ts
+++ b/packages/core/metadata/validation/projectValidationPendingChecks.ts
@@ -1,16 +1,77 @@
 import type { OwnerTypeRef } from "./dataPath/types"
+import { resolveDataPath } from "./dataPath/resolver"
+import { validateResolvedDataPathPolicy } from "./dataPath/policies"
+import type { FormDataPathIndex } from "./dataPath/formIndex"
+import type { OwnerMetadataCache } from "./dataPath/ownerCache"
+import type { DataPathPropertyRule } from "../orchestration/property/types"
+import type { ElementType } from "../orchestration/formElement/types"
+import type { ParsedYaml } from "../../yaml/parseMetadataYaml"
 import type { Diagnostic } from "./types"
 import type { YamlPath } from "./yamlLocations"
 
 export type ValidationPendingCheck = {
   kind: "dataPath"
   filePath: string
+  parsed: ParsedYaml
   yamlPath: YamlPath
   owner: OwnerTypeRef
   value: string
+  index: FormDataPathIndex
+  rule: DataPathPropertyRule
+  elementType?: ElementType
+  hasValuesPicture?: boolean
+  tableContext?: { dataPath: string }
   policy: "formDataPath"
 }
 
 export interface ValidationPendingCheckResult {
   diagnostics: Diagnostic[]
+}
+
+export function validatePendingChecks(params: {
+  ownerCache: OwnerMetadataCache
+  checks: readonly ValidationPendingCheck[]
+}): ValidationPendingCheckResult {
+  const diagnostics: Diagnostic[] = []
+
+  for (const check of params.checks) {
+    if (check.kind !== "dataPath") continue
+    const result = resolveDataPath({
+      filePath: check.filePath,
+      parsed: check.parsed,
+      yamlPath: check.yamlPath,
+      value: check.value,
+      index: check.index,
+      ownerCache: params.ownerCache,
+      ...(check.tableContext === undefined ? {} : { tableContext: check.tableContext }),
+    })
+
+    diagnostics.push(...result.diagnostics)
+    if (result.status === "error" || result.target === undefined) continue
+
+    diagnostics.push(
+      ...validateResolvedDataPathPolicy({
+        filePath: check.filePath,
+        parsed: check.parsed,
+        yamlPath: check.yamlPath,
+        value: check.value,
+        rule: check.rule,
+        target: result.target,
+        ...(check.elementType === undefined ? {} : { elementType: check.elementType }),
+        ...(check.hasValuesPicture === undefined ? {} : { hasValuesPicture: check.hasValuesPicture }),
+      })
+    )
+  }
+
+  return { diagnostics: dedupeDiagnostics(diagnostics) }
+}
+
+function dedupeDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
+  const seen = new Set<string>()
+  return diagnostics.filter((diagnostic) => {
+    const key = `${diagnostic.filePath}:${diagnostic.line}:${diagnostic.col}:${diagnostic.source}:${diagnostic.message}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
 }

--- a/packages/core/metadata/validation/projectValidationPendingChecks.ts
+++ b/packages/core/metadata/validation/projectValidationPendingChecks.ts
@@ -1,0 +1,16 @@
+import type { OwnerTypeRef } from "./dataPath/types"
+import type { Diagnostic } from "./types"
+import type { YamlPath } from "./yamlLocations"
+
+export type ValidationPendingCheck = {
+  kind: "dataPath"
+  filePath: string
+  yamlPath: YamlPath
+  owner: OwnerTypeRef
+  value: string
+  policy: "formDataPath"
+}
+
+export interface ValidationPendingCheckResult {
+  diagnostics: Diagnostic[]
+}

--- a/packages/core/metadata/validation/projectValidationTypes.ts
+++ b/packages/core/metadata/validation/projectValidationTypes.ts
@@ -1,4 +1,5 @@
 import type { ObjectFieldIndex } from "./dataPath/objectFields"
+import type { ValidationOwnerFacts } from "./dataPath/ownerFacts"
 import type { OwnerTypeRef } from "./dataPath/types"
 import type {
   PendingMetadataTargetReference,
@@ -26,6 +27,7 @@ export interface ValidationObjectRecord {
   kind: ValidationProjectFile["kind"]
   owner: { dir: string; name: string }
   ownerRef?: OwnerTypeRef
+  ownerFacts?: ValidationOwnerFacts
   model?: unknown
   fieldIndex?: ObjectFieldIndex
   objectIndexEntries?: ProjectObjectIndexEntry[]

--- a/packages/core/metadata/validation/projectValidationTypes.ts
+++ b/packages/core/metadata/validation/projectValidationTypes.ts
@@ -28,7 +28,6 @@ export interface ValidationObjectRecord {
   owner: { dir: string; name: string }
   ownerRef?: OwnerTypeRef
   ownerFacts?: ValidationOwnerFacts
-  model?: unknown
   fieldIndex?: ObjectFieldIndex
   objectIndexEntries?: ProjectObjectIndexEntry[]
   memberIndexEntries?: ProjectMemberIndexEntry[]

--- a/packages/core/metadata/validation/projectValidationWorker.imports.test.ts
+++ b/packages/core/metadata/validation/projectValidationWorker.imports.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "fs"
+import { join } from "path"
+import { describe, expect, it } from "vitest"
+
+describe("projectValidationWorker imports", () => {
+  it("does not import model YAML conversion or core registration directly", () => {
+    const source = readFileSync(join(__dirname, "projectValidationWorker.ts"), "utf8")
+
+    expect(source).not.toContain("fromYAML")
+    expect(source).not.toContain("registerCoreMetadata")
+  })
+})

--- a/packages/core/metadata/validation/projectValidationWorker.ts
+++ b/packages/core/metadata/validation/projectValidationWorker.ts
@@ -152,6 +152,7 @@ function runFirstPass(message: Extract<ValidationWorkerMessage, { kind: "firstPa
       cache,
       context: message.context,
       schemaCache,
+      rulesSnapshot: requireWorkerRulesSnapshot(),
     })
     const firstPassMs = performance.now() - firstPassStartedAt
     timing?.recordFirstPass(firstPassMs)
@@ -182,6 +183,13 @@ function requireWorkerSchemaCache(): ValidationSchemaCache {
     throw new Error("Validation worker не инициализирован")
   }
   return workerSchemaCache
+}
+
+function requireWorkerRulesSnapshot(): ValidationRulesSnapshot {
+  if (workerRulesSnapshot === undefined) {
+    throw new Error("Validation worker rulesSnapshot не инициализирован")
+  }
+  return workerRulesSnapshot
 }
 
 function runSecondPass(message: Extract<ValidationWorkerMessage, { kind: "secondPass" }>): {

--- a/packages/core/metadata/validation/projectValidationWorker.ts
+++ b/packages/core/metadata/validation/projectValidationWorker.ts
@@ -1,5 +1,4 @@
 import { performance } from "node:perf_hooks"
-import { parentPort } from "node:worker_threads"
 import { resolve } from "path"
 import type { ConfigurationContext } from "../context/types"
 import { createOwnerMetadataCacheFromSharedValidationSnapshot } from "./dataPath/sharedOwnerCache"
@@ -37,22 +36,19 @@ import { registerValidationMetadata } from "./registerValidationMetadata"
 
 registerValidationMetadata()
 
-type ValidationWorkerMessage =
+export type ValidationWorkerTask =
   | {
-      id: number
       kind: "init"
       context: ConfigurationContext
       rulesSnapshot: ValidationRulesSnapshot
     }
   | {
-      id: number
       kind: "firstPass"
       projectDir: string
       context: ConfigurationContext
       filePaths: string[]
     }
   | {
-      id: number
       kind: "secondPass"
       projectDir: string
       context: ConfigurationContext
@@ -60,6 +56,26 @@ type ValidationWorkerMessage =
       sharedValidationSnapshot: SharedValidationSnapshot
       pendingReferences: PendingMetadataTargetReference[]
       filePaths: string[]
+    }
+
+export type ValidationWorkerTaskResult =
+  | ({ kind: "initResult" } & ValidationSchemaCacheCompileProfile)
+  | {
+      kind: "firstPassResult"
+      diagnostics: Diagnostic[]
+      objectRecords: ValidationObjectRecord[]
+      objectIndexEntries: ProjectObjectIndexEntry[]
+      memberIndexEntries: ProjectMemberIndexEntry[]
+      valueIndexEntries: ProjectValueIndexEntry[]
+      pendingReferences: PendingMetadataTargetReference[]
+      timing?: WorkerFirstPassTiming
+      profile?: WorkerFirstPassProfile
+    }
+  | {
+      kind: "secondPassResult"
+      diagnostics: Diagnostic[]
+      timing: WorkerSecondPassTiming
+      profile?: WorkerSecondPassProfile
     }
 
 interface WorkerValidationState {
@@ -84,35 +100,19 @@ function createEmptyWorkerValidationState(): WorkerValidationState {
   }
 }
 
-parentPort?.on("message", (message: ValidationWorkerMessage) => {
-  try {
-    if (message.kind === "init") {
-      parentPort?.postMessage({ id: message.id, kind: "initResult", ...runInit(message) })
-      return
-    }
+export default function runValidationWorkerTask(message: ValidationWorkerTask): ValidationWorkerTaskResult {
+  if (message.kind === "init") return { kind: "initResult", ...runInit(message) }
+  if (message.kind === "firstPass") return { kind: "firstPassResult", ...runFirstPass(message) }
+  return { kind: "secondPassResult", ...runSecondPass(message) }
+}
 
-    if (message.kind === "firstPass") {
-      parentPort?.postMessage({ id: message.id, kind: "firstPassResult", ...runFirstPass(message) })
-      return
-    }
-
-    parentPort?.postMessage({ id: message.id, kind: "secondPassResult", ...runSecondPass(message) })
-  } catch (caught) {
-    parentPort?.postMessage({
-      id: message.id,
-      kind: "error",
-      message: caught instanceof Error ? caught.message : String(caught),
-    })
-  }
-})
-
-function runInit(message: Extract<ValidationWorkerMessage, { kind: "init" }>): ValidationSchemaCacheCompileProfile {
+function runInit(message: Extract<ValidationWorkerTask, { kind: "init" }>): ValidationSchemaCacheCompileProfile {
   workerSchemaCache = createValidationSchemaCache(message.context)
   workerRulesSnapshot = message.rulesSnapshot
   return workerSchemaCache.compileAll()
 }
 
-function runFirstPass(message: Extract<ValidationWorkerMessage, { kind: "firstPass" }>): {
+function runFirstPass(message: Extract<ValidationWorkerTask, { kind: "firstPass" }>): {
   diagnostics: Diagnostic[]
   objectRecords: ValidationObjectRecord[]
   objectIndexEntries: ProjectObjectIndexEntry[]
@@ -192,7 +192,7 @@ function requireWorkerRulesSnapshot(): ValidationRulesSnapshot {
   return workerRulesSnapshot
 }
 
-function runSecondPass(message: Extract<ValidationWorkerMessage, { kind: "secondPass" }>): {
+function runSecondPass(message: Extract<ValidationWorkerTask, { kind: "secondPass" }>): {
   diagnostics: Diagnostic[]
   timing: {
     contextMs: number
@@ -304,6 +304,23 @@ interface WorkerFirstPassTiming {
   readMs: number
   firstPassMs: number
   fileCount: number
+}
+
+interface WorkerSecondPassTiming {
+  contextMs: number
+  referenceValidationMs: number
+  validationMs: number
+  fileCount: number
+  referenceHits: number
+  referenceMisses: number
+  referenceConflicts: number
+  referenceFilterFailures: number
+  referenceDependencies: number
+  referenceUnsupported: number
+  referenceFallbacks: number
+  snapshotBytes: number
+  pendingReferences: number
+  memberIndexEntries: number
 }
 
 interface WorkerFirstPassProfile {

--- a/packages/core/metadata/validation/projectValidationWorker.ts
+++ b/packages/core/metadata/validation/projectValidationWorker.ts
@@ -32,6 +32,7 @@ import {
   type ProjectValidationFileState,
 } from "./projectValidationPasses"
 import type { ValidationMode, ValidationObjectRecord } from "./projectValidationTypes"
+import type { ValidationRulesSnapshot } from "./rulesSnapshot"
 import type { Diagnostic } from "./types"
 
 registerCoreMetadata()
@@ -41,6 +42,7 @@ type ValidationWorkerMessage =
       id: number
       kind: "init"
       context: ConfigurationContext
+      rulesSnapshot: ValidationRulesSnapshot
     }
   | {
       id: number
@@ -70,6 +72,7 @@ interface WorkerValidationState {
 
 let workerState = createEmptyWorkerValidationState()
 let workerSchemaCache: ValidationSchemaCache | undefined
+let workerRulesSnapshot: ValidationRulesSnapshot | undefined
 
 function createEmptyWorkerValidationState(): WorkerValidationState {
   return {
@@ -105,6 +108,7 @@ parentPort?.on("message", (message: ValidationWorkerMessage) => {
 
 function runInit(message: Extract<ValidationWorkerMessage, { kind: "init" }>): ValidationSchemaCacheCompileProfile {
   workerSchemaCache = createValidationSchemaCache(message.context)
+  workerRulesSnapshot = message.rulesSnapshot
   return workerSchemaCache.compileAll()
 }
 

--- a/packages/core/metadata/validation/projectValidationWorker.ts
+++ b/packages/core/metadata/validation/projectValidationWorker.ts
@@ -19,7 +19,6 @@ import {
   createProjectYamlCache,
   createProjectYamlCacheFromEntries,
   type ProjectYamlCache,
-  type ProjectYamlEntry,
 } from "./projectYamlCache"
 import {
   createValidationSchemaCache,
@@ -62,7 +61,6 @@ type ValidationWorkerMessage =
     }
 
 interface WorkerValidationState {
-  entries: Map<string, ProjectYamlEntry>
   states: Map<string, ProjectValidationFileState>
   objectIndexEntries: ProjectObjectIndexEntry[]
   memberIndexEntries: ProjectMemberIndexEntry[]
@@ -75,7 +73,6 @@ let workerSchemaCache: ValidationSchemaCache | undefined
 
 function createEmptyWorkerValidationState(): WorkerValidationState {
   return {
-    entries: new Map(),
     states: new Map(),
     objectIndexEntries: [],
     memberIndexEntries: [],
@@ -143,7 +140,6 @@ function runFirstPass(message: Extract<ValidationWorkerMessage, { kind: "firstPa
       continue
     }
 
-    workerState.entries.set(resolve(entry.filePath), entry)
     const cache = createProjectYamlCacheFromEntries([entry])
     const firstPassStartedAt = performance.now()
     const first = validateProjectFileFirstPass({
@@ -243,12 +239,15 @@ function runSecondPass(message: Extract<ValidationWorkerMessage, { kind: "second
     diagnostics.push(...second.diagnostics)
   }
 
+  const validationMs = performance.now() - validationStartedAt
+  workerState = createEmptyWorkerValidationState()
+
   return {
     diagnostics,
     timing: {
       contextMs: referenceStartedAt - contextStartedAt,
       referenceValidationMs: validationStartedAt - referenceStartedAt,
-      validationMs: performance.now() - validationStartedAt,
+      validationMs,
       fileCount: message.filePaths.length,
       referenceHits: referenceResult.stats.hits,
       referenceMisses: referenceResult.stats.misses,
@@ -443,22 +442,7 @@ function validationProfileKey(state: ProjectValidationFileState): string {
 }
 
 function createWorkerYamlCache(): ProjectYamlCache {
-  const local = createProjectYamlCacheFromEntries([...workerState.entries.values()])
-  const fallback = createProjectYamlCache()
-
-  return {
-    get(filePath) {
-      const entry = local.get(filePath)
-      if (!("error" in entry) || !entry.error.message.startsWith("YAML-файл отсутствует в validation snapshot")) {
-        return entry
-      }
-      return fallback.get(filePath)
-    },
-    release(filePath) {
-      local.release(filePath)
-      fallback.release(filePath)
-    },
-  }
+  return createProjectYamlCache()
 }
 
 function unrecognizedFileDiagnostic(filePath: string): Diagnostic {
@@ -480,7 +464,7 @@ export function workerStateStatsForTests(): {
 } {
   const states = [...workerState.states.values()]
   return {
-    retainedEntries: workerState.entries.size,
+    retainedEntries: 0,
     retainedStates: workerState.states.size,
     retainedPropertyModels: states.filter((state) => state.kind === "properties" && "model" in state).length,
     retainedFormStates: states.filter((state) => state.kind === "form" && "formState" in state).length,

--- a/packages/core/metadata/validation/projectValidationWorker.ts
+++ b/packages/core/metadata/validation/projectValidationWorker.ts
@@ -471,3 +471,18 @@ function unrecognizedFileDiagnostic(filePath: string): Diagnostic {
     message: "Не удалось распознать YAML-файл для validation",
   }
 }
+
+export function workerStateStatsForTests(): {
+  retainedEntries: number
+  retainedStates: number
+  retainedPropertyModels: number
+  retainedFormStates: number
+} {
+  const states = [...workerState.states.values()]
+  return {
+    retainedEntries: workerState.entries.size,
+    retainedStates: workerState.states.size,
+    retainedPropertyModels: states.filter((state) => state.kind === "properties" && "model" in state).length,
+    retainedFormStates: states.filter((state) => state.kind === "form" && "formState" in state).length,
+  }
+}

--- a/packages/core/metadata/validation/projectValidationWorker.ts
+++ b/packages/core/metadata/validation/projectValidationWorker.ts
@@ -2,7 +2,6 @@ import { performance } from "node:perf_hooks"
 import { parentPort } from "node:worker_threads"
 import { resolve } from "path"
 import type { ConfigurationContext } from "../context/types"
-import { registerCoreMetadata } from "../register"
 import { createOwnerMetadataCacheFromSharedValidationSnapshot } from "./dataPath/sharedOwnerCache"
 import { getProjectReferenceObjectPathContributor } from "./projectReferenceIndexRegistry"
 import type {
@@ -34,8 +33,9 @@ import {
 import type { ValidationMode, ValidationObjectRecord } from "./projectValidationTypes"
 import type { ValidationRulesSnapshot } from "./rulesSnapshot"
 import type { Diagnostic } from "./types"
+import { registerValidationMetadata } from "./registerValidationMetadata"
 
-registerCoreMetadata()
+registerValidationMetadata()
 
 type ValidationWorkerMessage =
   | {

--- a/packages/core/metadata/validation/projectValidationWorkerPool.test.ts
+++ b/packages/core/metadata/validation/projectValidationWorkerPool.test.ts
@@ -42,6 +42,25 @@ describe("ProjectValidationWorkerPool", () => {
     }
   }, 120_000)
 
+  it("reuses initialized worker schema caches on repeated start", async () => {
+    const pool = createProjectValidationWorkerPool({ concurrency: 1 })
+
+    try {
+      const first = await pool.start(context)
+      const second = await pool.start(context)
+
+      expect(first.reused).toBeUndefined()
+      expect(second).toMatchObject({
+        reused: true,
+        schemaCompileMs: first.schemaCompileMs,
+        formSchemaMs: first.formSchemaMs,
+        propertiesSchemaMs: first.propertiesSchemaMs,
+      })
+    } finally {
+      await pool.close()
+    }
+  }, 120_000)
+
   it("starts from plain tsx without legacy path aliases", async () => {
     const script = [
       'const { createProjectValidationWorkerPool } = await import("./metadata/validation/projectValidationWorkerPool.ts")',

--- a/packages/core/metadata/validation/projectValidationWorkerPool.test.ts
+++ b/packages/core/metadata/validation/projectValidationWorkerPool.test.ts
@@ -15,6 +15,17 @@ const context = {
 } as const
 
 describe("ProjectValidationWorkerPool", () => {
+  it("does not retain YAML entries or model state after worker validation", async () => {
+    const worker = await import("./projectValidationWorker")
+
+    expect(worker.workerStateStatsForTests()).toEqual({
+      retainedEntries: 0,
+      retainedStates: 0,
+      retainedPropertyModels: 0,
+      retainedFormStates: 0,
+    })
+  })
+
   it("starts and initializes worker schema caches", async () => {
     const pool = createProjectValidationWorkerPool({ concurrency: 1 })
 

--- a/packages/core/metadata/validation/projectValidationWorkerPool.ts
+++ b/packages/core/metadata/validation/projectValidationWorkerPool.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from "node:path"
 import { performance } from "node:perf_hooks"
-import { Worker } from "node:worker_threads"
 import { fileURLToPath, pathToFileURL } from "node:url"
+import Piscina from "piscina"
 import type { ConfigurationContext } from "../context/types"
 import {
   type PendingMetadataTargetReference,
@@ -16,6 +16,7 @@ import type { ValidationMode, ValidationObjectRecord, ValidationObjectTableSnaps
 import type { Diagnostic } from "./types"
 import { createValidationSnapshotProvider } from "./validationSnapshotProvider"
 import { createValidationRulesSnapshot, type ValidationRulesSnapshot } from "./rulesSnapshot"
+import type { ValidationWorkerTask, ValidationWorkerTaskResult } from "./projectValidationWorker"
 
 export interface FirstPassPoolParams {
   projectDir: string
@@ -49,6 +50,7 @@ export interface ProjectValidationWorkerPoolStartProfile {
   formSchemaMs: number
   propertiesSchemaMs: number
   rulesSnapshotBytes: number
+  reused?: boolean
 }
 
 interface WorkerSecondPassTiming {
@@ -131,70 +133,50 @@ type WorkerRequest =
       filePaths: string[]
     }
 
-type WorkerResponse =
-  | {
-      kind: "initResult"
-      formMs: number
-      propertiesMs: number
-      totalMs: number
-    }
-  | {
-      kind: "firstPassResult"
-      diagnostics: Diagnostic[]
-      objectRecords: ValidationObjectRecord[]
-      objectIndexEntries: ProjectObjectIndexEntry[]
-      memberIndexEntries: ProjectMemberIndexEntry[]
-      valueIndexEntries: ProjectValueIndexEntry[]
-      pendingReferences: PendingMetadataTargetReference[]
-      timing?: Omit<WorkerFirstPassTiming, "workerWallMs">
-      profile?: WorkerFirstPassProfile
-    }
-  | {
-      kind: "secondPassResult"
-      diagnostics: Diagnostic[]
-      timing?: WorkerSecondPassTiming
-      profile?: WorkerSecondPassProfile
-    }
-  | { kind: "error"; message: string }
-
 export function createProjectValidationWorkerPool(params: { concurrency: number }): ProjectValidationWorkerPool {
-  const workers: Worker[] = []
-  const assignedFilePaths = new Map<Worker, string[]>()
+  let pools: Piscina[] = []
+  let startProfile: ProjectValidationWorkerPoolStartProfile | undefined
+  const assignedFilePathsByPartition = new Map<number, string[]>()
 
   return {
     async start(context) {
-      while (workers.length < params.concurrency) workers.push(createWorker())
+      if (startProfile !== undefined) return { ...startProfile, reused: true }
+      while (pools.length < params.concurrency) pools.push(createWorkerPool())
       const rulesSnapshot = createValidationRulesSnapshot(context)
       const startedAt = performance.now()
       const results = await Promise.all(
-        workers.map(async (worker) => {
-          const response = await request(worker, { kind: "init", context, rulesSnapshot })
+        pools.map(async (pool) => {
+          const response = await request(pool, { kind: "init", context, rulesSnapshot })
           if (response.kind !== "initResult") throw new Error("Worker вернул неожиданный результат init")
           return response
         })
       )
 
-      return {
+      startProfile = {
         workerInitMs: performance.now() - startedAt,
         schemaCompileMs: results.reduce((sum, result) => sum + result.totalMs, 0),
         formSchemaMs: results.reduce((sum, result) => sum + result.formMs, 0),
         propertiesSchemaMs: results.reduce((sum, result) => sum + result.propertiesMs, 0),
         rulesSnapshotBytes: JSON.stringify(rulesSnapshot).length,
       }
+      return startProfile
     },
     async close() {
-      await Promise.all(workers.map((worker) => worker.terminate()))
+      await Promise.all(pools.map((pool) => pool.destroy()))
+      pools = []
+      startProfile = undefined
+      assignedFilePathsByPartition.clear()
     },
     size() {
-      return workers.length
+      return pools.length
     },
     async runFirstPass(firstPassParams) {
-      const partitions = partitionRoundRobin(firstPassParams.files, workers.length)
+      const partitions = partitionRoundRobin(firstPassParams.files, pools.length)
       const results = await Promise.all(
-        workers.map(async (worker, index) => {
+        pools.map(async (pool, index) => {
           const files = partitions[index] ?? []
           const filePaths = files.map((file) => file.absolutePath)
-          assignedFilePaths.set(worker, filePaths)
+          assignedFilePathsByPartition.set(index, filePaths)
           if (filePaths.length === 0) {
             return {
               index,
@@ -208,7 +190,7 @@ export function createProjectValidationWorkerPool(params: { concurrency: number 
           }
 
           const requestStartedAt = performance.now()
-          const response = await request(worker, {
+          const response = await request(pool, {
             kind: "firstPass",
             projectDir: firstPassParams.projectDir,
             context: firstPassParams.context,
@@ -244,14 +226,14 @@ export function createProjectValidationWorkerPool(params: { concurrency: number 
       const sharedValidationSnapshot = provider.sharedPayload()
       const snapshotMs = performance.now() - snapshotStartedAt
       const pendingReferences = secondPassParams.objectTable.pendingReferences ?? []
-      const referencePartitions = partitionPendingReferencesForWorkers(pendingReferences, workers.length)
+      const referencePartitions = partitionPendingReferencesForWorkers(pendingReferences, pools.length)
       const requestStartedAt = performance.now()
       const results = await Promise.all(
-        workers.map(async (worker, index) => {
-          const filePaths = assignedFilePaths.get(worker) ?? []
+        pools.map(async (pool, index) => {
+          const filePaths = assignedFilePathsByPartition.get(index) ?? []
           if (filePaths.length === 0) return { index, diagnostics: [] }
 
-          const response = await request(worker, {
+          const response = await request(pool, {
             kind: "secondPass",
             projectDir: secondPassParams.projectDir,
             context: secondPassParams.context,
@@ -557,14 +539,19 @@ export function partitionPendingReferencesForWorkers(
   return partitions
 }
 
-function createWorker(): Worker {
+function createWorkerPool(): Piscina {
   const currentFile = fileURLToPath(import.meta.url)
   const workerFile = currentFile.endsWith(".ts")
     ? join(dirname(currentFile), "projectValidationWorker.ts")
     : join(dirname(currentFile), "projectValidationWorker.js")
   const execArgv = workerFile.endsWith(".ts") ? withTypeScriptWorkerLoader(dirname(currentFile)) : process.execArgv
 
-  return new Worker(workerFile, { execArgv })
+  return new Piscina({
+    filename: workerFile,
+    minThreads: 1,
+    maxThreads: 1,
+    execArgv,
+  })
 }
 
 function withTypeScriptWorkerLoader(workerDir: string): string[] {
@@ -572,30 +559,8 @@ function withTypeScriptWorkerLoader(workerDir: string): string[] {
   return ["--import", "tsx", "--import", registerUrl]
 }
 
-let nextRequestId = 1
-
-function request(worker: Worker, message: WorkerRequest): Promise<WorkerResponse> {
-  const id = nextRequestId++
-  return new Promise((resolve, reject) => {
-    const onMessage = (response: WorkerResponse & { id?: number }) => {
-      if (response.id !== id) return
-      cleanup()
-      if (response.kind === "error") reject(new Error(response.message))
-      else resolve(response)
-    }
-    const onError = (error: Error) => {
-      cleanup()
-      reject(error)
-    }
-    const cleanup = () => {
-      worker.off("message", onMessage)
-      worker.off("error", onError)
-    }
-
-    worker.on("message", onMessage)
-    worker.on("error", onError)
-    worker.postMessage({ ...message, id })
-  })
+async function request(pool: Piscina, message: WorkerRequest): Promise<ValidationWorkerTaskResult> {
+  return (await pool.run(message satisfies ValidationWorkerTask)) as ValidationWorkerTaskResult
 }
 
 function partitionRoundRobin<T>(items: readonly T[], count: number): T[][] {

--- a/packages/core/metadata/validation/projectValidationWorkerPool.ts
+++ b/packages/core/metadata/validation/projectValidationWorkerPool.ts
@@ -15,6 +15,7 @@ import type { SharedValidationSnapshot } from "./sharedValidationSnapshot"
 import type { ValidationMode, ValidationObjectRecord, ValidationObjectTableSnapshot } from "./projectValidationTypes"
 import type { Diagnostic } from "./types"
 import { createValidationSnapshotProvider } from "./validationSnapshotProvider"
+import { createValidationRulesSnapshot, type ValidationRulesSnapshot } from "./rulesSnapshot"
 
 export interface FirstPassPoolParams {
   projectDir: string
@@ -47,6 +48,7 @@ export interface ProjectValidationWorkerPoolStartProfile {
   schemaCompileMs: number
   formSchemaMs: number
   propertiesSchemaMs: number
+  rulesSnapshotBytes: number
 }
 
 interface WorkerSecondPassTiming {
@@ -111,6 +113,7 @@ type WorkerRequest =
   | {
       kind: "init"
       context: ConfigurationContext
+      rulesSnapshot: ValidationRulesSnapshot
     }
   | {
       kind: "firstPass"
@@ -161,10 +164,11 @@ export function createProjectValidationWorkerPool(params: { concurrency: number 
   return {
     async start(context) {
       while (workers.length < params.concurrency) workers.push(createWorker())
+      const rulesSnapshot = createValidationRulesSnapshot(context)
       const startedAt = performance.now()
       const results = await Promise.all(
         workers.map(async (worker) => {
-          const response = await request(worker, { kind: "init", context })
+          const response = await request(worker, { kind: "init", context, rulesSnapshot })
           if (response.kind !== "initResult") throw new Error("Worker вернул неожиданный результат init")
           return response
         })
@@ -175,6 +179,7 @@ export function createProjectValidationWorkerPool(params: { concurrency: number 
         schemaCompileMs: results.reduce((sum, result) => sum + result.totalMs, 0),
         formSchemaMs: results.reduce((sum, result) => sum + result.formMs, 0),
         propertiesSchemaMs: results.reduce((sum, result) => sum + result.propertiesMs, 0),
+        rulesSnapshotBytes: JSON.stringify(rulesSnapshot).length,
       }
     },
     async close() {

--- a/packages/core/metadata/validation/registerValidationMetadata.ts
+++ b/packages/core/metadata/validation/registerValidationMetadata.ts
@@ -1,0 +1,9 @@
+import { registerCoreMetadata } from "../register"
+
+let registered = false
+
+export function registerValidationMetadata(): void {
+  if (registered) return
+  registered = true
+  registerCoreMetadata()
+}

--- a/packages/core/metadata/validation/rulesSnapshot.test.ts
+++ b/packages/core/metadata/validation/rulesSnapshot.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { mockContext } from "../../tests/mockContext"
+import { createValidationRulesSnapshot, findValidationRulesSpec } from "./rulesSnapshot"
+
+describe("ValidationRulesSnapshot", () => {
+  it("is JSON-compatible", () => {
+    const snapshot = createValidationRulesSnapshot(mockContext)
+
+    expect(structuredClone(snapshot)).toEqual(snapshot)
+    expect(JSON.parse(JSON.stringify(snapshot))).toEqual(snapshot)
+  })
+
+  it("includes catalog properties descriptor", () => {
+    const snapshot = createValidationRulesSnapshot(mockContext)
+    const catalog = findValidationRulesSpec(snapshot, "Справочник")
+
+    expect(catalog).toMatchObject({
+      dir: "Справочник",
+      itemType: "MetadataCatalog",
+      root: "Catalog",
+      properties: expect.arrayContaining([
+        expect.objectContaining({
+          modelKey: "attributes",
+          yamlPath: ["Реквизиты"],
+        }),
+      ]),
+    })
+  })
+
+  it("includes metadata target descriptors", () => {
+    const snapshot = createValidationRulesSnapshot(mockContext)
+    const catalog = findValidationRulesSpec(snapshot, "Справочник")
+
+    expect(catalog?.properties).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          modelKey: "defaultObjectForm",
+          yamlPath: ["ОсновнаяФормаОбъекта"],
+          metadataTarget: expect.objectContaining({ kind: "member" }),
+        }),
+      ])
+    )
+  })
+})

--- a/packages/core/metadata/validation/rulesSnapshot.ts
+++ b/packages/core/metadata/validation/rulesSnapshot.ts
@@ -22,8 +22,14 @@ export interface ValidationRulesSpecSnapshot {
   itemType: string
   root?: MetadataRootName
   metadataTargetOwner?: MetadataTargetOwnerDeclaration
+  nesting?: ValidationRulesNestingSnapshot
   uniqueNameScopes: readonly ValidationRulesUniqueNameScopeSnapshot[]
   properties: readonly ValidationRulesPropertySnapshot[]
+}
+
+export interface ValidationRulesNestingSnapshot {
+  kind: "recursiveChildDir"
+  childDir: string
 }
 
 export interface ValidationRulesUniqueNameScopeSnapshot {
@@ -67,6 +73,7 @@ function snapshotSpec(spec: ValidationProjectSpec): ValidationRulesSpecSnapshot 
     itemType: rule.itemType,
     ...(rootFromYAML[spec.dir] === undefined ? {} : { root: rootFromYAML[spec.dir] }),
     ...(rule.metadataTargetOwner === undefined ? {} : { metadataTargetOwner: rule.metadataTargetOwner }),
+    ...(spec.nesting === undefined ? {} : { nesting: { kind: spec.nesting.kind, childDir: spec.nesting.childDir } }),
     uniqueNameScopes: (rule.uniqueNameScopes ?? []).map((scope) => ({ collections: [...scope.collections] })),
     properties: snapshotProperties(rule.properties),
   }

--- a/packages/core/metadata/validation/rulesSnapshot.ts
+++ b/packages/core/metadata/validation/rulesSnapshot.ts
@@ -1,0 +1,88 @@
+import { rootFromYAML } from "../commonObjects/metadataTargets/roots"
+import type {
+  MetadataRootName,
+  MetadataTargetConstraint,
+} from "../commonObjects/metadataTargets/types"
+import type { ConfigurationContext } from "../context/types"
+import type { MetadataTargetOwnerDeclaration } from "../orchestration/property/types"
+import {
+  configurationValidationProjectSpec,
+  validationProjectSpecs,
+  type ValidationProjectSpec,
+} from "./projectSpecs"
+
+export interface ValidationRulesSnapshot {
+  version: 1
+  specs: ValidationRulesSpecSnapshot[]
+}
+
+export interface ValidationRulesSpecSnapshot {
+  dir: string
+  kind: ValidationProjectSpec["kind"]
+  itemType: string
+  root?: MetadataRootName
+  metadataTargetOwner?: MetadataTargetOwnerDeclaration
+  uniqueNameScopes: readonly ValidationRulesUniqueNameScopeSnapshot[]
+  properties: readonly ValidationRulesPropertySnapshot[]
+}
+
+export interface ValidationRulesUniqueNameScopeSnapshot {
+  collections: readonly string[]
+}
+
+export interface ValidationRulesPropertySnapshot {
+  modelKey: string
+  yamlPath: readonly string[]
+  type?: string
+  metadataTarget?: MetadataTargetConstraint
+}
+
+interface SnapshotSourceProperty {
+  yaml?: string | false
+  type?: string
+  metadataTarget?: MetadataTargetConstraint
+  yamlInline?: true
+}
+
+export function createValidationRulesSnapshot(_context: ConfigurationContext): ValidationRulesSnapshot {
+  return {
+    version: 1,
+    specs: [configurationValidationProjectSpec, ...validationProjectSpecs].map(snapshotSpec),
+  }
+}
+
+export function findValidationRulesSpec(
+  snapshot: ValidationRulesSnapshot,
+  dir: string
+): ValidationRulesSpecSnapshot | undefined {
+  return snapshot.specs.find((spec) => spec.dir === dir)
+}
+
+function snapshotSpec(spec: ValidationProjectSpec): ValidationRulesSpecSnapshot {
+  const rule = spec.rule
+
+  return {
+    dir: spec.dir,
+    kind: spec.kind,
+    itemType: rule.itemType,
+    ...(rootFromYAML[spec.dir] === undefined ? {} : { root: rootFromYAML[spec.dir] }),
+    ...(rule.metadataTargetOwner === undefined ? {} : { metadataTargetOwner: rule.metadataTargetOwner }),
+    uniqueNameScopes: (rule.uniqueNameScopes ?? []).map((scope) => ({ collections: [...scope.collections] })),
+    properties: snapshotProperties(rule.properties),
+  }
+}
+
+function snapshotProperties(properties: ValidationProjectSpec["rule"]["properties"]): ValidationRulesPropertySnapshot[] {
+  return Object.entries(properties as Readonly<Record<string, SnapshotSourceProperty>>).flatMap(([modelKey, property]) => {
+    if (property.yaml === false || property.yaml === undefined) return []
+
+    return [
+      {
+        modelKey,
+        yamlPath: [property.yaml],
+        ...(property.type === undefined ? {} : { type: property.type }),
+        ...(property.metadataTarget === undefined ? {} : { metadataTarget: property.metadataTarget }),
+      },
+    ]
+  })
+}

--- a/packages/core/metadata/validation/rulesSnapshot.ts
+++ b/packages/core/metadata/validation/rulesSnapshot.ts
@@ -5,6 +5,7 @@ import type {
 } from "../commonObjects/metadataTargets/types"
 import type { ConfigurationContext } from "../context/types"
 import type { MetadataTargetOwnerDeclaration } from "../orchestration/property/types"
+import { getTypeRule } from "../orchestration/property/typeRuleRegistry"
 import {
   configurationValidationProjectSpec,
   validationProjectSpecs,
@@ -41,6 +42,7 @@ export interface ValidationRulesPropertySnapshot {
   yamlPath: readonly string[]
   type?: string
   metadataTarget?: MetadataTargetConstraint
+  children?: readonly ValidationRulesPropertySnapshot[]
 }
 
 interface SnapshotSourceProperty {
@@ -48,6 +50,7 @@ interface SnapshotSourceProperty {
   type?: string
   metadataTarget?: MetadataTargetConstraint
   yamlInline?: true
+  itemRule?: ValidationProjectSpec["rule"]
 }
 
 export function createValidationRulesSnapshot(_context: ConfigurationContext): ValidationRulesSnapshot {
@@ -89,7 +92,26 @@ function snapshotProperties(properties: ValidationProjectSpec["rule"]["propertie
         yamlPath: [property.yaml],
         ...(property.type === undefined ? {} : { type: property.type }),
         ...(property.metadataTarget === undefined ? {} : { metadataTarget: property.metadataTarget }),
+        ...childrenSnapshot(property),
       },
     ]
   })
+}
+
+function childrenSnapshot(property: SnapshotSourceProperty): { children?: readonly ValidationRulesPropertySnapshot[] } {
+  const itemRule = nestedItemRule(property)
+  return itemRule === undefined ? {} : { children: snapshotProperties(itemRule.properties) }
+}
+
+function nestedItemRule(property: SnapshotSourceProperty): ValidationProjectSpec["rule"] | undefined {
+  if (property.type !== undefined) {
+    const collectionItemRule = getTypeRule(property.type, "collectionItemRule")
+    if (collectionItemRule?.itemRule) return collectionItemRule.itemRule
+  }
+
+  if ("itemRule" in property && property.itemRule !== undefined) {
+    return property.itemRule as ValidationProjectSpec["rule"]
+  }
+
+  return undefined
 }

--- a/packages/core/metadata/validation/sharedValidationBinaryOwners.test.ts
+++ b/packages/core/metadata/validation/sharedValidationBinaryOwners.test.ts
@@ -48,9 +48,10 @@ describe("SharedValidationBinaryOwners", () => {
           kind: "properties",
           owner: { dir: "Константа", name: "ИспользоватьСинхронизациюДанных" },
           ownerRef: { kind: "Константа", name: "ИспользоватьСинхронизациюДанных" },
-          model: {
-            itemType: "MetadataConstant",
-            name: "ИспользоватьСинхронизациюДанных",
+          ownerFacts: {
+            ref: { kind: "Константа", name: "ИспользоватьСинхронизациюДанных" },
+            filePath: "/project/Константа/ИспользоватьСинхронизациюДанных/Свойства.yaml",
+            fieldIndex: { fields: new Map(), standardAttributeAliases: new Map(), diagnostics: [] },
             type: { type: ["boolean"] },
           },
           fieldIndex: { fields: new Map(), standardAttributeAliases: new Map(), diagnostics: [] },
@@ -80,7 +81,6 @@ describe("SharedValidationBinaryOwners", () => {
             filePath: record.filePath,
             fieldIndex: record.fieldIndex!,
           },
-          model: undefined,
           fieldIndex: undefined,
         },
       ],
@@ -104,7 +104,6 @@ function catalogRecord(): ValidationObjectRecord {
     kind: "properties",
     owner: { dir: "Справочник", name: "Номенклатура" },
     ownerRef: { kind: "Справочник", name: "Номенклатура" },
-    model: { itemType: "MetadataCatalog", name: "Номенклатура" },
     fieldIndex: {
       fields: new Map([
         [

--- a/packages/core/metadata/validation/sharedValidationBinaryOwners.test.ts
+++ b/packages/core/metadata/validation/sharedValidationBinaryOwners.test.ts
@@ -68,6 +68,33 @@ describe("SharedValidationBinaryOwners", () => {
     if (owner.status !== "ok") throw new Error("owner expected")
     expect(owner.owner.model).toMatchObject({ type: { type: ["boolean"] } })
   })
+
+  it("restores compact owner facts without model payload", () => {
+    const record = catalogRecord()
+    const table = createValidationObjectTable({
+      records: [
+        {
+          ...record,
+          ownerFacts: {
+            ref: { kind: "Справочник", name: "Номенклатура" },
+            filePath: record.filePath,
+            fieldIndex: record.fieldIndex!,
+          },
+          model: undefined,
+          fieldIndex: undefined,
+        },
+      ],
+      filePaths: [record.filePath],
+    })
+    const snapshot = createBinarySharedOwnersSnapshot(table.snapshot())
+    const binary = createOwnerMetadataCacheFromBinarySharedOwners({ projectDir: "/project", snapshot })
+
+    const owner = binary.get({ kind: "Справочник", name: "Номенклатура" })
+
+    expect(owner.status).toBe("ok")
+    if (owner.status !== "ok") throw new Error("owner expected")
+    expect([...owner.owner.fieldIndex.fields.keys()]).toEqual(["Артикул", "Товары"])
+  })
 })
 
 function catalogRecord(): ValidationObjectRecord {

--- a/packages/core/metadata/validation/sharedValidationBinaryOwners.ts
+++ b/packages/core/metadata/validation/sharedValidationBinaryOwners.ts
@@ -1,6 +1,7 @@
 import { resolve } from "path"
 import { getDataPathOwnerKind } from "./dataPath/registry"
 import type { OwnerMetadataCache, OwnerMetadataResult } from "./dataPath/ownerCache"
+import { modelStubFromOwnerFacts } from "./dataPath/ownerFacts"
 import type { ObjectField, ObjectFieldIndex, ObjectFieldTableSource } from "./dataPath/objectFields"
 import type { DataPathTableInfo, DataPathTypeInfo, DataPathValueKind, OwnerTypeRef } from "./dataPath/types"
 import type { ValidationObjectRecord, ValidationObjectTableSnapshot } from "./projectValidationTypes"
@@ -306,11 +307,13 @@ function createBinaryOwnersView(snapshot: BinarySharedOwnersSnapshot) {
 }
 
 function encodeOwner(record: ValidationObjectRecord): EncodedOwner {
-  const fieldIndex = record.fieldIndex
+  const facts = record.ownerFacts
+  const fieldIndex = facts?.fieldIndex ?? record.fieldIndex
+  const model = record.model ?? (facts === undefined ? undefined : modelStubFromOwnerFacts(facts))
   return {
-    ref: record.ownerRef as OwnerTypeRef,
-    filePath: record.filePath,
-    ...(record.model === undefined ? {} : { modelText: JSON.stringify(record.model) }),
+    ref: (facts?.ref ?? record.ownerRef) as OwnerTypeRef,
+    filePath: facts?.filePath ?? record.filePath,
+    ...(model === undefined ? {} : { modelText: JSON.stringify(model) }),
     status: record.importDiagnostics.length > 0 ? STATUS_IMPORT_ERROR : STATUS_OK,
     diagnostics: record.importDiagnostics,
     fields: fieldIndex === undefined ? [] : [...fieldIndex.fields.values()].map(encodeField),

--- a/packages/core/metadata/validation/sharedValidationBinaryOwners.ts
+++ b/packages/core/metadata/validation/sharedValidationBinaryOwners.ts
@@ -309,7 +309,7 @@ function createBinaryOwnersView(snapshot: BinarySharedOwnersSnapshot) {
 function encodeOwner(record: ValidationObjectRecord): EncodedOwner {
   const facts = record.ownerFacts
   const fieldIndex = facts?.fieldIndex ?? record.fieldIndex
-  const model = record.model ?? (facts === undefined ? undefined : modelStubFromOwnerFacts(facts))
+  const model = facts === undefined ? {} : modelStubFromOwnerFacts(facts)
   return {
     ref: (facts?.ref ?? record.ownerRef) as OwnerTypeRef,
     filePath: facts?.filePath ?? record.filePath,

--- a/packages/core/metadata/validation/sharedValidationSnapshot.test.ts
+++ b/packages/core/metadata/validation/sharedValidationSnapshot.test.ts
@@ -47,7 +47,6 @@ function catalogRecord(): ValidationObjectRecord {
     kind: "properties",
     owner: { dir: "Справочник", name: "Номенклатура" },
     ownerRef: { kind: "Справочник", name: "Номенклатура" },
-    model: { itemType: "MetadataCatalog", name: "Номенклатура" },
     fieldIndex: {
       fields: new Map([
         [

--- a/packages/core/metadata/validation/validateProject.test.ts
+++ b/packages/core/metadata/validation/validateProject.test.ts
@@ -9,7 +9,7 @@ import {
   getProjectValidationReadCountForTests,
   resetProjectValidationReadCountForTests,
 } from "./projectValidationPasses"
-import { validateProject } from "./validateProject"
+import { createValidationWorkerPoolHandle, validateProject } from "./validateProject"
 
 describe("validateProject", { timeout: 30_000 }, () => {
   const tempDirs: string[] = []
@@ -234,6 +234,25 @@ describe("validateProject", { timeout: 30_000 }, () => {
     const parallel = await validateProject({ projectDir, context: mockContext, concurrency: 2 })
 
     expect(parallel.diagnostics).toEqual(sequential.diagnostics)
+  })
+
+  it("reusable worker pool handle validates projects repeatedly", async () => {
+    const projectDir = createProject()
+    writeProjectFile(projectDir, "Справочник/Товары/Свойства.yaml", "Комментарий: ok")
+
+    const oneShot = await validateProject({ projectDir, context: mockContext, concurrency: 2 })
+    const handle = createValidationWorkerPoolHandle({ concurrency: 2 })
+
+    try {
+      const first = await handle.validateProject({ projectDir, context: mockContext })
+      const second = await handle.validateProject({ projectDir, context: mockContext })
+
+      expect(handle.size()).toBe(0)
+      expect(first).toEqual(oneShot)
+      expect(second).toEqual(oneShot)
+    } finally {
+      await handle.close()
+    }
   })
 
   it("parallel validation keeps subsystem files with duplicate local names", async () => {

--- a/packages/core/metadata/validation/validateProject.ts
+++ b/packages/core/metadata/validation/validateProject.ts
@@ -313,7 +313,7 @@ function processPendingFirstPasses(params: {
         cache,
         context: params.context,
         schemaCache: params.schemaCache,
-        rulesSnapshot: params.rulesSnapshot,
+        ...(file.kind === "form" ? { rulesSnapshot: params.rulesSnapshot } : {}),
       })
       params.states.set(resolve(file.absolutePath), first.state)
       params.objectTable.mergeRecords(first.objectRecords)

--- a/packages/core/metadata/validation/validateProject.ts
+++ b/packages/core/metadata/validation/validateProject.ts
@@ -24,6 +24,7 @@ import {
 } from "./projectValidationPasses"
 import { createValidationYamlQueue } from "./projectValidationQueue"
 import { createValidationSnapshotProvider } from "./validationSnapshotProvider"
+import { createValidationRulesSnapshot, type ValidationRulesSnapshot } from "./rulesSnapshot"
 import type { Diagnostic } from "./types"
 
 export interface ValidateProjectParams {
@@ -53,6 +54,7 @@ function validateProjectInProcess(params: ValidateProjectParams): ValidateProjec
   const projectDir = resolve(params.projectDir)
   const context = params.context ?? defaultValidationContext()
   const schemaCache = createValidationSchemaCache(context)
+  const rulesSnapshot = createValidationRulesSnapshot(context)
   const files =
     params.filePath === undefined
       ? discoverValidationProjectFiles(projectDir)
@@ -66,7 +68,17 @@ function validateProjectInProcess(params: ValidateProjectParams): ValidateProjec
   const states = new Map<string, ProjectValidationFileState>()
 
   const diagnostics: Diagnostic[] = []
-  processPendingFirstPasses({ projectDir, context, schemaCache, queue, entries, states, objectTable, diagnostics })
+  processPendingFirstPasses({
+    projectDir,
+    context,
+    schemaCache,
+    rulesSnapshot,
+    queue,
+    entries,
+    states,
+    objectTable,
+    diagnostics,
+  })
   const skipMetadataTargetValidation = params.filePath === undefined
 
   if (skipMetadataTargetValidation) {
@@ -132,7 +144,17 @@ function validateProjectInProcess(params: ValidateProjectParams): ValidateProjec
     }
 
     if (enqueuedDependency) {
-      processPendingFirstPasses({ projectDir, context, schemaCache, queue, entries, states, objectTable, diagnostics })
+      processPendingFirstPasses({
+        projectDir,
+        context,
+        schemaCache,
+        rulesSnapshot,
+        queue,
+        entries,
+        states,
+        objectTable,
+        diagnostics,
+      })
       for (const stateKey of states.keys()) secondPassPending.add(stateKey)
     }
   }
@@ -264,6 +286,7 @@ function processPendingFirstPasses(params: {
   projectDir: string
   context: ConfigurationContext
   schemaCache: ReturnType<typeof createValidationSchemaCache>
+  rulesSnapshot: ValidationRulesSnapshot
   queue: ReturnType<typeof createValidationYamlQueue>
   entries: Map<string, ProjectYamlEntry>
   states: Map<string, ProjectValidationFileState>
@@ -290,6 +313,7 @@ function processPendingFirstPasses(params: {
         cache,
         context: params.context,
         schemaCache: params.schemaCache,
+        rulesSnapshot: params.rulesSnapshot,
       })
       params.states.set(resolve(file.absolutePath), first.state)
       params.objectTable.mergeRecords(first.objectRecords)

--- a/packages/core/metadata/validation/validateProject.ts
+++ b/packages/core/metadata/validation/validateProject.ts
@@ -13,7 +13,7 @@ import {
 } from "./projectFiles"
 import { createProjectYamlCacheFromEntries, type ProjectYamlEntry } from "./projectYamlCache"
 import { createValidationObjectTable } from "./projectValidationObjectTable"
-import { createProjectValidationWorkerPool } from "./projectValidationWorkerPool"
+import { createProjectValidationWorkerPool, type ProjectValidationWorkerPool } from "./projectValidationWorkerPool"
 import {
   createValidationSchemaCache,
   readProjectYamlDiagnostic,
@@ -38,6 +38,12 @@ export interface ValidateProjectResult {
   diagnostics: Diagnostic[]
 }
 
+export interface ValidationWorkerPoolHandle {
+  validateProject(params: Omit<ValidateProjectParams, "concurrency">): Promise<ValidateProjectResult>
+  close(): Promise<void>
+  size(): number
+}
+
 const expectedPatterns =
   "Ожидались Конфигурация.yaml или пути вида <Вид>/<Имя>/Свойства.yaml и <Вид>/<Имя>/Формы/<Форма>/Форма.yaml"
 const MIN_FILES_FOR_WORKER_VALIDATION = 128
@@ -48,6 +54,53 @@ export async function validateProject(params: ValidateProjectParams): Promise<Va
     return validateProjectInProcess({ ...params, concurrency: 1 })
   }
   return validateProjectWithWorkers({ ...params, concurrency })
+}
+
+export function createValidationWorkerPoolHandle(params: { concurrency?: number } = {}): ValidationWorkerPoolHandle {
+  const concurrency = normalizeValidationConcurrency(params.concurrency)
+  const pool = createProjectValidationWorkerPool({ concurrency })
+  let closed = false
+  let currentRun: Promise<void> = Promise.resolve()
+
+  async function runExclusive<T>(task: () => Promise<T>): Promise<T> {
+    const previous = currentRun
+    let release: () => void = () => undefined
+    currentRun = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous
+    try {
+      return await task()
+    } finally {
+      release()
+    }
+  }
+
+  return {
+    validateProject(projectParams) {
+      if (closed) throw new Error("Validation worker pool handle is closed")
+      return runExclusive(async () => {
+        if (projectParams.filePath !== undefined || concurrency === 1) {
+          return validateProjectInProcess({ ...projectParams, concurrency: 1 })
+        }
+        return validateProjectWithWorkers({
+          ...projectParams,
+          concurrency,
+          pool,
+          closePool: false,
+        })
+      })
+    },
+    async close() {
+      if (closed) return
+      closed = true
+      await currentRun
+      await pool.close()
+    },
+    size() {
+      return pool.size()
+    },
+  }
 }
 
 function validateProjectInProcess(params: ValidateProjectParams): ValidateProjectResult {
@@ -163,7 +216,11 @@ function validateProjectInProcess(params: ValidateProjectParams): ValidateProjec
 }
 
 async function validateProjectWithWorkers(
-  params: ValidateProjectParams & { concurrency: number }
+  params: ValidateProjectParams & {
+    concurrency: number
+    pool?: ProjectValidationWorkerPool
+    closePool?: boolean
+  }
 ): Promise<ValidateProjectResult> {
   const totalStartedAt = performance.now()
   const projectDir = resolve(params.projectDir)
@@ -175,7 +232,8 @@ async function validateProjectWithWorkers(
     return validateProjectInProcess({ ...params, concurrency: 1 })
   }
 
-  const pool = createProjectValidationWorkerPool({ concurrency: params.concurrency })
+  const pool = params.pool ?? createProjectValidationWorkerPool({ concurrency: params.concurrency })
+  const closePool = params.closePool ?? true
   let startMs = 0
   let schemaCompileMs = 0
   let formSchemaMs = 0
@@ -233,7 +291,7 @@ async function validateProjectWithWorkers(
 
     return { diagnostics }
   } finally {
-    await pool.close()
+    if (closePool) await pool.close()
   }
 }
 

--- a/packages/core/metadata/validation/validationSnapshotProvider.test.ts
+++ b/packages/core/metadata/validation/validationSnapshotProvider.test.ts
@@ -81,7 +81,6 @@ function catalogRecord(): ValidationObjectRecord {
     kind: "properties",
     owner: { dir: "Справочник", name: "Номенклатура" },
     ownerRef: { kind: "Справочник", name: "Номенклатура" },
-    model: { itemType: "MetadataCatalog", name: "Номенклатура" },
     fieldIndex: {
       fields: new Map([
         [

--- a/packages/core/metadata/validation/yamlFactExtractor.test.ts
+++ b/packages/core/metadata/validation/yamlFactExtractor.test.ts
@@ -17,7 +17,7 @@ describe("extractValidationYamlFacts", () => {
 
     const facts = extractValidationYamlFacts({
       file,
-      data: parsed.data,
+      parsed,
       rulesSnapshot: createValidationRulesSnapshot(mockContext),
     })
 
@@ -37,7 +37,7 @@ describe("extractValidationYamlFacts", () => {
 
     const facts = extractValidationYamlFacts({
       file,
-      data: {},
+      parsed: parseMetadataYaml("{}\n"),
       rulesSnapshot: createValidationRulesSnapshot(mockContext),
     })
 

--- a/packages/core/metadata/validation/yamlFactExtractor.test.ts
+++ b/packages/core/metadata/validation/yamlFactExtractor.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "fs"
+import { join } from "path"
+import { describe, expect, it } from "vitest"
+import { mockContext } from "../../tests/mockContext"
+import { parseMetadataYaml } from "../../yaml/parseMetadataYaml"
+import { resolveValidationProjectFile } from "./projectFiles"
+import { createValidationRulesSnapshot } from "./rulesSnapshot"
+import { extractValidationYamlFacts } from "./yamlFactExtractor"
+
+describe("extractValidationYamlFacts", () => {
+  it("extracts object index entries from properties YAML without model import", () => {
+    const projectDir = join(__dirname, "__fixtures__/project-with-form")
+    const filePath = join(projectDir, "Справочник/СправочникСФормой/Свойства.yaml")
+    const file = resolveValidationProjectFile(projectDir, filePath)
+    if (file === undefined) throw new Error("file not resolved")
+    const parsed = parseMetadataYaml(readFileSync(filePath, "utf8"))
+
+    const facts = extractValidationYamlFacts({
+      file,
+      data: parsed.data,
+      rulesSnapshot: createValidationRulesSnapshot(mockContext),
+    })
+
+    expect(facts.objectIndexEntries).toEqual([
+      expect.objectContaining({
+        canonical: "Catalog.СправочникСФормой",
+        result: expect.objectContaining({ ok: true, filePath }),
+      }),
+    ])
+  })
+
+  it("extracts object index entries for nested recursive objects", () => {
+    const projectDir = "/project"
+    const filePath = "/project/Подсистема/Администрирование/Подсистемы/Настройки/Свойства.yaml"
+    const file = resolveValidationProjectFile(projectDir, filePath)
+    if (file === undefined) throw new Error("file not resolved")
+
+    const facts = extractValidationYamlFacts({
+      file,
+      data: {},
+      rulesSnapshot: createValidationRulesSnapshot(mockContext),
+    })
+
+    expect(facts.objectIndexEntries).toEqual([
+      expect.objectContaining({
+        canonical: "Subsystem.Администрирование.Subsystem.Настройки",
+      }),
+    ])
+  })
+})

--- a/packages/core/metadata/validation/yamlFactExtractor.ts
+++ b/packages/core/metadata/validation/yamlFactExtractor.ts
@@ -1,30 +1,60 @@
-import type { ParsedMetadataTarget } from "../commonObjects/metadataTargets/types"
+import { parseMetadataTargetFromYAML } from "../commonObjects/metadataTargets"
+import type { MetadataTargetOwner, ParsedMetadataTarget } from "../commonObjects/metadataTargets/types"
+import { getTypeFromYAML } from "../commonObjects/typeDescription/helper"
+import type { TypeDescription } from "../commonObjects/typeDescription/types"
+import { CollectableElementTypeFromYAML, type ElementType } from "../forms/elements/orchestration/types"
+import type { DataPathPropertyRule, PropertyRule } from "../orchestration/property/types"
+import { getElementRule } from "../orchestration/formElement/ruleFactory"
+import type { ParsedYaml } from "../../yaml/parseMetadataYaml"
+import { typeDescriptionToDataPathTypeInfo } from "./dataPath/typeDescription"
+import type { FormDataPathIndex } from "./dataPath/formIndex"
+import type { FormDataPathSource, FormDataPathColumnSource } from "./dataPath/types"
 import {
+  projectMemberIndexKey,
   projectObjectIndexKey,
+  projectValueIndexKey,
+  type PendingMetadataTargetReference,
   type ProjectMemberIndexEntry,
   type ProjectObjectIndexEntry,
   type ProjectValueIndexEntry,
 } from "./projectReferenceIndex"
 import type { ValidationProjectFile } from "./projectFiles"
+import type { ValidationPendingCheck } from "./projectValidationPendingChecks"
 import { findValidationRulesSpec, type ValidationRulesSnapshot, type ValidationRulesSpecSnapshot } from "./rulesSnapshot"
+import { diagnosticAtYamlPath } from "./yamlLocations"
+import type { Diagnostic } from "./types"
 
 export interface ValidationYamlFacts {
   objectIndexEntries: ProjectObjectIndexEntry[]
   memberIndexEntries: ProjectMemberIndexEntry[]
   valueIndexEntries: ProjectValueIndexEntry[]
+  pendingReferences: PendingMetadataTargetReference[]
+  pendingChecks: ValidationPendingCheck[]
+  diagnostics: Diagnostic[]
 }
 
 export function extractValidationYamlFacts(params: {
   file: ValidationProjectFile
-  data: unknown
+  parsed: ParsedYaml
   rulesSnapshot: ValidationRulesSnapshot
 }): ValidationYamlFacts {
   if (params.file.kind === "form") {
-    return emptyFacts()
+    return extractFormYamlFacts(params.file, params.parsed)
   }
 
   const spec = findValidationRulesSpec(params.rulesSnapshot, params.file.owner.dir)
   const objectTarget = spec === undefined ? undefined : objectTargetForProjectFile(params.file, spec)
+  const owner = objectTarget === undefined ? undefined : { root: objectTarget.root, objectName: objectTarget.objectName }
+  const pendingReferences =
+    spec === undefined
+      ? []
+      : collectPendingReferences({
+          filePath: params.file.absolutePath,
+          owner,
+          value: params.parsed.data,
+          properties: spec.properties,
+          yamlPath: [],
+        })
   return {
     objectIndexEntries:
       objectTarget === undefined
@@ -36,12 +66,15 @@ export function extractValidationYamlFacts(params: {
               result: {
                 ok: true,
                 filePath: params.file.absolutePath,
-                details: objectIndexDetails(params.data),
+                details: objectIndexDetails(params.parsed.data),
               },
             },
           ],
     memberIndexEntries: [],
     valueIndexEntries: [],
+    pendingReferences,
+    pendingChecks: [],
+    diagnostics: [],
   }
 }
 
@@ -90,5 +123,368 @@ function metadataRecord(value: unknown): Record<string, unknown> {
 }
 
 function emptyFacts(): ValidationYamlFacts {
-  return { objectIndexEntries: [], memberIndexEntries: [], valueIndexEntries: [] }
+  return {
+    objectIndexEntries: [],
+    memberIndexEntries: [],
+    valueIndexEntries: [],
+    pendingReferences: [],
+    pendingChecks: [],
+    diagnostics: [],
+  }
+}
+
+function collectPendingReferences(params: {
+  filePath: string
+  owner: MetadataTargetOwner | undefined
+  value: unknown
+  properties: readonly ValidationRulesSpecSnapshot["properties"][number][]
+  yamlPath: readonly (string | number)[]
+}): PendingMetadataTargetReference[] {
+  const record = asRecord(params.value)
+  if (record === undefined) return []
+
+  const references: PendingMetadataTargetReference[] = []
+  for (const property of params.properties) {
+    const value = valueAtPath(record, property.yamlPath)
+    if (value === undefined) continue
+
+    if (property.metadataTarget !== undefined) {
+      references.push(
+        ...collectTargetValues({
+          filePath: params.filePath,
+          owner: params.owner,
+          value,
+          constraint: property.metadataTarget,
+          yamlPath: [...params.yamlPath, ...property.yamlPath],
+        })
+      )
+    }
+
+    if (property.children !== undefined) {
+      references.push(
+        ...collectNestedReferences({
+          filePath: params.filePath,
+          owner: params.owner,
+          value,
+          properties: property.children,
+          yamlPath: [...params.yamlPath, ...property.yamlPath],
+        })
+      )
+    }
+  }
+
+  return references
+}
+
+function collectNestedReferences(params: {
+  filePath: string
+  owner: MetadataTargetOwner | undefined
+  value: unknown
+  properties: readonly ValidationRulesSpecSnapshot["properties"][number][]
+  yamlPath: readonly (string | number)[]
+}): PendingMetadataTargetReference[] {
+  if (Array.isArray(params.value)) {
+    return params.value.flatMap((item, index) =>
+      collectPendingReferences({ ...params, value: item, yamlPath: [...params.yamlPath, index] })
+    )
+  }
+
+  const record = asRecord(params.value)
+  if (record === undefined) return []
+
+  return Object.entries(record).flatMap(([key, item]) =>
+    collectPendingReferences({ ...params, value: item, yamlPath: [...params.yamlPath, key] })
+  )
+}
+
+function collectTargetValues(params: {
+  filePath: string
+  owner: MetadataTargetOwner | undefined
+  value: unknown
+  constraint: PendingMetadataTargetReference["constraint"]
+  yamlPath: readonly (string | number)[]
+}): PendingMetadataTargetReference[] {
+  if (typeof params.value === "string") {
+    const reference = pendingReferenceFromYamlValue({ ...params, value: params.value, yamlPath: params.yamlPath })
+    return reference === undefined ? [] : [reference]
+  }
+
+  if (Array.isArray(params.value)) {
+    return params.value.flatMap((item, index) =>
+      collectTargetValues({ ...params, value: item, yamlPath: [...params.yamlPath, index] })
+    )
+  }
+
+  return []
+}
+
+function pendingReferenceFromYamlValue(params: {
+  filePath: string
+  owner: MetadataTargetOwner | undefined
+  value: string
+  constraint: PendingMetadataTargetReference["constraint"]
+  yamlPath: readonly (string | number)[]
+}): PendingMetadataTargetReference | undefined {
+  const parsed = parseMetadataTargetFromYAML({
+    value: params.value,
+    constraint: params.constraint,
+    owner: params.owner,
+  })
+  if (!parsed.ok) return undefined
+
+  return {
+    filePath: params.filePath,
+    yamlPath: [...params.yamlPath],
+    canonical: targetKey(parsed.target),
+    target: parsed.target,
+    constraint: params.constraint,
+  }
+}
+
+function targetKey(target: ParsedMetadataTarget): string {
+  if (target.kind === "object") return projectObjectIndexKey(target)
+  if (target.kind === "member") return projectMemberIndexKey(target)
+  return projectValueIndexKey(target)
+}
+
+function extractFormYamlFacts(file: ValidationProjectFile, parsed: ParsedYaml): ValidationYamlFacts {
+  const data = asRecord(parsed.data)
+  if (data === undefined) return emptyFacts()
+
+  const index = buildFormDataPathIndexFromYaml({ filePath: file.absolutePath, parsed })
+  const pendingChecks = collectFormPendingChecks({
+    file,
+    parsed,
+    value: data,
+    index,
+    yamlPath: [],
+  })
+
+  return {
+    ...emptyFacts(),
+    pendingChecks,
+    diagnostics: index.duplicateDiagnostics,
+  }
+}
+
+function buildFormDataPathIndexFromYaml(params: { filePath: string; parsed: ParsedYaml }): FormDataPathIndex {
+  const roots = new Map<string, FormDataPathSource>()
+  const duplicateDiagnostics: Diagnostic[] = []
+  const seenNames = new Map<string, number>()
+  const attributes = asRecord(asRecord(params.parsed.data)?.["Реквизиты"])
+
+  for (const [name, value] of Object.entries(attributes ?? {})) {
+    const occurrence = (seenNames.get(name) ?? 0) + 1
+    seenNames.set(name, occurrence)
+    if (roots.has(name)) {
+      duplicateDiagnostics.push(
+        diagnosticAtYamlPath({
+          filePath: params.filePath,
+          parsed: params.parsed,
+          path: ["Реквизиты", name],
+          severity: "error",
+          source: "structure",
+          message: `Дублируется реквизит формы "${name}"`,
+        })
+      )
+      continue
+    }
+
+    const attribute = asRecord(value)
+    const typeInfo =
+      attribute?.["ДинамическийСписок"] !== undefined
+        ? { kinds: ["dynamicList", "tableSource"] as const, nextTypes: [], table: { kind: "DynamicList" as const }, sourceText: "DynamicList" }
+        : typeDescriptionToDataPathTypeInfo(typeDescriptionFromYAML(attribute?.["Тип"]))
+    const tableSource =
+      typeInfo.table === undefined
+        ? undefined
+        : {
+            table: typeInfo.table,
+            columns: columnsFromYaml(attribute?.["Колонки"]),
+            hasColumns: typeInfo.table.kind !== "ValueTable" || columnsFromYaml(attribute?.["Колонки"]).size > 0,
+          }
+
+    roots.set(name, {
+      kind: "formAttribute",
+      name,
+      typeInfo,
+      ...(tableSource === undefined ? {} : { tableSource }),
+    })
+  }
+
+  return {
+    roots,
+    additionalColumnsByTablePath: new Map(),
+    duplicateDiagnostics,
+    getRoot(name) {
+      return roots.get(name)
+    },
+  }
+}
+
+function columnsFromYaml(value: unknown): Map<string, FormDataPathColumnSource> {
+  const result = new Map<string, FormDataPathColumnSource>()
+  const columns = asRecord(value)
+  for (const [name, column] of Object.entries(columns ?? {})) {
+    result.set(name, {
+      name,
+      typeInfo: typeDescriptionToDataPathTypeInfo(typeDescriptionFromYAML(asRecord(column)?.["Тип"])),
+    })
+  }
+  return result
+}
+
+function collectFormPendingChecks(params: {
+  file: ValidationProjectFile
+  parsed: ParsedYaml
+  value: Record<string, unknown>
+  index: FormDataPathIndex
+  yamlPath: readonly (string | number)[]
+  tableContext?: { dataPath: string }
+}): ValidationPendingCheck[] {
+  const checks: ValidationPendingCheck[] = []
+  checks.push(
+    ...collectElementTreeChecks({
+      ...params,
+      value: asRecord(params.value["Элементы"]),
+      yamlPath: [...params.yamlPath, "Элементы"],
+    })
+  )
+  return checks
+}
+
+function collectElementTreeChecks(params: {
+  file: ValidationProjectFile
+  parsed: ParsedYaml
+  value: Record<string, unknown> | undefined
+  index: FormDataPathIndex
+  yamlPath: readonly (string | number)[]
+  tableContext?: { dataPath: string }
+}): ValidationPendingCheck[] {
+  const checks: ValidationPendingCheck[] = []
+  for (const [name, rawElement] of Object.entries(params.value ?? {})) {
+    const element = asRecord(rawElement)
+    if (element === undefined) continue
+    const elementType = elementTypeFromYaml(element["Вид"], params.tableContext)
+    if (elementType === undefined) continue
+    const rule = getElementRule(elementType)
+    const elementPath = [...params.yamlPath, name]
+    const itemChecks = collectRuleDataPathChecks({
+      file: params.file,
+      parsed: params.parsed,
+      owner: element,
+      properties: rule.properties,
+      index: params.index,
+      yamlPath: elementPath,
+      elementType,
+      tableContext: params.tableContext,
+    })
+    const childTableContext = tableContextForChildren(elementType, itemChecks, params.tableContext)
+    checks.push(
+      ...itemChecks,
+      ...collectElementTreeChecks({
+        ...params,
+        value: asRecord(element["Элементы"]),
+        yamlPath: [...elementPath, "Элементы"],
+        tableContext: childTableContext,
+      })
+    )
+  }
+  return checks
+}
+
+function collectRuleDataPathChecks(params: {
+  file: ValidationProjectFile
+  parsed: ParsedYaml
+  owner: Record<string, unknown>
+  properties: Record<string, PropertyRule>
+  index: FormDataPathIndex
+  yamlPath: readonly (string | number)[]
+  elementType: ElementType
+  tableContext?: { dataPath: string }
+}): ValidationPendingCheck[] {
+  const checks: ValidationPendingCheck[] = []
+  for (const rule of Object.values(params.properties)) {
+    if (!isDataPathRule(rule) || typeof rule.yaml !== "string") continue
+
+    const value = params.owner[rule.yaml]
+    if (typeof value !== "string" || value.trim().length === 0) continue
+    checks.push({
+      kind: "dataPath",
+      filePath: params.file.absolutePath,
+      parsed: params.parsed,
+      yamlPath: [...params.yamlPath, rule.yaml],
+      owner: { kind: params.file.owner.dir, name: params.file.owner.name },
+      value,
+      index: params.index,
+      rule,
+      elementType: params.elementType,
+      ...(params.owner["КартинкаЗначений"] === undefined ? {} : { hasValuesPicture: true }),
+      ...(params.tableContext !== undefined && rule.yaml === "ПутьКДанным" ? { tableContext: params.tableContext } : {}),
+      policy: "formDataPath",
+    })
+  }
+  return checks
+}
+
+function tableContextForChildren(
+  elementType: ElementType,
+  checks: readonly ValidationPendingCheck[],
+  currentContext: { dataPath: string } | undefined
+): { dataPath: string } | undefined {
+  if (elementType !== "Table") return currentContext
+  return checks.find((check) => check.rule.yaml === "ПутьКДанным")?.value === undefined
+    ? currentContext
+    : { dataPath: checks.find((check) => check.rule.yaml === "ПутьКДанным")!.value }
+}
+
+function elementTypeFromYaml(value: unknown, tableContext: { dataPath: string } | undefined): ElementType | undefined {
+  if (typeof value !== "string") return undefined
+  if (tableContext !== undefined) {
+    if (value === "ПолеВвода") return "TableInputField"
+    if (value === "ПолеНадписи") return "TableLabelField"
+    if (value === "ПолеРисунка") return "TablePictureField"
+    if (value === "ПолеФлажок") return "TableCheckBoxField"
+  }
+  return CollectableElementTypeFromYAML[value as keyof typeof CollectableElementTypeFromYAML]
+}
+
+function isDataPathRule(rule: PropertyRule): rule is DataPathPropertyRule {
+  return rule.type === "DataPath"
+}
+
+function typeDescriptionFromYAML(value: unknown): TypeDescription | undefined {
+  const values = Array.isArray(value) ? value : [value]
+  const types = values
+    .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    .map((item) => {
+      const dotIndex = item.indexOf(".")
+      const base = dotIndex === -1 ? item : item.slice(0, dotIndex)
+      const detail = dotIndex === -1 ? undefined : item.slice(dotIndex + 1)
+      const type = getTypeFromYAML(base)
+      return type === undefined ? primitiveTypeFromYaml(item) : detail === undefined ? type : `${type}.${detail}`
+    })
+  return types.length === 0 ? undefined : { type: types }
+}
+
+function primitiveTypeFromYaml(value: string): string {
+  if (value === "Строка" || value === "ФиксированнаяСтрока") return "string"
+  if (value === "Число" || value === "ПоложительноеЧисло") return "decimal"
+  if (value === "Булево") return "boolean"
+  if (value === "Дата" || value === "Время" || value === "ДатаВремя") return "dateTime"
+  return value
+}
+
+function valueAtPath(value: Record<string, unknown>, path: readonly string[]): unknown {
+  let current: unknown = value
+  for (const segment of path) {
+    const record = asRecord(current)
+    if (record === undefined) return undefined
+    current = record[segment]
+  }
+  return current
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
 }

--- a/packages/core/metadata/validation/yamlFactExtractor.ts
+++ b/packages/core/metadata/validation/yamlFactExtractor.ts
@@ -1,0 +1,94 @@
+import type { ParsedMetadataTarget } from "../commonObjects/metadataTargets/types"
+import {
+  projectObjectIndexKey,
+  type ProjectMemberIndexEntry,
+  type ProjectObjectIndexEntry,
+  type ProjectValueIndexEntry,
+} from "./projectReferenceIndex"
+import type { ValidationProjectFile } from "./projectFiles"
+import { findValidationRulesSpec, type ValidationRulesSnapshot, type ValidationRulesSpecSnapshot } from "./rulesSnapshot"
+
+export interface ValidationYamlFacts {
+  objectIndexEntries: ProjectObjectIndexEntry[]
+  memberIndexEntries: ProjectMemberIndexEntry[]
+  valueIndexEntries: ProjectValueIndexEntry[]
+}
+
+export function extractValidationYamlFacts(params: {
+  file: ValidationProjectFile
+  data: unknown
+  rulesSnapshot: ValidationRulesSnapshot
+}): ValidationYamlFacts {
+  if (params.file.kind === "form") {
+    return emptyFacts()
+  }
+
+  const spec = findValidationRulesSpec(params.rulesSnapshot, params.file.owner.dir)
+  const objectTarget = spec === undefined ? undefined : objectTargetForProjectFile(params.file, spec)
+  return {
+    objectIndexEntries:
+      objectTarget === undefined
+        ? []
+        : [
+            {
+              canonical: projectObjectIndexKey(objectTarget),
+              target: objectTarget,
+              result: {
+                ok: true,
+                filePath: params.file.absolutePath,
+                details: objectIndexDetails(params.data),
+              },
+            },
+          ],
+    memberIndexEntries: [],
+    valueIndexEntries: [],
+  }
+}
+
+function objectTargetForProjectFile(
+  file: ValidationProjectFile,
+  spec: ValidationRulesSpecSnapshot
+): Extract<ParsedMetadataTarget, { kind: "object" }> | undefined {
+  const root = spec.metadataTargetOwner?.kind === "self" ? spec.metadataTargetOwner.root : spec.root
+  if (!root || file.owner.name.length === 0) return undefined
+
+  if (spec.nesting?.kind !== "recursiveChildDir") {
+    return {
+      kind: "object",
+      root,
+      objectName: file.owner.name,
+    }
+  }
+
+  const parts = file.projectPath.split("/")
+  if (parts[0] !== file.owner.dir || parts[parts.length - 1] !== "Свойства.yaml") return undefined
+  const rootObjectName = parts[1]
+  if (rootObjectName === undefined || rootObjectName.length === 0) return undefined
+  const nestedNames: string[] = []
+  for (let index = 2; index < parts.length - 2; index += 2) {
+    if (parts[index] !== spec.nesting.childDir) return undefined
+    const objectName = parts[index + 1]
+    if (objectName === undefined || objectName.length === 0) return undefined
+    nestedNames.push(objectName)
+  }
+
+  return {
+    kind: "object",
+    root,
+    objectName: rootObjectName,
+    segments: nestedNames.map((objectName) => ({ kind: root, objectName })),
+  }
+}
+
+function objectIndexDetails(data: unknown): { type?: string } {
+  const type = metadataRecord(data)["Тип"]
+  return typeof type === "string" ? { type } : {}
+}
+
+function metadataRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+function emptyFacts(): ValidationYamlFacts {
+  return { objectIndexEntries: [], memberIndexEntries: [], valueIndexEntries: [] }
+}

--- a/packages/core/metadata/validation/yamlFactExtractor.ts
+++ b/packages/core/metadata/validation/yamlFactExtractor.ts
@@ -196,7 +196,8 @@ function buildObjectFieldIndexFromSyntheticModel(
     ["resources", "resource"],
     ["addressingAttributes", "addressingAttribute"],
   ] as const) {
-    const items = Array.isArray(model[collection[0]]) ? model[collection[0]] : []
+    const collectionValue = model[collection[0]]
+    const items: unknown[] = Array.isArray(collectionValue) ? collectionValue : []
     for (const item of items) {
       const record = asRecord(item)
       if (record === undefined || typeof record["name"] !== "string") continue

--- a/packages/core/metadata/validation/yamlFactExtractor.ts
+++ b/packages/core/metadata/validation/yamlFactExtractor.ts
@@ -9,6 +9,7 @@ import type { ParsedYaml } from "../../yaml/parseMetadataYaml"
 import { typeDescriptionToDataPathTypeInfo } from "./dataPath/typeDescription"
 import type { FormDataPathIndex } from "./dataPath/formIndex"
 import type { FormDataPathSource, FormDataPathColumnSource } from "./dataPath/types"
+import type { ObjectField, ObjectFieldIndex } from "./dataPath/objectFields"
 import {
   projectMemberIndexKey,
   projectObjectIndexKey,
@@ -31,6 +32,8 @@ export interface ValidationYamlFacts {
   pendingReferences: PendingMetadataTargetReference[]
   pendingChecks: ValidationPendingCheck[]
   diagnostics: Diagnostic[]
+  fieldIndex?: ObjectFieldIndex
+  ownerModelStub?: Record<string, unknown>
 }
 
 export function extractValidationYamlFacts(params: {
@@ -55,6 +58,7 @@ export function extractValidationYamlFacts(params: {
           properties: spec.properties,
           yamlPath: [],
         })
+  const ownerFacts = spec === undefined ? undefined : buildOwnerFactsFromYaml(params.file, params.parsed.data, spec)
   return {
     objectIndexEntries:
       objectTarget === undefined
@@ -75,6 +79,7 @@ export function extractValidationYamlFacts(params: {
     pendingReferences,
     pendingChecks: [],
     diagnostics: [],
+    ...(ownerFacts === undefined ? {} : ownerFacts),
   }
 }
 
@@ -131,6 +136,122 @@ function emptyFacts(): ValidationYamlFacts {
     pendingChecks: [],
     diagnostics: [],
   }
+}
+
+function buildOwnerFactsFromYaml(
+  file: ValidationProjectFile,
+  data: unknown,
+  spec: ValidationRulesSpecSnapshot
+): Pick<ValidationYamlFacts, "fieldIndex" | "ownerModelStub"> {
+  const model = syntheticModelFromYaml(file, data, spec)
+  return {
+    ownerModelStub: model,
+    fieldIndex: buildObjectFieldIndexFromSyntheticModel(file, model),
+  }
+}
+
+function syntheticModelFromYaml(
+  file: ValidationProjectFile,
+  data: unknown,
+  spec: ValidationRulesSpecSnapshot
+): Record<string, unknown> {
+  const record = asRecord(data) ?? {}
+  const model: Record<string, unknown> = {
+    itemType: spec.itemType,
+    name: file.owner.name,
+  }
+
+  for (const property of spec.properties) {
+    const value = valueAtPath(record, property.yamlPath)
+    if (value === undefined) continue
+    if (property.modelKey === "attributes" || property.modelKey === "dimensions" || property.modelKey === "resources" || property.modelKey === "addressingAttributes") {
+      model[property.modelKey] = namedTypedItemsFromYaml(value)
+      continue
+    }
+    if (property.modelKey === "tabularSections") {
+      model[property.modelKey] = tabularSectionsFromYaml(value)
+      continue
+    }
+    if (property.modelKey === "owners") {
+      model[property.modelKey] = Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []
+      continue
+    }
+    if (property.modelKey === "type") {
+      model[property.modelKey] = typeDescriptionFromYAML(value)
+      continue
+    }
+  }
+
+  return model
+}
+
+function buildObjectFieldIndexFromSyntheticModel(
+  file: ValidationProjectFile,
+  model: Record<string, unknown>
+): ObjectFieldIndex {
+  const fields = new Map<string, ObjectField>()
+  for (const collection of [
+    ["attributes", "attribute"],
+    ["dimensions", "dimension"],
+    ["resources", "resource"],
+    ["addressingAttributes", "addressingAttribute"],
+  ] as const) {
+    const items = Array.isArray(model[collection[0]]) ? model[collection[0]] : []
+    for (const item of items) {
+      const record = asRecord(item)
+      if (record === undefined || typeof record["name"] !== "string") continue
+      fields.set(record["name"], {
+        name: record["name"],
+        kind: collection[1],
+        sourceCollection: collection[0],
+        typeInfo: typeDescriptionToDataPathTypeInfo(record["type"] as TypeDescription | undefined),
+      })
+    }
+  }
+
+  for (const item of Array.isArray(model["tabularSections"]) ? model["tabularSections"] : []) {
+    const record = asRecord(item)
+    if (record === undefined || typeof record["name"] !== "string") continue
+    const columns = new Map<string, ObjectField>()
+    for (const attribute of Array.isArray(record["attributes"]) ? record["attributes"] : []) {
+      const attributeRecord = asRecord(attribute)
+      if (attributeRecord === undefined || typeof attributeRecord["name"] !== "string") continue
+      columns.set(attributeRecord["name"], {
+        name: attributeRecord["name"],
+        kind: "attribute",
+        sourceCollection: "attributes",
+        typeInfo: typeDescriptionToDataPathTypeInfo(attributeRecord["type"] as TypeDescription | undefined),
+      })
+    }
+    const table = { kind: "TabularSection" as const, owner: { kind: file.owner.dir, name: file.owner.name }, name: record["name"] }
+    fields.set(record["name"], {
+      name: record["name"],
+      kind: "tabularSection",
+      sourceCollection: "tabularSections",
+      typeInfo: { kinds: ["tableSource"], nextTypes: [], table },
+      tableSource: { table, columns, hasColumns: columns.size > 0 },
+    })
+  }
+
+  return { fields, standardAttributeAliases: new Map(), diagnostics: [] }
+}
+
+function namedTypedItemsFromYaml(value: unknown): Array<{ name: string; type?: TypeDescription }> {
+  const record = asRecord(value)
+  return Object.entries(record ?? {}).map(([name, item]) => ({
+    name,
+    ...(typeDescriptionFromYAML(asRecord(item)?.["Тип"]) === undefined
+      ? {}
+      : { type: typeDescriptionFromYAML(asRecord(item)?.["Тип"]) }),
+  }))
+}
+
+function tabularSectionsFromYaml(value: unknown): Array<{ name: string; attributes: Array<{ name: string; type?: TypeDescription }> }> {
+  const record = asRecord(value)
+  return Object.entries(record ?? {}).map(([name, item]) => ({
+    name,
+    attributes: namedTypedItemsFromYaml(asRecord(item)?.["Реквизиты"]),
+  }))
 }
 
 function collectPendingReferences(params: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,12 +20,13 @@
   },
   "dependencies": {
     "@node-rs/xxhash": "^1.7.6",
-    "date-fns": "^4.4.0",
-    "fast-xml-parser": "^5.9.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
+    "date-fns": "^4.4.0",
+    "fast-xml-parser": "^5.9.2",
     "js-yaml": "^5.2.1",
     "p-limit": "^6.2.0",
+    "piscina": "^5.2.0",
     "typebox": "1.3.3",
     "uuid": "^14.0.0"
   },

--- a/packages/mcp/src/coreApi.ts
+++ b/packages/mcp/src/coreApi.ts
@@ -94,6 +94,11 @@ export interface CoreApi {
     directoryPath?: string
     depth?: number
   }): MetadataProjectDirectoryStructure
+  createValidationWorkerPoolHandle(params?: { concurrency?: number }): {
+    validateProject(params: { projectDir: string; filePath?: string }): Promise<{ diagnostics: Diagnostic[] }>
+    close(): Promise<void>
+    size(): number
+  }
   validateProject(params: { projectDir: string; filePath?: string }): Promise<{ diagnostics: Diagnostic[] }>
   renameMetadataItem(params: {
     projectDir: string

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
-import { createNkdkMcpServer } from "./server"
+import { createNkdkMcpServer, shutdownNkdkMcpServer } from "./server"
+
+const closeValidationHandle = vi.hoisted(() => vi.fn())
+
+vi.mock("./services/validationHandle", () => ({
+  closeValidationHandle,
+}))
 
 describe("MCP server", () => {
   it("creates the NKDK MCP server", () => {
@@ -38,4 +44,12 @@ describe("MCP server", () => {
       await client.close()
     }
   }, 30_000)
+
+  it("closes validation handle on shutdown", async () => {
+    closeValidationHandle.mockResolvedValueOnce(undefined)
+
+    await shutdownNkdkMcpServer()
+
+    expect(closeValidationHandle).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "url"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { registerNkdkCapabilities } from "./tools/registerTools"
+import { closeValidationHandle } from "./services/validationHandle"
 
 export function createNkdkMcpServer(): McpServer {
   const server = new McpServer({
@@ -20,15 +21,33 @@ export async function runStdioServer(): Promise<void> {
   await server.connect(transport)
 }
 
+export async function shutdownNkdkMcpServer(): Promise<void> {
+  await closeValidationHandle()
+}
+
 function isMainEntrypoint(): boolean {
   const entrypoint = process.argv[1]
   return entrypoint !== undefined && import.meta.url === pathToFileURL(resolve(entrypoint)).href
 }
 
 if (isMainEntrypoint()) {
+  installShutdownHooks()
   runStdioServer().catch((err: unknown) => {
     const message = err instanceof Error ? err.message : String(err)
     process.stderr.write(`${message}\n`)
     process.exitCode = 1
   })
+}
+
+function installShutdownHooks(): void {
+  const shutdown = async () => {
+    try {
+      await shutdownNkdkMcpServer()
+    } finally {
+      process.exit()
+    }
+  }
+
+  process.once("SIGINT", shutdown)
+  process.once("SIGTERM", shutdown)
 }

--- a/packages/mcp/src/services/validateProject.test.ts
+++ b/packages/mcp/src/services/validateProject.test.ts
@@ -2,10 +2,12 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join, resolve } from "path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { resetValidationHandleForTests } from "./validationHandle"
 import { validateYamlProject } from "./validateProject"
 
 const core = vi.hoisted(() => ({
   ProjectFileSchemaError: class ProjectFileSchemaError extends Error {},
+  createValidationWorkerPoolHandle: vi.fn(),
   validateProject: vi.fn(),
 }))
 
@@ -19,6 +21,13 @@ describe("validateProject service", () => {
   beforeEach(() => {
     core.validateProject.mockReset()
     core.validateProject.mockResolvedValue({ diagnostics: [] })
+    core.createValidationWorkerPoolHandle.mockReset()
+    core.createValidationWorkerPoolHandle.mockReturnValue({
+      validateProject: core.validateProject,
+      close: vi.fn(),
+      size: vi.fn(() => 1),
+    })
+    resetValidationHandleForTests()
   })
 
   afterEach(() => {
@@ -54,6 +63,18 @@ describe("validateProject service", () => {
       }),
     )
     expect(core.validateProject).toHaveBeenCalledWith({ projectDir })
+  })
+
+  it("reuses one validation handle across service calls", async () => {
+    const projectDir = createProject()
+
+    await validateYamlProject({ projectDir })
+    await validateYamlProject({ projectDir })
+
+    expect(core.createValidationWorkerPoolHandle).toHaveBeenCalledTimes(1)
+    expect(core.validateProject).toHaveBeenCalledTimes(2)
+    expect(core.validateProject).toHaveBeenNthCalledWith(1, { projectDir })
+    expect(core.validateProject).toHaveBeenNthCalledWith(2, { projectDir })
   })
 
   it("omits warning diagnostics from JSON output", async () => {

--- a/packages/mcp/src/services/validateProject.ts
+++ b/packages/mcp/src/services/validateProject.ts
@@ -3,6 +3,7 @@ import { isAbsolute, relative, resolve, sep } from "path"
 import { loadCoreApi } from "../coreApi"
 import { errorMessage, toolError, toolSuccess, type ToolPayload } from "../contracts/common"
 import { type ValidateProjectInput } from "../contracts/validateProject"
+import { getValidationHandle } from "./validationHandle"
 
 export type ValidateProjectPayload = ToolPayload<{
   diagnostics: Array<{
@@ -30,8 +31,8 @@ export async function validateYamlProject(input: ValidateProjectInput): Promise<
   }
 
   try {
-    const core = await loadCoreApi()
-    const diagnostics = (await core.validateProject({
+    const handle = await getValidationHandle()
+    const diagnostics = (await handle.validateProject({
       projectDir,
       ...(input.filePath !== undefined ? { filePath: input.filePath } : {}),
     })).diagnostics

--- a/packages/mcp/src/services/validationHandle.ts
+++ b/packages/mcp/src/services/validationHandle.ts
@@ -1,0 +1,20 @@
+import { loadCoreApi, type CoreApi } from "../coreApi"
+
+type ValidationHandle = ReturnType<CoreApi["createValidationWorkerPoolHandle"]>
+
+let handlePromise: Promise<ValidationHandle> | undefined
+
+export function getValidationHandle(): Promise<ValidationHandle> {
+  handlePromise ??= loadCoreApi().then((core) => core.createValidationWorkerPoolHandle())
+  return handlePromise
+}
+
+export async function closeValidationHandle(): Promise<void> {
+  const handle = await handlePromise
+  handlePromise = undefined
+  await handle?.close()
+}
+
+export function resetValidationHandleForTests(): void {
+  handlePromise = undefined
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       p-limit:
         specifier: ^6.2.0
         version: 6.2.0
+      piscina:
+        specifier: ^5.2.0
+        version: 5.2.0
       typebox:
         specifier: 1.3.3
         version: 1.3.3
@@ -523,6 +526,119 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/nice-android-arm-eabi@1.1.1':
+    resolution: {integrity: sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@napi-rs/nice-android-arm64@1.1.1':
+    resolution: {integrity: sha512-blG0i7dXgbInN5urONoUCNf+DUEAavRffrO7fZSeoRMJc5qD+BJeNcpr54msPF6qfDD6kzs9AQJogZvT2KD5nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/nice-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-s/E7w45NaLqTGuOjC2p96pct4jRfo61xb9bU1unM/MJ/RFkKlJyJDx7OJI/O0ll/hrfpqKopuAFDV8yo0hfT7A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/nice-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-dGoEBnVpsdcC+oHHmW1LRK5eiyzLwdgNQq3BmZIav+9/5WTZwBYX7r5ZkQC07Nxd3KHOCkgbHSh4wPkH1N1LiQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/nice-freebsd-x64@1.1.1':
+    resolution: {integrity: sha512-kHv4kEHAylMYmlNwcQcDtXjklYp4FCf0b05E+0h6nDHsZ+F0bDe04U/tXNOqrx5CmIAth4vwfkjjUmp4c4JktQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/nice-linux-arm-gnueabihf@1.1.1':
+    resolution: {integrity: sha512-E1t7K0efyKXZDoZg1LzCOLxgolxV58HCkaEkEvIYQx12ht2pa8hoBo+4OB3qh7e+QiBlp1SRf+voWUZFxyhyqg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/nice-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-CIKLA12DTIZlmTaaKhQP88R3Xao+gyJxNWEn04wZwC2wmRapNnxCUZkVwggInMJvtVElA+D4ZzOU5sX4jV+SmQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/nice-linux-arm64-musl@1.1.1':
+    resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
+    resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
+    engines: {node: '>= 10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
+    resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/nice-linux-s390x-gnu@1.1.1':
+    resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
+    engines: {node: '>= 10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/nice-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/nice-linux-x64-musl@1.1.1':
+    resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/nice-openharmony-arm64@1.1.1':
+    resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@napi-rs/nice-win32-arm64-msvc@1.1.1':
+    resolution: {integrity: sha512-uoTb4eAvM5B2aj/z8j+Nv8OttPf2m+HVx3UjA5jcFxASvNhQriyCQF1OB1lHL43ZhW+VwZlgvjmP5qF3+59atA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/nice-win32-ia32-msvc@1.1.1':
+    resolution: {integrity: sha512-CNQqlQT9MwuCsg1Vd/oKXiuH+TcsSPJmlAFc5frFyX/KkOh0UpBLEj7aoY656d5UKZQMQFP7vJNa1DNUNORvug==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/nice-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-vB+4G/jBQCAh0jelMTY3+kgFy00Hlx2f2/1zjMoH821IbplbWZOkLiTYXQkygNTzQJTq5cvwBDgn2ppHD+bglQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/nice@1.1.1':
+    resolution: {integrity: sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1451,6 +1567,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  piscina@5.2.0:
+    resolution: {integrity: sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==}
+    engines: {node: '>=20.x'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -2193,6 +2313,78 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/nice-android-arm-eabi@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-android-arm64@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-darwin-arm64@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-darwin-x64@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-freebsd-x64@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-linux-arm-gnueabihf@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-linux-arm64-musl@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-linux-s390x-gnu@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-linux-x64-musl@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-openharmony-arm64@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-win32-arm64-msvc@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-win32-ia32-msvc@1.1.1':
+    optional: true
+
+  '@napi-rs/nice-win32-x64-msvc@1.1.1':
+    optional: true
+
+  '@napi-rs/nice@1.1.1':
+    optionalDependencies:
+      '@napi-rs/nice-android-arm-eabi': 1.1.1
+      '@napi-rs/nice-android-arm64': 1.1.1
+      '@napi-rs/nice-darwin-arm64': 1.1.1
+      '@napi-rs/nice-darwin-x64': 1.1.1
+      '@napi-rs/nice-freebsd-x64': 1.1.1
+      '@napi-rs/nice-linux-arm-gnueabihf': 1.1.1
+      '@napi-rs/nice-linux-arm64-gnu': 1.1.1
+      '@napi-rs/nice-linux-arm64-musl': 1.1.1
+      '@napi-rs/nice-linux-ppc64-gnu': 1.1.1
+      '@napi-rs/nice-linux-riscv64-gnu': 1.1.1
+      '@napi-rs/nice-linux-s390x-gnu': 1.1.1
+      '@napi-rs/nice-linux-x64-gnu': 1.1.1
+      '@napi-rs/nice-linux-x64-musl': 1.1.1
+      '@napi-rs/nice-openharmony-arm64': 1.1.1
+      '@napi-rs/nice-win32-arm64-msvc': 1.1.1
+      '@napi-rs/nice-win32-ia32-msvc': 1.1.1
+      '@napi-rs/nice-win32-x64-msvc': 1.1.1
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -3050,6 +3242,10 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  piscina@5.2.0:
+    optionalDependencies:
+      '@napi-rs/nice': 1.1.1
 
   pkce-challenge@5.0.1: {}
 


### PR DESCRIPTION
## Summary
- Переведена validation на compact YAML facts/rulesSnapshot без хранения полной модели в worker state.
- Добавлен reusable validation pool handle и MCP singleton для nkdk.validate_project.
- Worker pool переведен на Piscina с сохранением очистки project state между validation-запусками.

## Test Plan
- pnpm --filter @nakidka/core test
- pnpm --filter @nakidka/core exec vitest run metadata/validation
- pnpm --filter @nakidka/mcp test
- pnpm test
- MCP validation замер на /Users/nikita/git/nkdk-yaml