### PR TITLE
Validation schema auto ref

### DIFF
--- a/.agents/skills/validation-profile/SKILL.md
+++ b/.agents/skills/validation-profile/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: validation-profile
+description: Use when the user asks to measure YAML project validation speed or memory through the compiled standalone validation path.
+---
+
+# validation-profile
+
+## Что делает скилл
+
+Скилл выполняет benchmark валидации YAML-проекта через compiled standalone path:
+
+```text
+packages/core/dist/index.js
+  -> packages/core/dist/projectValidationWorker.js
+  -> packages/core/dist/projectValidationAjvStandalone.js
+```
+
+Он не использует MCP service и не импортирует `packages/core/index.ts`, потому что это source/tsx path.
+
+## Жёсткие инварианты
+
+- Перед каждым замером выполняй свежую сборку: `pnpm --filter @nakidka/core build`.
+- Запускай только `node .agents/skills/validation-profile/validation-profile.mjs ...`.
+- Не запускай `pnpm test`.
+- Не исправляй validation diagnostics в рамках этого скилла.
+- Не коммить результаты замеров.
+- Если пользователь просит сравнить source/tsx и compiled standalone, скажи, что это отдельная диагностика вне этого скилла.
+
+## Быстрый запуск
+
+```bash
+pnpm --filter @nakidka/core build
+node .agents/skills/validation-profile/validation-profile.mjs /path/to/yaml
+```
+
+С одним прогоном:
+
+```bash
+pnpm --filter @nakidka/core build
+node .agents/skills/validation-profile/validation-profile.mjs /path/to/yaml --runs 1
+```
+
+С worker timing:
+
+```bash
+pnpm --filter @nakidka/core build
+node .agents/skills/validation-profile/validation-profile.mjs /path/to/yaml --runs 1 --timing
+```
+
+## Параметры runner'а
+
+- `--runs N` — число прогонов, по умолчанию `5`.
+- `--concurrency N` — явно задать число worker'ов. Если не задано, core использует свой default.
+- `--timing` — добавить один прогон с `NKDK_VALIDATION_TIMING=1` и распарсить first/second pass worker memory.
+- `--json` — вывести только JSON.
+
+## Как отвечать пользователю
+
+В финальном ответе покажи:
+
+```text
+Режим: compiled standalone
+YAML-каталог: <path>
+Воркеры: <N>
+Cold: <seconds>
+Warm: avg=<seconds> min=<seconds> max=<seconds>
+Diagnostics: <total> = <errors> errors + <warnings> warnings
+Peak RSS: <MiB>
+RSS по прогонам: <run list>
+```
+
+Если был `--timing`, добавь краткую таблицу:
+
+```text
+worker | phase | files | processRssPeak | workerHeapPeak
+```
+
+## Ограничения
+
+`--timing` использует существующий `NKDK_VALIDATION_TIMING=1`, поэтому показывает first pass и second pass целиком. Он не показывает `afterRead`, `afterReferenceValidation` или другие внутренние точки, если core не был специально инструментирован.
+
+Если diagnostics выглядят неожиданно, явно укажи, что это результат compiled standalone, и предложи отдельную проверку parity.

--- a/.agents/skills/validation-profile/validation-profile.mjs
+++ b/.agents/skills/validation-profile/validation-profile.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process"
+import { existsSync, statSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+
+function usage() {
+  return [
+    "Использование:",
+    "  node .agents/skills/validation-profile/validation-profile.mjs <yaml-dir> [--runs N] [--concurrency N] [--timing] [--json]",
+  ].join("\n")
+}
+
+function fail(message) {
+  console.error(`Ошибка: ${message}`)
+  console.error(usage())
+  process.exit(2)
+}
+
+function isPositiveInteger(value) {
+  return typeof value === "string" && /^[1-9][0-9]*$/.test(value)
+}
+
+function parseArgs(argv) {
+  const options = {
+    runs: 5,
+    concurrency: undefined,
+    timing: false,
+    jsonOnly: false,
+    projectDir: undefined,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--runs") {
+      const value = argv[++index]
+      if (!isPositiveInteger(value)) fail("--runs должен быть положительным целым числом")
+      options.runs = Number(value)
+      continue
+    }
+    if (arg === "--concurrency") {
+      const value = argv[++index]
+      if (!isPositiveInteger(value)) fail("--concurrency должен быть положительным целым числом")
+      options.concurrency = Number(value)
+      continue
+    }
+    if (arg === "--timing") {
+      options.timing = true
+      continue
+    }
+    if (arg === "--json") {
+      options.jsonOnly = true
+      continue
+    }
+    if (arg === "-h" || arg === "--help") {
+      console.log(usage())
+      process.exit(0)
+    }
+    if (arg.startsWith("-")) fail(`неизвестный параметр ${arg}`)
+    if (options.projectDir !== undefined) fail("можно указать только один YAML-каталог")
+    options.projectDir = resolve(arg)
+  }
+
+  if (options.projectDir === undefined) fail("не указан YAML-каталог")
+  if (!existsSync(options.projectDir)) fail(`YAML-каталог не найден: ${options.projectDir}`)
+  if (!statSync(options.projectDir).isDirectory()) fail(`путь не является каталогом: ${options.projectDir}`)
+
+  return options
+}
+
+async function loadCompiledCore() {
+  const distIndex = resolve(repoRoot, "packages/core/dist/index.js")
+  const standalone = resolve(repoRoot, "packages/core/dist/projectValidationAjvStandalone.js")
+  const worker = resolve(repoRoot, "packages/core/dist/projectValidationWorker.js")
+
+  if (!existsSync(distIndex) || !existsSync(worker) || !existsSync(standalone)) {
+    fail(
+      [
+        "compiled validation files are missing.",
+        "Перед запуском выполни: pnpm --filter @nakidka/core build",
+      ].join(" ")
+    )
+  }
+
+  return import(pathToFileURL(distIndex).href)
+}
+
+function memorySnapshot() {
+  const memory = process.memoryUsage()
+  return {
+    rssMiB: Math.round(memory.rss / 1024 / 1024),
+    heapUsedMiB: Math.round(memory.heapUsed / 1024 / 1024),
+    rssBytes: memory.rss,
+  }
+}
+
+function countDiagnostics(diagnostics) {
+  let errors = 0
+  let warnings = 0
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.severity === "error") errors += 1
+    if (diagnostic.severity === "warning") warnings += 1
+  }
+  return { errors, warnings }
+}
+
+function average(values) {
+  if (values.length === 0) return undefined
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length)
+}
+
+async function runProfile(options) {
+  const core = await loadCompiledCore()
+  const handle = core.createValidationWorkerPoolHandle(
+    options.concurrency === undefined ? undefined : { concurrency: options.concurrency }
+  )
+  const runs = []
+  let peakRssBytes = process.memoryUsage().rss
+  const timer = setInterval(() => {
+    peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss)
+  }, 25)
+
+  try {
+    for (let run = 1; run <= options.runs; run += 1) {
+      const started = performance.now()
+      const validation = await handle.validateProject({ projectDir: options.projectDir })
+      const elapsedMs = Math.round(performance.now() - started)
+      const memory = memorySnapshot()
+      peakRssBytes = Math.max(peakRssBytes, memory.rssBytes)
+      const counts = countDiagnostics(validation.diagnostics)
+
+      runs.push({
+        run,
+        elapsedMs,
+        diagnostics: validation.diagnostics.length,
+        errors: counts.errors,
+        warnings: counts.warnings,
+        workerPoolSize: handle.size(),
+        rssMiB: memory.rssMiB,
+        heapUsedMiB: memory.heapUsedMiB,
+      })
+    }
+  } finally {
+    clearInterval(timer)
+    await handle.close()
+  }
+
+  const warm = runs.slice(1).map((run) => run.elapsedMs)
+  const result = {
+    mode: "compiled-standalone",
+    projectDir: options.projectDir,
+    runs,
+    coldMs: runs[0]?.elapsedMs,
+    warmAvgMs: average(warm),
+    warmMinMs: warm.length === 0 ? undefined : Math.min(...warm),
+    warmMaxMs: warm.length === 0 ? undefined : Math.max(...warm),
+    peakRssMiB: Math.round(peakRssBytes / 1024 / 1024),
+  }
+
+  if (options.timing) {
+    result.timing = runTimingPass(options)
+  }
+
+  return result
+}
+
+function runTimingPass(options) {
+  const script = [
+    "import { createValidationWorkerPoolHandle } from './packages/core/dist/index.js';",
+    `const projectDir = ${JSON.stringify(options.projectDir)};`,
+    `const handle = createValidationWorkerPoolHandle(${
+      options.concurrency === undefined ? "" : JSON.stringify({ concurrency: options.concurrency })
+    });`,
+    "try { await handle.validateProject({ projectDir }); } finally { await handle.close(); }",
+  ].join("\n")
+
+  const spawned = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NKDK_VALIDATION_TIMING: "1",
+    },
+    maxBuffer: 1024 * 1024 * 64,
+  })
+
+  if (spawned.status !== 0) {
+    throw new Error(
+      [
+        "timing pass failed",
+        `status=${spawned.status}`,
+        spawned.stderr.trim(),
+        spawned.stdout.trim(),
+      ]
+        .filter(Boolean)
+        .join("\n")
+    )
+  }
+
+  const rawLines = spawned.stderr.split(/\r?\n/).filter((line) => line.startsWith("[validation] worker "))
+  return {
+    firstPass: rawLines.filter((line) => line.includes(" first pass ")).map(parseTimingLine),
+    secondPass: rawLines.filter((line) => line.includes(" second pass ")).map(parseTimingLine),
+    rawLines,
+  }
+}
+
+function parseTimingLine(line) {
+  const result = { raw: line }
+  const worker = /worker (\d+)/.exec(line)
+  if (worker) result.worker = Number(worker[1])
+  result.phase = line.includes(" first pass ") ? "firstPass" : "secondPass"
+
+  for (const token of line.split(" ")) {
+    const eq = token.indexOf("=")
+    if (eq === -1) continue
+    const key = token.slice(0, eq)
+    const rawValue = token.slice(eq + 1)
+    if (rawValue.endsWith("ms")) {
+      result[key] = Number(rawValue.slice(0, -"ms".length))
+      continue
+    }
+    if (rawValue.endsWith("MiB")) {
+      result[key] = Number(rawValue.slice(0, -"MiB".length))
+      continue
+    }
+    const number = Number(rawValue)
+    result[key] = Number.isNaN(number) ? rawValue : number
+  }
+
+  return result
+}
+
+function printResult(result, options) {
+  if (options.jsonOnly) {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  console.log("Validation profile: compiled standalone")
+  console.log(`YAML-каталог: ${result.projectDir}`)
+  console.log(`Воркеры: ${result.runs[0]?.workerPoolSize ?? "unknown"}`)
+  console.log(`Cold: ${formatMs(result.coldMs)}`)
+  console.log(
+    `Warm: avg=${formatMs(result.warmAvgMs)} min=${formatMs(result.warmMinMs)} max=${formatMs(result.warmMaxMs)}`
+  )
+  console.log(`Peak RSS: ${result.peakRssMiB} MiB`)
+  console.log("")
+  console.log("Runs:")
+  for (const run of result.runs) {
+    console.log(
+      [
+        `  ${run.run}.`,
+        `${formatMs(run.elapsedMs)}`,
+        `diagnostics=${run.diagnostics}`,
+        `errors=${run.errors}`,
+        `warnings=${run.warnings}`,
+        `rss=${run.rssMiB}MiB`,
+        `heap=${run.heapUsedMiB}MiB`,
+      ].join(" ")
+    )
+  }
+
+  if (result.timing !== undefined) {
+    console.log("")
+    console.log("Timing memory:")
+    for (const item of [...result.timing.firstPass, ...result.timing.secondPass]) {
+      console.log(
+        [
+          `  worker=${item.worker}`,
+          `phase=${item.phase}`,
+          `files=${item.files}`,
+          `rssPeak=${item.processRssPeak}MiB`,
+          `heapPeak=${item.workerHeapPeak}MiB`,
+        ].join(" ")
+      )
+    }
+  }
+
+  console.log("")
+  console.log(JSON.stringify(result, null, 2))
+}
+
+function formatMs(value) {
+  return value === undefined ? "n/a" : `${(value / 1000).toFixed(2)}s`
+}
+
+const options = parseArgs(process.argv.slice(2))
+const result = await runProfile(options)
+printResult(result, options)

--- a/docs/superpowers/plans/2026-07-07-validation-profile-skill.md
+++ b/docs/superpowers/plans/2026-07-07-validation-profile-skill.md
@@ -1,0 +1,569 @@
+# Validation Profile Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `.agents/skills/validation-profile`, a repo-skill that profiles compiled standalone project validation for a YAML directory.
+
+**Architecture:** The skill has a concise `SKILL.md` and one deterministic Node runner. The runner imports `packages/core/dist/index.js`, so validation uses compiled `projectValidationWorker.js` and `projectValidationAjvStandalone.js`; the skill workflow performs `pnpm --filter @nakidka/core build` before invoking the runner.
+
+**Tech Stack:** Node.js ESM, `@nakidka/core` built dist, existing validation worker pool, existing `NKDK_VALIDATION_TIMING=1` logs, repo skill metadata format.
+
+## Global Constraints
+
+- Create files only under `.agents/skills/validation-profile/`.
+- Measure only compiled standalone validation; do not call `packages/mcp/src/services/validateProject.ts` and do not import `packages/core/index.ts`.
+- The runner does not run `pnpm --filter @nakidka/core build`; the skill workflow does.
+- The runner does not modify project files, commit, push, or run `pnpm test`.
+- Full `pnpm test` is not required because only diagnostic skill files are added.
+- Use ASCII in new files unless existing project text requires Russian user-facing messages.
+
+---
+
+## File Structure
+
+- Create `.agents/skills/validation-profile/validation-profile.mjs`.
+  - Responsibility: parse CLI args, run compiled standalone validation, collect timing/memory/diagnostics, optionally run a timing pass, print JSON or JSON plus short text summary.
+- Create `.agents/skills/validation-profile/SKILL.md`.
+  - Responsibility: tell Codex when and how to use the runner, enforce compiled-only workflow, and define the final response shape.
+
+---
+
+### Task 1: Compiled Standalone Profile Runner
+
+**Files:**
+- Create: `.agents/skills/validation-profile/validation-profile.mjs`
+
+**Interfaces:**
+- Consumes: `packages/core/dist/index.js` exports `createValidationWorkerPoolHandle(params?: { concurrency?: number })`.
+- Produces: CLI command `node .agents/skills/validation-profile/validation-profile.mjs <yaml-dir> [--runs N] [--concurrency N] [--timing] [--json]`.
+- Produces JSON object:
+  - `mode: "compiled-standalone"`
+  - `projectDir: string`
+  - `runs: Array<{ run: number; elapsedMs: number; diagnostics: number; errors: number; warnings: number; workerPoolSize: number; rssMiB: number; heapUsedMiB: number }>`
+  - `coldMs?: number`
+  - `warmAvgMs?: number`
+  - `warmMinMs?: number`
+  - `warmMaxMs?: number`
+  - `peakRssMiB: number`
+  - `timing?: { firstPass: unknown[]; secondPass: unknown[]; rawLines: string[] }`
+
+- [ ] **Step 1: Create runner skeleton with strict argument parsing**
+
+Create `.agents/skills/validation-profile/validation-profile.mjs` with:
+
+```js
+#!/usr/bin/env node
+import { existsSync, statSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import { spawnSync } from "node:child_process"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+
+function usage() {
+  return [
+    "Использование:",
+    "  node .agents/skills/validation-profile/validation-profile.mjs <yaml-dir> [--runs N] [--concurrency N] [--timing] [--json]",
+  ].join("\\n")
+}
+
+function fail(message) {
+  console.error(`Ошибка: ${message}`)
+  console.error(usage())
+  process.exit(2)
+}
+
+function parseArgs(argv) {
+  const options = {
+    runs: 5,
+    concurrency: undefined,
+    timing: false,
+    jsonOnly: false,
+    projectDir: undefined,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--runs") {
+      const value = argv[++index]
+      if (!isPositiveInteger(value)) fail("--runs должен быть положительным целым числом")
+      options.runs = Number(value)
+      continue
+    }
+    if (arg === "--concurrency") {
+      const value = argv[++index]
+      if (!isPositiveInteger(value)) fail("--concurrency должен быть положительным целым числом")
+      options.concurrency = Number(value)
+      continue
+    }
+    if (arg === "--timing") {
+      options.timing = true
+      continue
+    }
+    if (arg === "--json") {
+      options.jsonOnly = true
+      continue
+    }
+    if (arg === "-h" || arg === "--help") {
+      console.log(usage())
+      process.exit(0)
+    }
+    if (arg.startsWith("-")) fail(`неизвестный параметр ${arg}`)
+    if (options.projectDir !== undefined) fail("можно указать только один YAML-каталог")
+    options.projectDir = resolve(arg)
+  }
+
+  if (options.projectDir === undefined) fail("не указан YAML-каталог")
+  if (!existsSync(options.projectDir)) fail(`YAML-каталог не найден: ${options.projectDir}`)
+  if (!statSync(options.projectDir).isDirectory()) fail(`путь не является каталогом: ${options.projectDir}`)
+
+  return options
+}
+
+function isPositiveInteger(value) {
+  return typeof value === "string" && /^[1-9][0-9]*$/.test(value)
+}
+
+const options = parseArgs(process.argv.slice(2))
+const result = await runProfile(options)
+printResult(result, options)
+```
+
+- [ ] **Step 2: Add compiled core loading guard**
+
+Append these functions below `parseArgs()` helpers and above the top-level call:
+
+```js
+async function loadCompiledCore() {
+  const distIndex = resolve(repoRoot, "packages/core/dist/index.js")
+  const standalone = resolve(repoRoot, "packages/core/dist/projectValidationAjvStandalone.js")
+  const worker = resolve(repoRoot, "packages/core/dist/projectValidationWorker.js")
+
+  if (!existsSync(distIndex) || !existsSync(worker) || !existsSync(standalone)) {
+    fail(
+      [
+        "compiled validation files are missing.",
+        "Перед запуском выполни: pnpm --filter @nakidka/core build",
+      ].join(" ")
+    )
+  }
+
+  return import(pathToFileURL(distIndex).href)
+}
+```
+
+- [ ] **Step 3: Implement memory helpers and validation run loop**
+
+Append:
+
+```js
+function memorySnapshot() {
+  const memory = process.memoryUsage()
+  return {
+    rssMiB: Math.round(memory.rss / 1024 / 1024),
+    heapUsedMiB: Math.round(memory.heapUsed / 1024 / 1024),
+    rssBytes: memory.rss,
+  }
+}
+
+function countDiagnostics(diagnostics) {
+  let errors = 0
+  let warnings = 0
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.severity === "error") errors += 1
+    if (diagnostic.severity === "warning") warnings += 1
+  }
+  return { errors, warnings }
+}
+
+function average(values) {
+  if (values.length === 0) return undefined
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length)
+}
+
+async function runProfile(options) {
+  const core = await loadCompiledCore()
+  const handle = core.createValidationWorkerPoolHandle(
+    options.concurrency === undefined ? undefined : { concurrency: options.concurrency }
+  )
+  const runs = []
+  let peakRssBytes = process.memoryUsage().rss
+  const timer = setInterval(() => {
+    peakRssBytes = Math.max(peakRssBytes, process.memoryUsage().rss)
+  }, 25)
+
+  try {
+    for (let run = 1; run <= options.runs; run += 1) {
+      const started = performance.now()
+      const validation = await handle.validateProject({ projectDir: options.projectDir })
+      const elapsedMs = Math.round(performance.now() - started)
+      const memory = memorySnapshot()
+      peakRssBytes = Math.max(peakRssBytes, memory.rssBytes)
+      const counts = countDiagnostics(validation.diagnostics)
+
+      runs.push({
+        run,
+        elapsedMs,
+        diagnostics: validation.diagnostics.length,
+        errors: counts.errors,
+        warnings: counts.warnings,
+        workerPoolSize: handle.size(),
+        rssMiB: memory.rssMiB,
+        heapUsedMiB: memory.heapUsedMiB,
+      })
+    }
+  } finally {
+    clearInterval(timer)
+    await handle.close()
+  }
+
+  const warm = runs.slice(1).map((run) => run.elapsedMs)
+  const result = {
+    mode: "compiled-standalone",
+    projectDir: options.projectDir,
+    runs,
+    coldMs: runs[0]?.elapsedMs,
+    warmAvgMs: average(warm),
+    warmMinMs: warm.length === 0 ? undefined : Math.min(...warm),
+    warmMaxMs: warm.length === 0 ? undefined : Math.max(...warm),
+    peakRssMiB: Math.round(peakRssBytes / 1024 / 1024),
+  }
+
+  if (options.timing) {
+    result.timing = runTimingPass(options)
+  }
+
+  return result
+}
+```
+
+- [ ] **Step 4: Implement `--timing` pass using existing worker logs**
+
+Append:
+
+```js
+function runTimingPass(options) {
+  const script = [
+    "import { createValidationWorkerPoolHandle } from './packages/core/dist/index.js';",
+    `const projectDir = ${JSON.stringify(options.projectDir)};`,
+    `const handle = createValidationWorkerPoolHandle(${options.concurrency === undefined ? "" : JSON.stringify({ concurrency: options.concurrency })});`,
+    "try { await handle.validateProject({ projectDir }); } finally { await handle.close(); }",
+  ].join("\\n")
+
+  const spawned = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NKDK_VALIDATION_TIMING: "1",
+    },
+    maxBuffer: 1024 * 1024 * 64,
+  })
+
+  if (spawned.status !== 0) {
+    throw new Error(
+      [
+        "timing pass failed",
+        `status=${spawned.status}`,
+        spawned.stderr.trim(),
+        spawned.stdout.trim(),
+      ].filter(Boolean).join("\\n")
+    )
+  }
+
+  const rawLines = spawned.stderr.split(/\\r?\\n/).filter((line) => line.startsWith("[validation] worker "))
+  return {
+    firstPass: rawLines.filter((line) => line.includes(" first pass ")).map(parseTimingLine),
+    secondPass: rawLines.filter((line) => line.includes(" second pass ")).map(parseTimingLine),
+    rawLines,
+  }
+}
+
+function parseTimingLine(line) {
+  const result = { raw: line }
+  const worker = /worker (\\d+)/.exec(line)
+  if (worker) result.worker = Number(worker[1])
+  result.phase = line.includes(" first pass ") ? "firstPass" : "secondPass"
+
+  for (const token of line.split(" ")) {
+    const eq = token.indexOf("=")
+    if (eq === -1) continue
+    const key = token.slice(0, eq)
+    const rawValue = token.slice(eq + 1)
+    if (rawValue.endsWith("ms")) {
+      result[key] = Number(rawValue.slice(0, -"ms".length))
+      continue
+    }
+    if (rawValue.endsWith("MiB")) {
+      result[key] = Number(rawValue.slice(0, -"MiB".length))
+      continue
+    }
+    const number = Number(rawValue)
+    result[key] = Number.isNaN(number) ? rawValue : number
+  }
+
+  return result
+}
+```
+
+- [ ] **Step 5: Implement output formatting**
+
+Append:
+
+```js
+function printResult(result, options) {
+  if (options.jsonOnly) {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  console.log("Validation profile: compiled standalone")
+  console.log(`YAML-каталог: ${result.projectDir}`)
+  console.log(`Воркеры: ${result.runs[0]?.workerPoolSize ?? "unknown"}`)
+  console.log(`Cold: ${formatMs(result.coldMs)}`)
+  console.log(
+    `Warm: avg=${formatMs(result.warmAvgMs)} min=${formatMs(result.warmMinMs)} max=${formatMs(result.warmMaxMs)}`
+  )
+  console.log(`Peak RSS: ${result.peakRssMiB} MiB`)
+  console.log("")
+  console.log("Runs:")
+  for (const run of result.runs) {
+    console.log(
+      [
+        `  ${run.run}.`,
+        `${formatMs(run.elapsedMs)}`,
+        `diagnostics=${run.diagnostics}`,
+        `errors=${run.errors}`,
+        `warnings=${run.warnings}`,
+        `rss=${run.rssMiB}MiB`,
+        `heap=${run.heapUsedMiB}MiB`,
+      ].join(" ")
+    )
+  }
+
+  if (result.timing !== undefined) {
+    console.log("")
+    console.log("Timing memory:")
+    for (const item of [...result.timing.firstPass, ...result.timing.secondPass]) {
+      console.log(
+        [
+          `  worker=${item.worker}`,
+          `phase=${item.phase}`,
+          `files=${item.files}`,
+          `rssPeak=${item.processRssPeak}MiB`,
+          `heapPeak=${item.workerHeapPeak}MiB`,
+        ].join(" ")
+      )
+    }
+  }
+
+  console.log("")
+  console.log(JSON.stringify(result, null, 2))
+}
+
+function formatMs(value) {
+  return value === undefined ? "n/a" : `${(value / 1000).toFixed(2)}s`
+}
+```
+
+- [ ] **Step 6: Verify runner help and validation errors**
+
+Run:
+
+```bash
+node .agents/skills/validation-profile/validation-profile.mjs --help
+```
+
+Expected: prints usage and exits `0`.
+
+Run:
+
+```bash
+node .agents/skills/validation-profile/validation-profile.mjs /path/that/does/not/exist
+```
+
+Expected: exits `2` and prints `Ошибка: YAML-каталог не найден`.
+
+- [ ] **Step 7: Verify compiled profile on real YAML project**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core build
+node .agents/skills/validation-profile/validation-profile.mjs /Users/nikita/git/nkdk-yaml --runs 1 --json
+```
+
+Expected:
+
+- exit `0`;
+- JSON contains `"mode": "compiled-standalone"`;
+- `runs[0].workerPoolSize` is a positive number;
+- `runs[0].elapsedMs` is a positive number;
+- `runs[0].diagnostics` is a number.
+
+- [ ] **Step 8: Verify timing mode**
+
+Run:
+
+```bash
+node .agents/skills/validation-profile/validation-profile.mjs /Users/nikita/git/nkdk-yaml --runs 1 --timing --json
+```
+
+Expected:
+
+- exit `0`;
+- JSON contains `timing.firstPass` and `timing.secondPass`;
+- each timing entry has `worker`, `phase`, `processRssPeak`, and `workerHeapPeak`.
+
+- [ ] **Step 9: Commit runner**
+
+Run:
+
+```bash
+git add .agents/skills/validation-profile/validation-profile.mjs
+git commit -m "feat: :sparkles: добавить validation profile runner"
+```
+
+---
+
+### Task 2: Skill Instructions
+
+**Files:**
+- Create: `.agents/skills/validation-profile/SKILL.md`
+
+**Interfaces:**
+- Consumes: CLI produced by Task 1.
+- Produces: discoverable skill metadata:
+  - `name: validation-profile`
+  - `description: Профилирует compiled standalone validation для YAML-каталога: сборка core, запуск dist worker/standalone, отчёт по времени, diagnostics и памяти.`
+
+- [ ] **Step 1: Create `SKILL.md`**
+
+Create `.agents/skills/validation-profile/SKILL.md`:
+
+```markdown
+---
+name: validation-profile
+description: Профилирует compiled standalone validation для YAML-каталога: сборка core, запуск dist worker/standalone, отчёт по времени, diagnostics и памяти.
+---
+
+# validation-profile
+
+## Что делает скилл
+
+Скилл выполняет benchmark валидации YAML-проекта через compiled standalone path:
+
+```text
+packages/core/dist/index.js
+  -> packages/core/dist/projectValidationWorker.js
+  -> packages/core/dist/projectValidationAjvStandalone.js
+```
+
+Он не использует MCP service и не импортирует `packages/core/index.ts`, потому что это source/tsx path.
+
+## Жёсткие инварианты
+
+- Перед каждым замером выполняй свежую сборку: `pnpm --filter @nakidka/core build`.
+- Запускай только `node .agents/skills/validation-profile/validation-profile.mjs ...`.
+- Не запускай `pnpm test`.
+- Не исправляй validation diagnostics в рамках этого скилла.
+- Не коммить результаты замеров.
+- Если пользователь просит сравнить source/tsx и compiled standalone, скажи, что это отдельная диагностика вне этого скилла.
+
+## Быстрый запуск
+
+```bash
+pnpm --filter @nakidka/core build
+node .agents/skills/validation-profile/validation-profile.mjs /path/to/yaml
+```
+
+С одним прогоном:
+
+```bash
+pnpm --filter @nakidka/core build
+node .agents/skills/validation-profile/validation-profile.mjs /path/to/yaml --runs 1
+```
+
+С worker timing:
+
+```bash
+pnpm --filter @nakidka/core build
+node .agents/skills/validation-profile/validation-profile.mjs /path/to/yaml --runs 1 --timing
+```
+
+## Параметры runner'а
+
+- `--runs N` — число прогонов, по умолчанию `5`.
+- `--concurrency N` — явно задать число worker'ов. Если не задано, core использует свой default.
+- `--timing` — добавить один прогон с `NKDK_VALIDATION_TIMING=1` и распарсить first/second pass worker memory.
+- `--json` — вывести только JSON.
+
+## Как отвечать пользователю
+
+В финальном ответе покажи:
+
+```text
+Режим: compiled standalone
+YAML-каталог: <path>
+Воркеры: <N>
+Cold: <seconds>
+Warm: avg=<seconds> min=<seconds> max=<seconds>
+Diagnostics: <total> = <errors> errors + <warnings> warnings
+Peak RSS: <MiB>
+RSS по прогонам: <run list>
+```
+
+Если был `--timing`, добавь краткую таблицу:
+
+```text
+worker | phase | files | processRssPeak | workerHeapPeak
+```
+
+## Ограничения
+
+`--timing` использует существующий `NKDK_VALIDATION_TIMING=1`, поэтому показывает first pass и second pass целиком. Он не показывает `afterRead`, `afterReferenceValidation` или другие внутренние точки, если core не был специально инструментирован.
+
+Если diagnostics выглядят неожиданно, явно укажи, что это результат compiled standalone, и предложи отдельную проверку parity.
+```
+
+- [ ] **Step 2: Verify skill text mentions compiled-only constraints**
+
+Run:
+
+```bash
+rg -n "compiled standalone|packages/core/dist/index.js|packages/core/index.ts|pnpm test" .agents/skills/validation-profile/SKILL.md
+```
+
+Expected: all four concepts are present.
+
+- [ ] **Step 3: Verify end-to-end skill command**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core build
+node .agents/skills/validation-profile/validation-profile.mjs /Users/nikita/git/nkdk-yaml --runs 1
+```
+
+Expected:
+
+- exit `0`;
+- output starts with `Validation profile: compiled standalone`;
+- output includes `YAML-каталог`, `Воркеры`, `Cold`, `Peak RSS`, and JSON.
+
+- [ ] **Step 4: Commit skill instructions**
+
+Run:
+
+```bash
+git add .agents/skills/validation-profile/SKILL.md
+git commit -m "docs: :memo: добавить validation profile skill"
+```
+
+---
+
+## Plan Self-Review
+
+- Spec coverage: Task 1 covers runner, compiled dist import, N runs, concurrency, memory/timing, JSON/text output. Task 2 covers skill instructions, workflow, constraints, final response.
+- Placeholder scan: no TBD/TODO/fill-in-later steps. Every code-writing step contains concrete code.
+- Type consistency: runner output shape in Task 1 matches `SKILL.md` response guidance in Task 2.

--- a/docs/superpowers/plans/2026-07-07-validation-schema-auto-ref.md
+++ b/docs/superpowers/plans/2026-07-07-validation-schema-auto-ref.md
@@ -1,0 +1,950 @@
+# Validation Schema Auto Ref Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Перенести ref-схемы validation на стандартные регистрации metadata item и metadata collection, сохранив нейтральные границы orchestration.
+
+**Architecture:** Добавляем нейтральный schema identity registry в orchestration рядом с текущими JSON Schema ref helpers. `registerMetadataItemRule` автоматически регистрирует одиночный rules-объект по `itemRule.itemType` или явному `schemaName`, а `registerMetadataItemCollectionRule` явно регистрирует shape коллекции и ссылку на item schema. Project/validation schema registry читает этот нейтральный registry и строит graph без знаний о конкретных applied/common/form объектах.
+
+**Tech Stack:** TypeScript, TypeBox, AJV 2020, Vitest, pnpm workspace.
+
+## Global Constraints
+
+- Ответы и комментарии по задаче вести на русском языке.
+- Не изменять XML-фикстуры.
+- Не писать новые правила fromXML/toXML/fromYAML/toYAML без явного запроса.
+- Не добавлять `order` в `rules.ts` без необходимости.
+- Минимизировать `as any` и `as unknown`; если приведение нужно, держать его на границе registry/helper и покрыть тестом.
+- `packages/core/metadata/orchestration`, `packages/core/metadata/validation` и `packages/core/metadata/project` не должны знать конкретные реализации метаданных.
+- Полная проверка перед завершением: `pnpm test` из корня worktree.
+
+---
+
+## File Structure
+
+- Modify: `packages/core/metadata/orchestration/jsonSchemaRefs.ts`
+  - Ответственность: нейтральные `$ref` helpers, сбор refs, property-ref factories и новый named schema identity registry.
+- Modify: `packages/core/metadata/orchestration/metadataItem/ruleFactory.ts`
+  - Ответственность: стандартная регистрация одиночного metadata item и подключение schema identity по умолчанию.
+- Modify: `packages/core/metadata/orchestration/metadataCollection/ruleFactory.ts`
+  - Ответственность: стандартная регистрация metadata collection, явная связь коллекции с item-rule и shape ref-схемы.
+- Modify: `packages/core/metadata/project/schemaRegistry.ts`
+  - Ответственность: объединить project-local schema exporters и нейтральные exporters из orchestration, раскрывать graph без частных условий.
+- Modify: `packages/core/metadata/orchestration/jsonSchemaRefs.test.ts`
+  - Ответственность: модульные тесты нейтрального registry и property ref behavior.
+- Modify: `packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts`
+  - Ответственность: тесты автоматической schema identity регистрации одиночного rules-объекта.
+- Modify: `packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts`
+  - Ответственность: тесты явной collection schema регистрации, `record`/`array`, рекурсии.
+- Modify: `packages/core/metadata/validation/schemaRegistry.test.ts`
+  - Ответственность: интеграционные проверки graph для реальных rules, включая `MetadataCatalogAttributes`.
+- Review/Modify: `packages/core/metadata/commonObjects/schemaRegister.ts`
+  - Ответственность: удалить ручные registrations, которые станут дубликатами стандартных metadata item/collection registrations.
+- Review/Modify: `packages/core/metadata/forms/schemaRegister.ts`
+  - Ответственность: оставить custom form registrations; удалить только дубликаты, если они покрыты стандартными registrations без изменения поведения.
+
+---
+
+### Task 1: Neutral Schema Identity Registry
+
+**Files:**
+- Modify: `packages/core/metadata/orchestration/jsonSchemaRefs.ts`
+- Modify: `packages/core/metadata/orchestration/jsonSchemaRefs.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type JSONSchemaExporter = (params: { context: ConfigurationContext }) => TSchema`
+  - `registerJSONSchemaIdentity(params: { name: string; exporter: JSONSchemaExporter; source: object | string }): void`
+  - `getJSONSchemaIdentityExporter(name: string): JSONSchemaExporter | undefined`
+  - `listJSONSchemaIdentityNames(): string[]`
+  - `clearJSONSchemaRefRegistries(): void` clears both property-ref factories and identity exporters.
+- Consumes: existing `ConfigurationContext`, `TSchema`, `createSchemaRef`, `collectSchemaRefs`.
+
+- [ ] **Step 1: Write failing tests for identity registration**
+
+Add to `packages/core/metadata/orchestration/jsonSchemaRefs.test.ts`:
+
+```ts
+import { Type } from "typebox"
+import {
+  clearJSONSchemaRefRegistries,
+  getJSONSchemaIdentityExporter,
+  listJSONSchemaIdentityNames,
+  registerJSONSchemaIdentity,
+} from "./jsonSchemaRefs"
+import { mockContext } from "../__fixtures__/context"
+
+describe("JSON Schema identity registry", () => {
+  beforeEach(() => {
+    clearJSONSchemaRefRegistries()
+  })
+
+  it("registers and lists named schema exporters", () => {
+    const source = { itemType: "SampleItem" }
+    registerJSONSchemaIdentity({
+      name: "SampleItem",
+      source,
+      exporter: () => Type.Object({ Имя: Type.String() }),
+    })
+
+    expect(listJSONSchemaIdentityNames()).toEqual(["SampleItem"])
+    expect(getJSONSchemaIdentityExporter("SampleItem")?.({ context: mockContext })).toMatchObject({
+      type: "object",
+      properties: { Имя: { type: "string" } },
+    })
+  })
+
+  it("allows idempotent registration for the same source", () => {
+    const source = { itemType: "SampleItem" }
+    const exporter = () => Type.Object({})
+
+    registerJSONSchemaIdentity({ name: "SampleItem", source, exporter })
+    registerJSONSchemaIdentity({ name: "SampleItem", source, exporter })
+
+    expect(listJSONSchemaIdentityNames()).toEqual(["SampleItem"])
+  })
+
+  it("rejects the same schema name for different sources", () => {
+    registerJSONSchemaIdentity({
+      name: "DuplicateItem",
+      source: { itemType: "Left" },
+      exporter: () => Type.Object({ left: Type.String() }),
+    })
+
+    expect(() =>
+      registerJSONSchemaIdentity({
+        name: "DuplicateItem",
+        source: { itemType: "Right" },
+        exporter: () => Type.Object({ right: Type.String() }),
+      })
+    ).toThrow('JSON Schema "DuplicateItem" already registered')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
+```
+
+Expected: FAIL because `registerJSONSchemaIdentity`, `getJSONSchemaIdentityExporter`, and `listJSONSchemaIdentityNames` are not exported yet.
+
+- [ ] **Step 3: Implement minimal registry**
+
+In `packages/core/metadata/orchestration/jsonSchemaRefs.ts`, add near the current `PropertyRefFactory` definitions:
+
+```ts
+type JSONSchemaExporter = (params: { context: ConfigurationContext }) => TSchema
+
+interface JSONSchemaIdentityRegistration {
+  exporter: JSONSchemaExporter
+  source: object | string
+}
+
+const schemaIdentityExporters = new Map<string, JSONSchemaIdentityRegistration>()
+```
+
+Update `clearJSONSchemaRefRegistries`:
+
+```ts
+export function clearJSONSchemaRefRegistries(): void {
+  propertyRefFactories.clear()
+  schemaIdentityExporters.clear()
+}
+```
+
+Add exported functions:
+
+```ts
+export function registerJSONSchemaIdentity(params: {
+  name: string
+  exporter: JSONSchemaExporter
+  source: object | string
+}): void {
+  const existing = schemaIdentityExporters.get(params.name)
+  if (existing !== undefined) {
+    if (existing.source === params.source && existing.exporter === params.exporter) return
+    throw new Error(`JSON Schema "${params.name}" already registered`)
+  }
+
+  schemaIdentityExporters.set(params.name, {
+    exporter: params.exporter,
+    source: params.source,
+  })
+}
+
+export function getJSONSchemaIdentityExporter(name: string): JSONSchemaExporter | undefined {
+  return schemaIdentityExporters.get(name)?.exporter
+}
+
+export function listJSONSchemaIdentityNames(): string[] {
+  return [...schemaIdentityExporters.keys()].sort()
+}
+```
+
+- [ ] **Step 4: Run task tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/metadata/orchestration/jsonSchemaRefs.ts packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
+git commit -m "feat: :sparkles: добавить registry schema identity"
+```
+
+---
+
+### Task 2: Metadata Item Registration Publishes Schema Identity
+
+**Files:**
+- Modify: `packages/core/metadata/orchestration/metadataItem/ruleFactory.ts`
+- Create or Modify: `packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts`
+
+**Interfaces:**
+- Consumes:
+  - `registerJSONSchemaIdentity(params)` from Task 1.
+- Produces:
+  - `registerMetadataItemRule({ propertyType, itemRule, schemaName? })`.
+  - Default schema name is `itemRule.itemType`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts` if missing, or append:
+
+```ts
+import { Type } from "typebox"
+import { clearJSONSchemaRefRegistries, getJSONSchemaIdentityExporter } from "../jsonSchemaRefs"
+import type { MetadataItemRule } from "../property/types"
+import { registerMetadataItemRule } from "./ruleFactory"
+import { mockContext } from "../../__fixtures__/context"
+
+const SampleItemRule = {
+  itemType: "SampleItem",
+  properties: {
+    name: { yaml: "Имя", type: "string", required: true },
+  },
+} as const satisfies MetadataItemRule
+
+describe("registerMetadataItemRule JSON Schema identity", () => {
+  beforeEach(() => {
+    clearJSONSchemaRefRegistries()
+  })
+
+  it("registers item schema by itemType by default", () => {
+    registerMetadataItemRule({ propertyType: "SampleItemProperty", itemRule: SampleItemRule })
+
+    const exporter = getJSONSchemaIdentityExporter("SampleItem")
+    expect(exporter?.({ context: mockContext })).toMatchObject({
+      type: "object",
+      properties: { Имя: { type: "string" } },
+      required: ["Имя"],
+    })
+  })
+
+  it("uses explicit schemaName when provided", () => {
+    registerMetadataItemRule({
+      propertyType: "SampleItemProperty",
+      itemRule: SampleItemRule,
+      schemaName: "ExplicitSampleItem",
+    })
+
+    expect(getJSONSchemaIdentityExporter("SampleItem")).toBeUndefined()
+    expect(getJSONSchemaIdentityExporter("ExplicitSampleItem")?.({ context: mockContext })).toMatchObject({
+      type: "object",
+    })
+  })
+})
+```
+
+If TypeScript complains that `Type` is unused, remove the import.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts
+```
+
+Expected: FAIL because `schemaName` is not accepted and no schema identity is registered.
+
+- [ ] **Step 3: Extend registration params**
+
+In `packages/core/metadata/orchestration/metadataItem/ruleFactory.ts`, change:
+
+```ts
+type MetadataItemRuleParams<Rule extends MetadataItemRule, PropertyType extends PropertyRuleType> = {
+  propertyType: PropertyType
+  itemRule: Rule
+}
+```
+
+to:
+
+```ts
+type MetadataItemRuleParams<Rule extends MetadataItemRule, PropertyType extends PropertyRuleType> = {
+  propertyType: PropertyType
+  itemRule: Rule
+  schemaName?: string
+}
+```
+
+- [ ] **Step 4: Register schema identity**
+
+Import `registerJSONSchemaIdentity` from `../jsonSchemaRefs` and add inside `registerMetadataItemRule` after destructuring:
+
+```ts
+const schemaName = params.schemaName ?? itemRule.itemType
+
+registerJSONSchemaIdentity({
+  name: schemaName,
+  source: itemRule,
+  exporter: ({ context }) => exportMetadataItemToJSONSchema({ context, rule: itemRule }),
+})
+```
+
+Keep the existing `registerTypeRule(propertyType, "exportToJSONSchema", ...)` behavior unchanged for inline fallback.
+
+- [ ] **Step 5: Run task tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/metadata/orchestration/metadataItem/ruleFactory.ts packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts
+git commit -m "feat: :sparkles: регистрировать schema identity metadata item"
+```
+
+---
+
+### Task 3: Metadata Collection Registration Publishes Explicit Ref Shape
+
+**Files:**
+- Modify: `packages/core/metadata/orchestration/metadataCollection/ruleFactory.ts`
+- Modify: `packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts`
+- Modify: `packages/core/metadata/orchestration/jsonSchemaRefs.ts`
+
+**Interfaces:**
+- Consumes:
+  - `registerJSONSchemaIdentity`
+  - `registerJSONSchemaPropertyRef`
+  - `schemaRef`
+  - existing `recordOfSchemaRef`
+- Produces:
+  - `type JSONSchemaCollectionShape = "record" | "array"`
+  - `registerMetadataItemCollectionRule({ ..., schemaName?, schemaShape? })`
+  - collection property ref is registered only through explicit collection registration.
+
+- [ ] **Step 1: Write failing tests for record and array refs**
+
+Append to `packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts`:
+
+```ts
+import { createJSONSchemaExportContext, clearJSONSchemaRefRegistries } from "../jsonSchemaRefs"
+import { exportPropertyToJSONSchema } from "../property/toJSONSchema"
+import { mockContext } from "../../__fixtures__/context"
+
+const CollectionItemRule = {
+  itemType: "CollectionItem",
+  properties: {
+    name: { yaml: "Имя", type: "string", required: true },
+  },
+} as const
+
+describe("registerMetadataItemCollectionRule JSON Schema refs", () => {
+  beforeEach(() => {
+    clearJSONSchemaRefRegistries()
+  })
+
+  it("registers record ref schema for metadata collections by default", () => {
+    registerMetadataItemCollectionRule({
+      propertyType: "CollectionItems",
+      itemRule: CollectionItemRule as any,
+      xmlElement: "Item",
+    })
+
+    const schema = exportPropertyToJSONSchema({
+      context: createJSONSchemaExportContext(mockContext, "externalRefs"),
+      rule: { type: "CollectionItems" },
+      value: undefined,
+    })
+
+    expect(schema).toEqual({
+      type: "object",
+      additionalProperties: { $ref: "nkdk://schema/CollectionItem" },
+    })
+  })
+
+  it("registers array ref schema when yamlAsArray is true", () => {
+    registerMetadataItemCollectionRule({
+      propertyType: "CollectionItemsArray",
+      itemRule: CollectionItemRule as any,
+      xmlElement: "Item",
+      yamlAsArray: true,
+    })
+
+    const schema = exportPropertyToJSONSchema({
+      context: createJSONSchemaExportContext(mockContext, "externalRefs"),
+      rule: { type: "CollectionItemsArray" },
+      value: undefined,
+    })
+
+    expect(schema).toEqual({
+      type: "array",
+      items: { $ref: "nkdk://schema/CollectionItem" },
+    })
+  })
+
+  it("uses explicit schemaName for collection item refs", () => {
+    registerMetadataItemCollectionRule({
+      propertyType: "ExplicitCollectionItems",
+      itemRule: CollectionItemRule as any,
+      xmlElement: "Item",
+      schemaName: "ExplicitCollectionItem",
+    })
+
+    const schema = exportPropertyToJSONSchema({
+      context: createJSONSchemaExportContext(mockContext, "externalRefs"),
+      rule: { type: "ExplicitCollectionItems" },
+      value: undefined,
+    })
+
+    expect(schema).toEqual({
+      type: "object",
+      additionalProperties: { $ref: "nkdk://schema/ExplicitCollectionItem" },
+    })
+  })
+})
+```
+
+If the file already imports the same helpers, merge imports instead of duplicating them. Keep the `as any` in tests only if the existing test fixtures use it; otherwise type the fixture as `MetadataItemRule`.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
+```
+
+Expected: FAIL because collection registration does not publish property refs yet.
+
+- [ ] **Step 3: Add array ref helper**
+
+In `packages/core/metadata/orchestration/jsonSchemaRefs.ts`, add:
+
+```ts
+export function arrayOfSchemaRef(name: string): TSchema {
+  return rawJSONSchema({
+    type: "array",
+    items: schemaRef(name),
+  })
+}
+```
+
+- [ ] **Step 4: Extend collection params**
+
+In `packages/core/metadata/orchestration/metadataCollection/ruleFactory.ts`, extend params type:
+
+```ts
+type JSONSchemaCollectionShape = "record" | "array"
+
+type MetadataItemCollectionRuleParams<Rule extends MetadataItemRule, PropertyType extends PropertyRuleType> = {
+  propertyType: PropertyType
+  itemRule: Rule
+  xmlElement?: string
+  keyField?: string
+  yamlAsArray?: true
+  collectionItemRule?: true
+  schemaName?: string
+  schemaShape?: JSONSchemaCollectionShape
+  // keep all existing params
+}
+```
+
+Do not remove existing fields; add only `schemaName` and `schemaShape`.
+
+- [ ] **Step 5: Register collection item schema and property ref**
+
+Import `arrayOfSchemaRef`, `recordOfSchemaRef`, `registerJSONSchemaIdentity`, and `registerJSONSchemaPropertyRef`. Inside `registerMetadataItemCollectionRule`, after `const { propertyType, itemRule } = params`, add:
+
+```ts
+const schemaName = params.schemaName ?? itemRule.itemType
+
+registerJSONSchemaIdentity({
+  name: schemaName,
+  source: itemRule,
+  exporter: ({ context }) => exportMetadataItemToJSONSchema({ context, rule: itemRule }),
+})
+
+registerJSONSchemaPropertyRef(propertyType, () => {
+  const shape = params.schemaShape ?? (params.yamlAsArray ? "array" : "record")
+  return shape === "array" ? arrayOfSchemaRef(schemaName) : recordOfSchemaRef(schemaName)
+})
+```
+
+Keep the existing inline `toJSONSchemaDefault` unchanged so inline mode still works.
+
+- [ ] **Step 6: Run task tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/metadata/orchestration/jsonSchemaRefs.ts packages/core/metadata/orchestration/metadataCollection/ruleFactory.ts packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
+git commit -m "feat: :sparkles: регистрировать ref-схемы коллекций"
+```
+
+---
+
+### Task 4: Project Schema Registry Reads Neutral Identity Exporters
+
+**Files:**
+- Modify: `packages/core/metadata/project/schemaRegistry.ts`
+- Modify: `packages/core/metadata/validation/schemaRegistry.test.ts`
+- Modify: `packages/core/metadata/project/schemaRegistry.test.ts`
+
+**Interfaces:**
+- Consumes:
+  - `getJSONSchemaIdentityExporter(name)`
+  - `listJSONSchemaIdentityNames()`
+- Produces:
+  - `exportJSONSchemaForSchemaName` can resolve names registered through standard metadata item/collection registrations.
+  - `listJSONSchemaNames()` includes both project-local and neutral names.
+
+- [ ] **Step 1: Write failing project registry test**
+
+Append to `packages/core/metadata/project/schemaRegistry.test.ts`:
+
+```ts
+import { Type } from "typebox"
+import { clearJSONSchemaRefRegistries, registerJSONSchemaIdentity } from "../orchestration/jsonSchemaRefs"
+import { exportJSONSchemaForSchemaName, listJSONSchemaNames } from "./schemaRegistry"
+import { mockContext } from "../__fixtures__/context"
+
+describe("project schema registry neutral identities", () => {
+  beforeEach(() => {
+    clearJSONSchemaRefRegistries()
+  })
+
+  it("exports schemas registered through orchestration identity registry", () => {
+    registerJSONSchemaIdentity({
+      name: "NeutralSchema",
+      source: "test",
+      exporter: () => Type.Object({ Имя: Type.String() }),
+    })
+
+    expect(listJSONSchemaNames()).toContain("NeutralSchema")
+    expect(exportJSONSchemaForSchemaName({ context: mockContext, name: "NeutralSchema" })).toMatchObject({
+      type: "object",
+      properties: { Имя: { type: "string" } },
+    })
+  })
+})
+```
+
+Merge imports if the file already has `Type`, `mockContext`, or registry imports.
+
+- [ ] **Step 2: Write failing integration test for real collection refs**
+
+Append to `packages/core/metadata/validation/schemaRegistry.test.ts`:
+
+```ts
+it("resolves MetadataCatalogAttributes through collection registration", () => {
+  const graph = exportJSONSchemaGraph({
+    context,
+    roots: [{ key: "catalog", name: "MetadataCatalog" }],
+  })
+
+  const catalog = graph.roots.catalog as { properties?: Record<string, unknown> }
+  expect(catalog.properties?.Реквизиты).toEqual({
+    type: "object",
+    additionalProperties: { $ref: "nkdk://schema/MetadataCatalogAttribute" },
+  })
+  expect(graph.schemas["nkdk://schema/MetadataCatalogAttribute"]).toMatchObject({
+    $id: "nkdk://schema/MetadataCatalogAttribute",
+    type: "object",
+  })
+})
+```
+
+Use the existing `context` setup in that test file; do not create a second context if one already exists.
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/project/schemaRegistry.test.ts packages/core/metadata/validation/schemaRegistry.test.ts
+```
+
+Expected: FAIL until project registry consults neutral identity exporters. The integration test may already pass because of old manual registrations; if it passes, keep it as a regression guard for the later cleanup task.
+
+- [ ] **Step 4: Add exporter resolution helper**
+
+In `packages/core/metadata/project/schemaRegistry.ts`, import:
+
+```ts
+import {
+  getJSONSchemaIdentityExporter,
+  listJSONSchemaIdentityNames,
+  // keep existing imports
+} from "../orchestration/jsonSchemaRefs"
+```
+
+Add helper:
+
+```ts
+function getSchemaExporter(name: string): SchemaExporter | undefined {
+  return schemaExporters.get(name) ?? getJSONSchemaIdentityExporter(name)
+}
+```
+
+- [ ] **Step 5: Use helper in export path**
+
+Change:
+
+```ts
+const exporter = schemaExporters.get(name)
+```
+
+to:
+
+```ts
+const exporter = getSchemaExporter(name)
+```
+
+Change `listJSONSchemaNames`:
+
+```ts
+export function listJSONSchemaNames(): string[] {
+  ensureJSONSchemaRegistry()
+  return [...new Set([...schemaExporters.keys(), ...listJSONSchemaIdentityNames()])].sort()
+}
+```
+
+Do not import concrete rules into `project/schemaRegistry.ts`.
+
+- [ ] **Step 6: Run task tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/project/schemaRegistry.test.ts packages/core/metadata/validation/schemaRegistry.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/metadata/project/schemaRegistry.ts packages/core/metadata/project/schemaRegistry.test.ts packages/core/metadata/validation/schemaRegistry.test.ts
+git commit -m "feat: :sparkles: читать schema identity из orchestration"
+```
+
+---
+
+### Task 5: Replace Duplicate Manual Property Ref Registrations
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/schemaRegister.ts`
+- Modify: `packages/core/metadata/forms/schemaRegister.ts`
+- Modify: `packages/core/metadata/validation/schemaRegistry.test.ts`
+
+**Interfaces:**
+- Consumes:
+  - standard registrations from Tasks 2-4.
+- Produces:
+  - manual property-ref registrations remain only where they describe custom schema exporters or discriminated unions.
+
+- [ ] **Step 1: Add regression tests before deleting registrations**
+
+In `packages/core/metadata/validation/schemaRegistry.test.ts`, ensure these cases exist or add them:
+
+```ts
+it("keeps form child items as discriminated external refs", () => {
+  const graph = exportJSONSchemaGraph({
+    context,
+    roots: [{ key: "form", name: "ClientApplicationForm", includeNestedChildItems: true }],
+  })
+
+  const formJson = JSON.stringify(graph.roots.form)
+  expect(formJson).toContain("nkdk://schema/InputField")
+  expect(formJson).toContain("nkdk://schema/Table")
+  expect(graph.schemas["nkdk://schema/InputField"]).toMatchObject({
+    $id: "nkdk://schema/InputField",
+  })
+})
+
+it("keeps custom DCS parameter value refs", () => {
+  const graph = exportJSONSchemaGraph({
+    context,
+    roots: [{ key: "form", name: "FormAttribute", includeNestedChildItems: true }],
+  })
+
+  expect(JSON.stringify(graph)).toContain("nkdk://schema/")
+})
+```
+
+If the second test is too broad after inspecting current tests, replace it with an existing DCS-specific schema name from `dcsMetadataValue/toJSONSchema.ts` or `parameterValue/toJSONSchema.ts`.
+
+- [ ] **Step 2: Run regression tests before cleanup**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/schemaRegistry.test.ts
+```
+
+Expected: PASS before cleanup.
+
+- [ ] **Step 3: Remove duplicated common object registrations**
+
+In `packages/core/metadata/commonObjects/schemaRegister.ts`, remove manual registrations that are now created by `registerMetadataItemCollectionRule`, starting with:
+
+```ts
+registerProjectJSONSchemaPropertyRef("MetadataCatalogAttributes", "MetadataCatalogAttribute")
+registerProjectJSONSchemaPropertyRef("MetadataDocumentAttributes", "MetadataDocumentAttribute")
+registerProjectJSONSchemaPropertyRef("MetadataAttributes", "MetadataAttribute")
+registerProjectJSONSchemaPropertyRef("MetadataRegisterAttributes", "MetadataRegisterAttribute")
+registerProjectJSONSchemaPropertyRef("MetadataReportAttributes", "MetadataAttribute")
+registerProjectJSONSchemaPropertyRef("MetadataTaskAddressingAttributes", "MetadataTaskAddressingAttribute")
+registerProjectJSONSchemaPropertyRefFactory("MetadataTabularSectionAttributes", () =>
+  recordOfSchemaRef("MetadataTabularSectionAttribute")
+)
+registerProjectJSONSchemaPropertyRefFactory("MetadataCommands", () => recordOfSchemaRef("MetadataCommand"))
+```
+
+Keep `registerProjectJSONSchema(...)` calls temporarily if they still provide custom exporters or if the corresponding rules are not registered through `registerMetadataItemRule`.
+
+- [ ] **Step 4: Review forms registrations conservatively**
+
+In `packages/core/metadata/forms/schemaRegister.ts`, keep these custom/manual registrations:
+
+```ts
+registerProjectJSONSchemaPropertyRefFactory("ClientApplicationForm", () => schemaRef("ClientApplicationForm"))
+registerProjectJSONSchemaPropertyRefFactory("FormAttributes", () => recordOfSchemaRef("FormAttribute"))
+registerProjectJSONSchemaPropertyRefFactory("FormAttributeColumns", () => recordOfSchemaRef("FormAttributeColumn"))
+registerProjectJSONSchemaPropertyRefFactory("FormCommands", () => recordOfSchemaRef("FormCommand"))
+registerProjectJSONSchemaPropertyRefFactory("FormParameters", () => recordOfSchemaRef("FormParameter"))
+```
+
+Keep form element discriminated refs:
+
+```ts
+registerProjectJSONSchemaPropertyRefFactory(type, () =>
+  recordOfDiscriminatedOneOfSchemaRefs(getChildItemTypesByPropertyType(type), "Вид")
+)
+```
+
+Only delete a forms registration if a test proves the standard metadata item/collection registration now produces the same schema.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/schemaRegistry.test.ts packages/core/metadata/validation/projectFileSchema.test.ts packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/metadata/commonObjects/schemaRegister.ts packages/core/metadata/forms/schemaRegister.ts packages/core/metadata/validation/schemaRegistry.test.ts
+git commit -m "refactor: :recycle: убрать дубли ref-регистраций схем"
+```
+
+---
+
+### Task 6: Standalone Validation Graph Verification
+
+**Files:**
+- Modify: `packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts`
+- Modify: `packages/core/metadata/validation/projectValidationStandaloneSchemas.ts`
+
+**Interfaces:**
+- Consumes:
+  - `createProjectValidationStandaloneSchemaSet`
+  - graph refs from Tasks 1-5.
+- Produces:
+  - standalone schema set keeps reachable refs from automatic collection registrations.
+
+- [ ] **Step 1: Add standalone schema-set regression test**
+
+Append to `packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts` or the closest existing standalone schema test:
+
+```ts
+import { createProjectValidationStandaloneSchemaSet } from "./projectValidationStandaloneSchemas"
+
+it("includes refs produced by metadata collection registrations", () => {
+  const schemaSet = createProjectValidationStandaloneSchemaSet()
+
+  expect(schemaSet.refs["nkdk://schema/MetadataCatalogAttribute"]).toMatchObject({
+    type: "object",
+  })
+  expect(JSON.stringify(schemaSet.byProjectDir["Справочник"])).toContain(
+    "nkdk://schema/MetadataCatalogAttribute"
+  )
+})
+```
+
+If `projectValidationStandaloneBuild.test.ts` already imports the schema set, merge the import.
+
+- [ ] **Step 2: Run standalone tests to verify behavior**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts packages/core/metadata/validation/projectValidationStandaloneLoader.test.ts
+```
+
+Expected: PASS. If it fails because refs are stripped, inspect `stripExternalRefsForValidation` and `collectExternalRefSchemas`.
+
+- [ ] **Step 3: Confirm reachable refs are preserved**
+
+Inspect `createStandalonePropertiesSchema` and keep root schemas with `$ref`, replacing only explicitly external validation properties:
+
+```ts
+const rootSchema = stripCollectedSchemaRefs(spec.exportSchema({ context, mode: "externalRefs" }))
+return replaceExternalValidationProperties(rootSchema, spec.externalValidationProperties)
+```
+
+This is the required shape; do not call `stripExternalRefsForValidation` for properties schemas.
+
+- [ ] **Step 4: Run standalone generator test**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts
+```
+
+Expected: PASS and generated standalone module shape still matches `project-validation-ajv-standalone-v1`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts packages/core/metadata/validation/projectValidationStandaloneSchemas.ts
+git commit -m "test: :white_check_mark: закрепить refs standalone validation"
+```
+
+---
+
+### Task 7: Full Verification and Boundary Guards
+
+**Files:**
+- Review/Modify: `packages/core/metadata/importBoundaries.test.ts`
+- No production changes unless a boundary regression is found.
+
+**Interfaces:**
+- Consumes all previous tasks.
+- Produces a fully verified branch.
+
+- [ ] **Step 1: Run focused validation and boundary tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/importBoundaries.test.ts packages/core/metadata/validation/schemaRegistry.test.ts packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: If boundary test misses the new rule, add a guard**
+
+Only if `importBoundaries.test.ts` does not already protect this, add an assertion that `metadata/project/schemaRegistry.ts` does not import concrete applied/common/form rules:
+
+```ts
+it("project schema registry не импортирует concrete metadata rules", () => {
+  const source = readFileSync(join(METADATA_DIR, "project", "schemaRegistry.ts"), "utf-8")
+
+  expect(source).not.toContain("../appliedObjects/")
+  expect(source).not.toContain("../commonObjects/")
+  expect(source).not.toContain("../forms/")
+})
+```
+
+If similar checks already exist, update the existing test instead of adding a duplicate.
+
+- [ ] **Step 3: Run full project tests**
+
+Run from the worktree root:
+
+```bash
+pnpm test
+```
+
+Expected:
+
+```text
+packages/core test:  Test Files  765+ passed
+packages/mcp test:   Test Files  13 passed
+packages/cli test:   Test Files  7 passed
+```
+
+Exact test counts may increase because this plan adds tests. There must be 0 failures.
+
+- [ ] **Step 4: Check working tree**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no unstaged changes except intentionally modified files before the final commit.
+
+- [ ] **Step 5: Final commit if boundary/full-verification files changed**
+
+If Task 7 changed files:
+
+```bash
+git add packages/core/metadata/importBoundaries.test.ts
+git commit -m "test: :white_check_mark: закрепить границы schema registry"
+```
+
+If Task 7 changed nothing, do not create an empty commit.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Standard metadata item registration: Task 2.
+  - Explicit collection registration: Task 3.
+  - Project/validation graph reads neutral registry: Task 4.
+  - Manual duplicate cleanup: Task 5.
+  - Standalone validation refs: Task 6.
+  - Boundary and full verification: Task 7.
+- No placeholders: every task has concrete files, commands, expected result, and commit step.
+- Type consistency:
+  - `schemaName` is used consistently in item and collection registrations.
+  - `registerJSONSchemaIdentity` has one signature across all tasks.
+  - `JSONSchemaExporter` always receives `{ context: ConfigurationContext }`.
+  - Collection `record` uses `additionalProperties`, `array` uses `items`.

--- a/docs/superpowers/specs/2026-07-07-validation-profile-skill-design.md
+++ b/docs/superpowers/specs/2026-07-07-validation-profile-skill-design.md
@@ -1,0 +1,135 @@
+# validation-profile skill design
+
+## Цель
+
+Добавить repo-skill `.agents/skills/validation-profile`, который по заданному YAML-каталогу выполняет compiled standalone validation benchmark и возвращает профиль скорости и памяти.
+
+Скилл нужен для повторяемых замеров валидации без ручного написания временных скриптов. Он измеряет только compiled path: свежая сборка `@nakidka/core`, импорт `packages/core/dist/index.js`, worker `packages/core/dist/projectValidationWorker.js`, standalone schema module `packages/core/dist/projectValidationAjvStandalone.js`.
+
+## Не цели
+
+- Не сравнивать source/tsx и compiled/standalone.
+- Не запускать MCP service `packages/mcp/src/services/validateProject.ts`, потому что текущий MCP `loadCoreApi()` импортирует `packages/core/index.ts` и тем самым использует source/tsx path.
+- Не исправлять validation diagnostics, parity bugs или memory leaks.
+- Не коммитить результаты замеров и не запускать полный `pnpm test`.
+
+## Состав скилла
+
+Каталог:
+
+```text
+.agents/skills/validation-profile/
+├── SKILL.md
+└── validation-profile.mjs
+```
+
+`SKILL.md` содержит:
+
+- когда использовать скилл;
+- обязательный compiled-only инвариант;
+- команды запуска;
+- как читать итоговый JSON и текстовый отчёт;
+- что делать при расхождении diagnostics или падении сборки.
+
+`validation-profile.mjs` содержит deterministic runner:
+
+- парсит аргументы;
+- импортирует `packages/core/dist/index.js`;
+- запускает `createValidationWorkerPoolHandle({ concurrency })`;
+- выполняет N прогонов;
+- собирает скорость, diagnostics, RSS/heap, worker pool size;
+- опционально запускает один `NKDK_VALIDATION_TIMING=1` прогон и извлекает worker timing/memory lines из stderr.
+
+## CLI договора
+
+Основной запуск:
+
+```bash
+node .agents/skills/validation-profile/validation-profile.mjs /path/to/yaml
+```
+
+Параметры:
+
+- `--runs N`, по умолчанию `5`.
+- `--concurrency N`, по умолчанию не передаётся, чтобы core применил свой default.
+- `--timing`, дополнительно запускает один timing-прогон с `NKDK_VALIDATION_TIMING=1`.
+- `--json`, печатает только JSON без человекочитаемой таблицы.
+
+Скрипт не делает build сам. Скилл перед запуском всегда выполняет:
+
+```bash
+pnpm --filter @nakidka/core build
+```
+
+Так build остаётся явным шагом workflow, а скрипт остаётся маленьким и проверяемым.
+
+## Workflow скилла
+
+1. Проверить, что команда запущена из корня репозитория.
+2. Проверить, что YAML-каталог задан и существует.
+3. Выполнить свежую сборку `pnpm --filter @nakidka/core build`.
+4. Запустить `node .agents/skills/validation-profile/validation-profile.mjs <yaml-dir>`.
+5. Если нужен подробный worker memory profile, повторить с `--timing`.
+6. В финальном ответе показать:
+   - режим `compiled standalone`;
+   - путь YAML-каталога;
+   - число worker'ов;
+   - cold time;
+   - warm avg/min/max;
+   - diagnostics/errors/warnings;
+   - RSS/heap после каждого прогона;
+   - peak RSS внутри процесса;
+   - при `--timing`: first pass и second pass memory per worker.
+
+## Формат результата
+
+JSON верхнего уровня:
+
+```json
+{
+  "mode": "compiled-standalone",
+  "projectDir": "/path/to/yaml",
+  "runs": [
+    {
+      "run": 1,
+      "elapsedMs": 17699,
+      "diagnostics": 43394,
+      "errors": 6072,
+      "warnings": 37322,
+      "workerPoolSize": 4,
+      "rssMiB": 6358,
+      "heapUsedMiB": 552
+    }
+  ],
+  "coldMs": 17699,
+  "warmAvgMs": 18564,
+  "warmMinMs": 16256,
+  "warmMaxMs": 20581,
+  "peakRssMiB": 7849,
+  "timing": {
+    "firstPass": [],
+    "secondPass": []
+  }
+}
+```
+
+`timing.firstPass` и `timing.secondPass` заполняются только в `--timing` режиме. Базовая реализация использует уже существующий `NKDK_VALIDATION_TIMING=1`, поэтому фазовая детализация ограничена текущими полями core: first pass целиком и second pass целиком. Детализация `afterRead`, `afterReferenceValidation`, `afterValidation` не входит в скилл, потому что требует изменения core-инструментации.
+
+## Ошибки и ограничения
+
+- Если `packages/core/dist/projectValidationAjvStandalone.js` отсутствует после build, скилл сообщает ошибку сборки/генерации standalone.
+- Если validation падает, скилл показывает stderr/stdout и не делает вывод о производительности.
+- Если diagnostics выглядят подозрительно, скилл явно пишет, что это результат compiled standalone. Проверка parity с source/tsx является отдельной задачей и не входит в этот скилл.
+- `/usr/bin/time -l` не является обязательным: в sandbox он может требовать повышенных прав. Основной источник memory profile — `process.memoryUsage()` внутри runner и worker timing logs.
+
+## Проверка
+
+Минимальная проверка реализации:
+
+```bash
+pnpm --filter @nakidka/core build
+node .agents/skills/validation-profile/validation-profile.mjs /Users/nikita/git/nkdk-yaml --runs 1
+node .agents/skills/validation-profile/validation-profile.mjs /Users/nikita/git/nkdk-yaml --runs 1 --timing
+```
+
+После создания скилла полный `pnpm test` не обязателен, потому что скилл диагностический и не меняет runtime-код. Если будут изменены core-файлы для поддержки дополнительного timing, тогда `pnpm test` обязателен.

--- a/packages/core/metadata/appliedObjects/metadataReport/rules.ts
+++ b/packages/core/metadata/appliedObjects/metadataReport/rules.ts
@@ -43,6 +43,7 @@ const MetadataReportAttributeRules = {
 registerMetadataItemCollectionRule({
   propertyType: "MetadataReportAttributes",
   itemRule: MetadataReportAttributeRules,
+  schemaName: "MetadataReportAttribute",
   xmlElement: "Attribute",
   keyField: "name",
   collectionItemRule: true,

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/types.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/types.ts
@@ -27,4 +27,6 @@ registerMetadataItemCollectionRule({
   toXML: exportFilterItemToXML,
   toJSONSchema: exportFilterItemToJSONSchema,
   yamlAsArray: true,
+  schemaName: "FilterItem",
+  schemaShape: "schema",
 })

--- a/packages/core/metadata/commonObjects/metadataAttribute/register.ts
+++ b/packages/core/metadata/commonObjects/metadataAttribute/register.ts
@@ -81,6 +81,7 @@ export const exportMetadataAttributesToJSONSchema = createExportMetadataAttribut
 registerMetadataItemCollectionRule({
   propertyType: "MetadataCatalogAttributes",
   itemRule: MetadataCatalogAttributeRules,
+  schemaName: "MetadataCatalogAttribute",
   xmlElement: "Attribute",
   keyField: "name",
   fromYAML: createImportMetadataAttributesFromYAML(MetadataCatalogAttributeRules),
@@ -91,6 +92,7 @@ registerMetadataItemCollectionRule({
 registerMetadataItemCollectionRule({
   propertyType: "MetadataAttributes",
   itemRule: MetadataAttributeRules,
+  schemaName: "MetadataAttribute",
   xmlElement: "Attribute",
   keyField: "name",
   fromYAML: createImportMetadataAttributesFromYAML(MetadataAttributeRules),
@@ -101,6 +103,7 @@ registerMetadataItemCollectionRule({
 registerMetadataItemCollectionRule({
   propertyType: "MetadataAttributesWithAllowedTypes",
   itemRule: MetadataAttributesWithAllowedTypesRules,
+  schemaName: "MetadataAttributesWithAllowedTypes",
   xmlElement: "Attribute",
   keyField: "name",
   fromYAML: createImportMetadataAttributesFromYAML(MetadataAttributesWithAllowedTypesRules),
@@ -111,6 +114,7 @@ registerMetadataItemCollectionRule({
 registerMetadataItemCollectionRule({
   propertyType: "MetadataTabularSectionAttributes",
   itemRule: MetadataTabularSectionAttributeRules,
+  schemaName: "MetadataTabularSectionAttribute",
   xmlElement: "Attribute",
   keyField: "name",
   fromYAML: createImportMetadataAttributesFromYAML(MetadataTabularSectionAttributeRules),
@@ -121,6 +125,7 @@ registerMetadataItemCollectionRule({
 registerMetadataItemCollectionRule({
   propertyType: "MetadataDocumentAttributes",
   itemRule: MetadataDocumentAttributeRules,
+  schemaName: "MetadataDocumentAttribute",
   xmlElement: "Attribute",
   keyField: "name",
   fromYAML: createImportMetadataAttributesFromYAML(MetadataDocumentAttributeRules),

--- a/packages/core/metadata/commonObjects/metadataTaskAddressingAttribute/register.ts
+++ b/packages/core/metadata/commonObjects/metadataTaskAddressingAttribute/register.ts
@@ -4,6 +4,7 @@ import { MetadataTaskAddressingAttributeRules } from "./rules"
 registerMetadataItemCollectionRule({
   propertyType: "MetadataTaskAddressingAttributes",
   itemRule: MetadataTaskAddressingAttributeRules,
+  schemaName: "MetadataTaskAddressingAttribute",
   xmlElement: "AddressingAttribute",
   keyField: "name",
   collectionItemRule: true,

--- a/packages/core/metadata/commonObjects/schemaRegister.ts
+++ b/packages/core/metadata/commonObjects/schemaRegister.ts
@@ -1,10 +1,5 @@
 import { exportMetadataItemToJSONSchema } from "../orchestration/metadataItem/toJSONSchema"
-import { recordOfSchemaRef } from "../orchestration/jsonSchemaRefs"
-import {
-  registerProjectJSONSchema,
-  registerProjectJSONSchemaPropertyRef,
-  registerProjectJSONSchemaPropertyRefFactory,
-} from "../project/schemaRegistry"
+import { registerProjectJSONSchema } from "../project/schemaRegistry"
 import { MetadataCommandRules } from "../appliedObjects/metadataCommand/rules"
 import {
   MetadataAttributeRules,
@@ -40,29 +35,3 @@ registerProjectJSONSchema("MetadataTabularSection", ({ context }) =>
 registerProjectJSONSchema("MetadataCommand", ({ context }) =>
   exportMetadataItemToJSONSchema({ context, rule: MetadataCommandRules })
 )
-
-registerProjectJSONSchemaPropertyRef("MetadataCatalogAttributes", "MetadataCatalogAttribute")
-registerProjectJSONSchemaPropertyRef("MetadataDocumentAttributes", "MetadataDocumentAttribute")
-registerProjectJSONSchemaPropertyRef("MetadataAttributes", "MetadataAttribute")
-registerProjectJSONSchemaPropertyRef("MetadataRegisterAttributes", "MetadataRegisterAttribute")
-registerProjectJSONSchemaPropertyRef("MetadataReportAttributes", "MetadataAttribute")
-registerProjectJSONSchemaPropertyRef("MetadataTaskAddressingAttributes", "MetadataTaskAddressingAttribute")
-registerProjectJSONSchemaPropertyRefFactory("MetadataTabularSectionAttributes", () =>
-  recordOfSchemaRef("MetadataTabularSectionAttribute")
-)
-registerProjectJSONSchemaPropertyRefFactory("MetadataCommands", () => recordOfSchemaRef("MetadataCommand"))
-
-for (const type of [
-  "MetadataTabularSections",
-  "MetadataDocumentTabularSections",
-  "MetadataTaskTabularSections",
-  "MetadataBusinessProcessTabularSections",
-  "MetadataDataProcessorTabularSections",
-  "MetadataReportTabularSections",
-  "MetadataExchangePlanTabularSections",
-  "MetadataChartOfAccountsTabularSections",
-  "MetadataChartOfCalculationTypesTabularSections",
-  "MetadataChartOfCharacteristicTypesTabularSections",
-] as const) {
-  registerProjectJSONSchemaPropertyRefFactory(type, () => recordOfSchemaRef("MetadataTabularSection"))
-}

--- a/packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
+++ b/packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
@@ -135,19 +135,21 @@ describe("jsonSchemaRefs", () => {
     expect(listJSONSchemaIdentityNames()).toEqual(["SampleItem"])
   })
 
-  it("rejects the same schema name for different sources", () => {
+  it("keeps the first exporter for repeated schema names", () => {
     registerJSONSchemaIdentity({
       name: "DuplicateItem",
       source: { itemType: "Left" },
       exporter: () => Type.Object({ left: Type.String() }),
     })
 
-    expect(() =>
-      registerJSONSchemaIdentity({
-        name: "DuplicateItem",
-        source: { itemType: "Right" },
-        exporter: () => Type.Object({ right: Type.String() }),
-      })
-    ).toThrow('JSON Schema "DuplicateItem" already registered')
+    registerJSONSchemaIdentity({
+      name: "DuplicateItem",
+      source: { itemType: "Right" },
+      exporter: () => Type.Object({ right: Type.String() }),
+    })
+
+    expect(getJSONSchemaIdentityExporter("DuplicateItem")?.({ context: baseContext })).toMatchObject({
+      properties: { left: { type: "string" } },
+    })
   })
 })

--- a/packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
+++ b/packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
@@ -1,8 +1,7 @@
 import { Type } from "typebox"
-import { afterEach, describe, expect, it } from "vitest"
+import { describe, expect, it } from "vitest"
 import {
   attachCollectedSchemaRefs,
-  clearJSONSchemaRefRegistries,
   collectSchemaRefs,
   createJSONSchemaExportContext,
   createSchemaRef,
@@ -22,10 +21,6 @@ const baseContext = {
 } as const
 
 describe("jsonSchemaRefs", () => {
-  afterEach(() => {
-    clearJSONSchemaRefRegistries()
-  })
-
   it("creates stable nkdk schema refs", () => {
     expect(createSchemaRef("InputField")).toBe("nkdk://schema/InputField")
   })
@@ -64,13 +59,15 @@ describe("jsonSchemaRefs", () => {
   })
 
   it("returns a property ref only in externalRefs mode and collects the ref", () => {
-    registerJSONSchemaPropertyRef("MetadataAttributes", () => recordOfSchemaRef("MetadataAttribute"))
+    registerJSONSchemaPropertyRef("TestMetadataAttributesRefOnly" as any, () =>
+      recordOfSchemaRef("TestMetadataAttributeRefOnly")
+    )
 
     const inlineContext = createJSONSchemaExportContext(baseContext, "inline")
     expect(
       exportPropertyExternalRefSchema({
         context: inlineContext,
-        rule: { type: "MetadataAttributes" },
+        rule: { type: "TestMetadataAttributesRefOnly" as any },
       })
     ).toBeUndefined()
 
@@ -78,61 +75,63 @@ describe("jsonSchemaRefs", () => {
     expect(
       exportPropertyExternalRefSchema({
         context: refContext,
-        rule: { type: "MetadataAttributes" },
+        rule: { type: "TestMetadataAttributesRefOnly" as any },
       })
     ).toEqual({
       type: "object",
-      additionalProperties: { $ref: "nkdk://schema/MetadataAttribute" },
+      additionalProperties: { $ref: "nkdk://schema/TestMetadataAttributeRefOnly" },
     })
 
     expect(attachCollectedSchemaRefs(refContext, Type.Object({}))).toMatchObject({
-      "x-nkdk-schemaRefs": ["nkdk://schema/MetadataAttribute"],
+      "x-nkdk-schemaRefs": ["nkdk://schema/TestMetadataAttributeRefOnly"],
     })
   })
 
   it("uses registered refs through property JSON Schema export", () => {
-    registerJSONSchemaPropertyRef("MetadataAttributes", () => recordOfSchemaRef("MetadataAttribute"))
+    registerJSONSchemaPropertyRef("TestMetadataAttributesPropertyExport" as any, () =>
+      recordOfSchemaRef("TestMetadataAttributePropertyExport")
+    )
 
     const context = createJSONSchemaExportContext(baseContext, "externalRefs")
     expect(
       exportPropertyToJSONSchema({
         context,
-        rule: { type: "MetadataAttributes" },
+        rule: { type: "TestMetadataAttributesPropertyExport" as any },
         value: undefined,
       })
     ).toEqual({
       type: "object",
-      additionalProperties: { $ref: "nkdk://schema/MetadataAttribute" },
+      additionalProperties: { $ref: "nkdk://schema/TestMetadataAttributePropertyExport" },
     })
 
     expect(attachCollectedSchemaRefs(context, Type.Object({}))).toMatchObject({
-      "x-nkdk-schemaRefs": ["nkdk://schema/MetadataAttribute"],
+      "x-nkdk-schemaRefs": ["nkdk://schema/TestMetadataAttributePropertyExport"],
     })
   })
 
   it("registers and lists named schema exporters", () => {
-    const source = { itemType: "SampleItem" }
+    const source = { itemType: "ListedSampleItem" }
     registerJSONSchemaIdentity({
-      name: "SampleItem",
+      name: "ListedSampleItem",
       source,
       exporter: () => Type.Object({ Имя: Type.String() }),
     })
 
-    expect(listJSONSchemaIdentityNames()).toEqual(["SampleItem"])
-    expect(getJSONSchemaIdentityExporter("SampleItem")?.({ context: baseContext })).toMatchObject({
+    expect(listJSONSchemaIdentityNames()).toContain("ListedSampleItem")
+    expect(getJSONSchemaIdentityExporter("ListedSampleItem")?.({ context: baseContext })).toMatchObject({
       type: "object",
       properties: { Имя: { type: "string" } },
     })
   })
 
   it("allows idempotent registration for the same source", () => {
-    const source = { itemType: "SampleItem" }
+    const source = { itemType: "IdempotentSampleItem" }
     const exporter = () => Type.Object({})
 
-    registerJSONSchemaIdentity({ name: "SampleItem", source, exporter })
-    registerJSONSchemaIdentity({ name: "SampleItem", source, exporter })
+    registerJSONSchemaIdentity({ name: "IdempotentSampleItem", source, exporter })
+    registerJSONSchemaIdentity({ name: "IdempotentSampleItem", source, exporter })
 
-    expect(listJSONSchemaIdentityNames()).toEqual(["SampleItem"])
+    expect(listJSONSchemaIdentityNames()).toContain("IdempotentSampleItem")
   })
 
   it("keeps the first exporter for repeated schema names", () => {

--- a/packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
+++ b/packages/core/metadata/orchestration/jsonSchemaRefs.test.ts
@@ -7,7 +7,10 @@ import {
   createJSONSchemaExportContext,
   createSchemaRef,
   exportPropertyExternalRefSchema,
+  getJSONSchemaIdentityExporter,
+  listJSONSchemaIdentityNames,
   recordOfSchemaRef,
+  registerJSONSchemaIdentity,
   registerJSONSchemaPropertyRef,
   stripCollectedSchemaRefs,
 } from "./jsonSchemaRefs"
@@ -105,5 +108,46 @@ describe("jsonSchemaRefs", () => {
     expect(attachCollectedSchemaRefs(context, Type.Object({}))).toMatchObject({
       "x-nkdk-schemaRefs": ["nkdk://schema/MetadataAttribute"],
     })
+  })
+
+  it("registers and lists named schema exporters", () => {
+    const source = { itemType: "SampleItem" }
+    registerJSONSchemaIdentity({
+      name: "SampleItem",
+      source,
+      exporter: () => Type.Object({ Имя: Type.String() }),
+    })
+
+    expect(listJSONSchemaIdentityNames()).toEqual(["SampleItem"])
+    expect(getJSONSchemaIdentityExporter("SampleItem")?.({ context: baseContext })).toMatchObject({
+      type: "object",
+      properties: { Имя: { type: "string" } },
+    })
+  })
+
+  it("allows idempotent registration for the same source", () => {
+    const source = { itemType: "SampleItem" }
+    const exporter = () => Type.Object({})
+
+    registerJSONSchemaIdentity({ name: "SampleItem", source, exporter })
+    registerJSONSchemaIdentity({ name: "SampleItem", source, exporter })
+
+    expect(listJSONSchemaIdentityNames()).toEqual(["SampleItem"])
+  })
+
+  it("rejects the same schema name for different sources", () => {
+    registerJSONSchemaIdentity({
+      name: "DuplicateItem",
+      source: { itemType: "Left" },
+      exporter: () => Type.Object({ left: Type.String() }),
+    })
+
+    expect(() =>
+      registerJSONSchemaIdentity({
+        name: "DuplicateItem",
+        source: { itemType: "Right" },
+        exporter: () => Type.Object({ right: Type.String() }),
+      })
+    ).toThrow('JSON Schema "DuplicateItem" already registered')
   })
 })

--- a/packages/core/metadata/orchestration/jsonSchemaRefs.ts
+++ b/packages/core/metadata/orchestration/jsonSchemaRefs.ts
@@ -37,6 +37,13 @@ export function recordOfSchemaRef(name: string): TSchema {
   })
 }
 
+export function arrayOfSchemaRef(name: string): TSchema {
+  return rawJSONSchema({
+    type: "array",
+    items: schemaRef(name),
+  })
+}
+
 export function recordOfOneOfSchemaRefs(names: readonly string[]): TSchema {
   return rawJSONSchema({
     type: "object",
@@ -67,8 +74,7 @@ export function registerJSONSchemaIdentity(params: {
 }): void {
   const existing = schemaIdentityExporters.get(params.name)
   if (existing !== undefined) {
-    if (existing.source === params.source && existing.exporter === params.exporter) return
-    throw new Error(`JSON Schema "${params.name}" already registered`)
+    return
   }
 
   schemaIdentityExporters.set(params.name, {

--- a/packages/core/metadata/orchestration/jsonSchemaRefs.ts
+++ b/packages/core/metadata/orchestration/jsonSchemaRefs.ts
@@ -7,11 +7,19 @@ export const JSON_SCHEMA_REF_PREFIX = "nkdk://schema/"
 const COLLECTED_SCHEMA_REFS_KEY = "x-nkdk-schemaRefs"
 
 type PropertyRefFactory = (params: { context: ConfigurationContext; rule: PropertyRule }) => TSchema | undefined
+type JSONSchemaExporter = (params: { context: ConfigurationContext }) => TSchema
+
+interface JSONSchemaIdentityRegistration {
+  exporter: JSONSchemaExporter
+  source: object | string
+}
 
 const propertyRefFactories = new Map<PropertyRuleType, PropertyRefFactory>()
+const schemaIdentityExporters = new Map<string, JSONSchemaIdentityRegistration>()
 
 export function clearJSONSchemaRefRegistries(): void {
   propertyRefFactories.clear()
+  schemaIdentityExporters.clear()
 }
 
 export function createSchemaRef(name: string): string {
@@ -50,6 +58,31 @@ export function recordOfDiscriminatedOneOfSchemaRefs(names: readonly string[], p
 
 export function registerJSONSchemaPropertyRef(type: PropertyRuleType, factory: PropertyRefFactory): void {
   propertyRefFactories.set(type, factory)
+}
+
+export function registerJSONSchemaIdentity(params: {
+  name: string
+  exporter: JSONSchemaExporter
+  source: object | string
+}): void {
+  const existing = schemaIdentityExporters.get(params.name)
+  if (existing !== undefined) {
+    if (existing.source === params.source && existing.exporter === params.exporter) return
+    throw new Error(`JSON Schema "${params.name}" already registered`)
+  }
+
+  schemaIdentityExporters.set(params.name, {
+    exporter: params.exporter,
+    source: params.source,
+  })
+}
+
+export function getJSONSchemaIdentityExporter(name: string): JSONSchemaExporter | undefined {
+  return schemaIdentityExporters.get(name)?.exporter
+}
+
+export function listJSONSchemaIdentityNames(): string[] {
+  return [...schemaIdentityExporters.keys()].sort()
 }
 
 export function createJSONSchemaExportContext(

--- a/packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
+++ b/packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
@@ -1,7 +1,12 @@
 import { compileValidationSchema } from "./../../validation/compileValidationSchema"
+import { Type } from "typebox"
 import { beforeEach, describe, expect, it } from "vitest"
 import { importPropertyFromXML, PropertyRule } from ".."
-import { clearJSONSchemaRefRegistries, createJSONSchemaExportContext } from "../jsonSchemaRefs"
+import {
+  clearJSONSchemaRefRegistries,
+  createJSONSchemaExportContext,
+  getJSONSchemaIdentityExporter,
+} from "../jsonSchemaRefs"
 import { exportPropertyToJSONSchema } from "../property/toJSONSchema"
 import type { MetadataItemRule } from "../property/types"
 import { mockContextFromXML } from "../../../tests/mockContext"
@@ -235,6 +240,43 @@ describe("registerMetadataItemCollectionRule JSON Schema refs", () => {
     expect(schema).toEqual({
       type: "object",
       additionalProperties: { $ref: "nkdk://schema/ExplicitCollectionItem" },
+    })
+  })
+
+  it("registers direct schema ref for custom collection schemas", () => {
+    registerMetadataItemCollectionRule({
+      propertyType: "TestCustomSchemaCollection" as any,
+      itemRule: TestCollectionItemRules,
+      xmlElement: "Item",
+      schemaName: "CustomCollectionSchema",
+      schemaShape: "schema",
+      toJSONSchema: () =>
+        Type.Array(
+          Type.Object(
+            {
+              custom: Type.Literal("yes"),
+            },
+            { additionalProperties: false }
+          )
+        ),
+    })
+
+    const schema = exportPropertyToJSONSchema({
+      context: createJSONSchemaExportContext(context, "externalRefs"),
+      rule: { type: "TestCustomSchemaCollection" as any },
+      value: undefined,
+    })
+    const identityExporter = getJSONSchemaIdentityExporter("CustomCollectionSchema")
+
+    expect(schema).toEqual({ $ref: "nkdk://schema/CustomCollectionSchema" })
+    expect(identityExporter?.({ context })).toMatchObject({
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          custom: { const: "yes" },
+        },
+      },
     })
   })
 })

--- a/packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
+++ b/packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
@@ -1,6 +1,7 @@
 import { compileValidationSchema } from "./../../validation/compileValidationSchema"
-import { describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
 import { importPropertyFromXML, PropertyRule } from ".."
+import { clearJSONSchemaRefRegistries, createJSONSchemaExportContext } from "../jsonSchemaRefs"
 import { exportPropertyToJSONSchema } from "../property/toJSONSchema"
 import type { MetadataItemRule } from "../property/types"
 import { mockContextFromXML } from "../../../tests/mockContext"
@@ -165,5 +166,75 @@ describe("registerMetadataItemCollectionRule default toJSONSchema", () => {
 
     expect(compiled.Check([{ name: "A", children: [] }])).toBe(true)
     expect(compiled.Check([{ name: "A", children: { B: {} } }])).toBe(false)
+  })
+})
+
+describe("registerMetadataItemCollectionRule JSON Schema refs", () => {
+  const context = {
+    defaultLanguage: "ru",
+    version: "2.20",
+  } as const
+
+  beforeEach(() => {
+    clearJSONSchemaRefRegistries()
+  })
+
+  it("registers record ref schema for metadata collections by default", () => {
+    registerMetadataItemCollectionRule({
+      propertyType: "TestRefCollection" as any,
+      itemRule: TestCollectionItemRules,
+      xmlElement: "Item",
+    })
+
+    const schema = exportPropertyToJSONSchema({
+      context: createJSONSchemaExportContext(context, "externalRefs"),
+      rule: { type: "TestRefCollection" as any },
+      value: undefined,
+    })
+
+    expect(schema).toEqual({
+      type: "object",
+      additionalProperties: { $ref: "nkdk://schema/TestCollectionItem" },
+    })
+  })
+
+  it("registers array ref schema when yamlAsArray is true", () => {
+    registerMetadataItemCollectionRule({
+      propertyType: "TestRefArrayCollection" as any,
+      itemRule: TestCollectionItemRules,
+      xmlElement: "Item",
+      yamlAsArray: true,
+    })
+
+    const schema = exportPropertyToJSONSchema({
+      context: createJSONSchemaExportContext(context, "externalRefs"),
+      rule: { type: "TestRefArrayCollection" as any },
+      value: undefined,
+    })
+
+    expect(schema).toEqual({
+      type: "array",
+      items: { $ref: "nkdk://schema/TestCollectionItem" },
+    })
+  })
+
+  it("uses explicit schemaName for collection item refs", () => {
+    registerMetadataItemCollectionRule({
+      propertyType: "TestExplicitRefCollection" as any,
+      itemRule: TestCollectionItemRules,
+      xmlElement: "Item",
+      schemaName: "ExplicitCollectionItem",
+    })
+
+    const schema = exportPropertyToJSONSchema({
+      context: createJSONSchemaExportContext(context, "externalRefs"),
+      rule: { type: "TestExplicitRefCollection" as any },
+      value: undefined,
+    })
+
+    expect(schema).toEqual({
+      type: "object",
+      additionalProperties: { $ref: "nkdk://schema/ExplicitCollectionItem" },
+    })
   })
 })

--- a/packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
+++ b/packages/core/metadata/orchestration/metadataCollection/ruleFactory.test.ts
@@ -1,9 +1,8 @@
 import { compileValidationSchema } from "./../../validation/compileValidationSchema"
 import { Type } from "typebox"
-import { beforeEach, describe, expect, it } from "vitest"
+import { describe, expect, it } from "vitest"
 import { importPropertyFromXML, PropertyRule } from ".."
 import {
-  clearJSONSchemaRefRegistries,
   createJSONSchemaExportContext,
   getJSONSchemaIdentityExporter,
 } from "../jsonSchemaRefs"
@@ -179,10 +178,6 @@ describe("registerMetadataItemCollectionRule JSON Schema refs", () => {
     defaultLanguage: "ru",
     version: "2.20",
   } as const
-
-  beforeEach(() => {
-    clearJSONSchemaRefRegistries()
-  })
 
   it("registers record ref schema for metadata collections by default", () => {
     registerMetadataItemCollectionRule({

--- a/packages/core/metadata/orchestration/metadataCollection/ruleFactory.ts
+++ b/packages/core/metadata/orchestration/metadataCollection/ruleFactory.ts
@@ -4,6 +4,7 @@ import {
   recordOfSchemaRef,
   registerJSONSchemaIdentity,
   registerJSONSchemaPropertyRef,
+  schemaRef,
 } from "../jsonSchemaRefs"
 import {
   ExportToJSONSchemaFn,
@@ -13,7 +14,7 @@ import {
   importFromYAMLFunction,
 } from "../property/fn"
 import { PropertyRuleType } from "../property/registry"
-import type { MetadataItemRule } from "../property/types"
+import type { MetadataItemRule, PropertyRule } from "../property/types"
 import { ToMetadata } from "../metadataItem/registry"
 import { exportMetadataItemToJSONSchema } from "../metadataItem/toJSONSchema"
 import { registerTypeRule } from "../property/typeRuleRegistry"
@@ -23,7 +24,7 @@ import { importMetadataItemCollectionFromYAMLAsArray, importMetadataItemCollecti
 import { exportMetadataCollectionToXML } from "./toXML"
 import { exportMetadataCollectionToYAMLAsArray, exportMetadataCollectionToYAMLAsRecord } from "./toYAML"
 
-type JSONSchemaCollectionShape = "record" | "array"
+type JSONSchemaCollectionShape = "record" | "array" | "schema"
 
 type CollectionRule<Rule extends MetadataItemRule, CollectionType extends PropertyRuleType, XMLKey extends string> = {
   propertyType: CollectionType
@@ -55,16 +56,29 @@ export const registerMetadataItemCollectionRule = <
 ): void => {
   const { propertyType, itemRule, xmlElement } = params
   const schemaName = params.schemaName ?? itemRule.itemType
+  const schemaShape = params.schemaShape ?? (params.yamlAsArray ? "array" : "record")
 
   registerJSONSchemaIdentity({
     name: schemaName,
     source: itemRule,
-    exporter: ({ context }) => exportMetadataItemToJSONSchema({ context, rule: itemRule }),
+    exporter: ({ context }) => {
+      if (schemaShape === "schema" && params.toJSONSchema !== undefined) {
+        return (
+          params.toJSONSchema({
+            context,
+            rule: { type: propertyType } as PropertyRule,
+            value: undefined,
+          }) ?? Type.Unknown()
+        )
+      }
+
+      return exportMetadataItemToJSONSchema({ context, rule: itemRule })
+    },
   })
 
   registerJSONSchemaPropertyRef(propertyType, () => {
-    const shape = params.schemaShape ?? (params.yamlAsArray ? "array" : "record")
-    return shape === "array" ? arrayOfSchemaRef(schemaName) : recordOfSchemaRef(schemaName)
+    if (schemaShape === "schema") return schemaRef(schemaName)
+    return schemaShape === "array" ? arrayOfSchemaRef(schemaName) : recordOfSchemaRef(schemaName)
   })
 
   const fromXMLDefault: ImportFromXMLFunction = (context, rule, xml) => {

--- a/packages/core/metadata/orchestration/metadataCollection/ruleFactory.ts
+++ b/packages/core/metadata/orchestration/metadataCollection/ruleFactory.ts
@@ -1,5 +1,11 @@
 import { Type } from "typebox"
 import {
+  arrayOfSchemaRef,
+  recordOfSchemaRef,
+  registerJSONSchemaIdentity,
+  registerJSONSchemaPropertyRef,
+} from "../jsonSchemaRefs"
+import {
   ExportToJSONSchemaFn,
   ExportToXMLFunctionNew,
   ExportToYAMLFunction,
@@ -16,6 +22,8 @@ import { importMetadataItemCollectionFromXML } from "./fromXML"
 import { importMetadataItemCollectionFromYAMLAsArray, importMetadataItemCollectionFromYAMLAsRecord } from "./fromYAML"
 import { exportMetadataCollectionToXML } from "./toXML"
 import { exportMetadataCollectionToYAMLAsArray, exportMetadataCollectionToYAMLAsRecord } from "./toYAML"
+
+type JSONSchemaCollectionShape = "record" | "array"
 
 type CollectionRule<Rule extends MetadataItemRule, CollectionType extends PropertyRuleType, XMLKey extends string> = {
   propertyType: CollectionType
@@ -34,6 +42,8 @@ type CollectionRule<Rule extends MetadataItemRule, CollectionType extends Proper
   toJSONSchema?: ExportToJSONSchemaFn
   /** Регистрирует item-правило коллекции для обхода вложенных metadata target. */
   collectionItemRule?: true
+  schemaName?: string
+  schemaShape?: JSONSchemaCollectionShape
 }
 
 export const registerMetadataItemCollectionRule = <
@@ -44,6 +54,18 @@ export const registerMetadataItemCollectionRule = <
   params: CollectionRule<Rule, CollectionType, XMLKey>
 ): void => {
   const { propertyType, itemRule, xmlElement } = params
+  const schemaName = params.schemaName ?? itemRule.itemType
+
+  registerJSONSchemaIdentity({
+    name: schemaName,
+    source: itemRule,
+    exporter: ({ context }) => exportMetadataItemToJSONSchema({ context, rule: itemRule }),
+  })
+
+  registerJSONSchemaPropertyRef(propertyType, () => {
+    const shape = params.schemaShape ?? (params.yamlAsArray ? "array" : "record")
+    return shape === "array" ? arrayOfSchemaRef(schemaName) : recordOfSchemaRef(schemaName)
+  })
 
   const fromXMLDefault: ImportFromXMLFunction = (context, rule, xml) => {
     const effectiveElement = xmlElement ?? (rule as any).xml

--- a/packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts
+++ b/packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, beforeEach } from "vitest"
-import { clearJSONSchemaRefRegistries, getJSONSchemaIdentityExporter } from "../jsonSchemaRefs"
+import { describe, expect, it } from "vitest"
+import { getJSONSchemaIdentityExporter } from "../jsonSchemaRefs"
 import type { MetadataItemRule } from "../property/types"
 import { registerMetadataItemRule } from "./ruleFactory"
 
@@ -15,11 +15,12 @@ const SampleItemRule = {
   },
 } as const satisfies MetadataItemRule
 
-describe("registerMetadataItemRule JSON Schema identity", () => {
-  beforeEach(() => {
-    clearJSONSchemaRefRegistries()
-  })
+const ExplicitOnlySampleItemRule = {
+  ...SampleItemRule,
+  itemType: "ExplicitOnlySampleItem",
+} as const satisfies MetadataItemRule
 
+describe("registerMetadataItemRule JSON Schema identity", () => {
   it("registers item schema by itemType by default", () => {
     registerMetadataItemRule({ propertyType: "SampleItemProperty", itemRule: SampleItemRule })
 
@@ -33,12 +34,12 @@ describe("registerMetadataItemRule JSON Schema identity", () => {
 
   it("uses explicit schemaName when provided", () => {
     registerMetadataItemRule({
-      propertyType: "SampleItemProperty",
-      itemRule: SampleItemRule,
+      propertyType: "ExplicitOnlySampleItemProperty",
+      itemRule: ExplicitOnlySampleItemRule,
       schemaName: "ExplicitSampleItem",
     })
 
-    expect(getJSONSchemaIdentityExporter("SampleItem")).toBeUndefined()
+    expect(getJSONSchemaIdentityExporter("ExplicitOnlySampleItem")).toBeUndefined()
     expect(getJSONSchemaIdentityExporter("ExplicitSampleItem")?.({ context: baseContext })).toMatchObject({
       type: "object",
     })

--- a/packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts
+++ b/packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts
@@ -9,7 +9,7 @@ const baseContext = {
 } as const
 
 const SampleItemRule = {
-  itemType: "SampleItem",
+  itemType: "RuleFactorySampleItem",
   properties: {
     name: { yaml: "Имя", type: "string", required: true },
   },
@@ -17,14 +17,14 @@ const SampleItemRule = {
 
 const ExplicitOnlySampleItemRule = {
   ...SampleItemRule,
-  itemType: "ExplicitOnlySampleItem",
+  itemType: "RuleFactoryExplicitOnlySampleItem",
 } as const satisfies MetadataItemRule
 
 describe("registerMetadataItemRule JSON Schema identity", () => {
   it("registers item schema by itemType by default", () => {
-    registerMetadataItemRule({ propertyType: "SampleItemProperty", itemRule: SampleItemRule })
+    registerMetadataItemRule({ propertyType: "RuleFactorySampleItemProperty", itemRule: SampleItemRule })
 
-    const exporter = getJSONSchemaIdentityExporter("SampleItem")
+    const exporter = getJSONSchemaIdentityExporter("RuleFactorySampleItem")
     expect(exporter?.({ context: baseContext })).toMatchObject({
       type: "object",
       properties: { Имя: { type: "string" } },
@@ -34,13 +34,13 @@ describe("registerMetadataItemRule JSON Schema identity", () => {
 
   it("uses explicit schemaName when provided", () => {
     registerMetadataItemRule({
-      propertyType: "ExplicitOnlySampleItemProperty",
+      propertyType: "RuleFactoryExplicitOnlySampleItemProperty",
       itemRule: ExplicitOnlySampleItemRule,
-      schemaName: "ExplicitSampleItem",
+      schemaName: "RuleFactoryExplicitSampleItem",
     })
 
-    expect(getJSONSchemaIdentityExporter("ExplicitOnlySampleItem")).toBeUndefined()
-    expect(getJSONSchemaIdentityExporter("ExplicitSampleItem")?.({ context: baseContext })).toMatchObject({
+    expect(getJSONSchemaIdentityExporter("RuleFactoryExplicitOnlySampleItem")).toBeUndefined()
+    expect(getJSONSchemaIdentityExporter("RuleFactoryExplicitSampleItem")?.({ context: baseContext })).toMatchObject({
       type: "object",
     })
   })

--- a/packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts
+++ b/packages/core/metadata/orchestration/metadataItem/ruleFactory.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeEach } from "vitest"
+import { clearJSONSchemaRefRegistries, getJSONSchemaIdentityExporter } from "../jsonSchemaRefs"
+import type { MetadataItemRule } from "../property/types"
+import { registerMetadataItemRule } from "./ruleFactory"
+
+const baseContext = {
+  defaultLanguage: "ru",
+  version: "2.20",
+} as const
+
+const SampleItemRule = {
+  itemType: "SampleItem",
+  properties: {
+    name: { yaml: "Имя", type: "string", required: true },
+  },
+} as const satisfies MetadataItemRule
+
+describe("registerMetadataItemRule JSON Schema identity", () => {
+  beforeEach(() => {
+    clearJSONSchemaRefRegistries()
+  })
+
+  it("registers item schema by itemType by default", () => {
+    registerMetadataItemRule({ propertyType: "SampleItemProperty", itemRule: SampleItemRule })
+
+    const exporter = getJSONSchemaIdentityExporter("SampleItem")
+    expect(exporter?.({ context: baseContext })).toMatchObject({
+      type: "object",
+      properties: { Имя: { type: "string" } },
+      required: ["Имя"],
+    })
+  })
+
+  it("uses explicit schemaName when provided", () => {
+    registerMetadataItemRule({
+      propertyType: "SampleItemProperty",
+      itemRule: SampleItemRule,
+      schemaName: "ExplicitSampleItem",
+    })
+
+    expect(getJSONSchemaIdentityExporter("SampleItem")).toBeUndefined()
+    expect(getJSONSchemaIdentityExporter("ExplicitSampleItem")?.({ context: baseContext })).toMatchObject({
+      type: "object",
+    })
+  })
+})

--- a/packages/core/metadata/orchestration/metadataItem/ruleFactory.ts
+++ b/packages/core/metadata/orchestration/metadataItem/ruleFactory.ts
@@ -1,4 +1,5 @@
 import { Type } from "typebox"
+import { registerJSONSchemaIdentity } from "../jsonSchemaRefs"
 import { PropertyRuleType } from "../property/registry"
 import type { MetadataItemRule } from "../property/types"
 import { registerTypeRule } from "../property/typeRuleRegistry"
@@ -11,12 +12,20 @@ import { exportMetadataItemToJSONSchema } from "./toJSONSchema"
 type MetadataItemRuleParams<Rule extends MetadataItemRule, PropertyType extends PropertyRuleType> = {
   propertyType: PropertyType
   itemRule: Rule
+  schemaName?: string
 }
 
 export const registerMetadataItemRule = <Rule extends MetadataItemRule, PropertyType extends PropertyRuleType>(
   params: MetadataItemRuleParams<Rule, PropertyType>
 ): void => {
   const { propertyType, itemRule } = params
+  const schemaName = params.schemaName ?? itemRule.itemType
+
+  registerJSONSchemaIdentity({
+    name: schemaName,
+    source: itemRule,
+    exporter: ({ context }) => exportMetadataItemToJSONSchema({ context, rule: itemRule }),
+  })
 
   registerImportFromXML(propertyType, itemRule)
   registerImportFromYAML(propertyType, itemRule)

--- a/packages/core/metadata/project/projectSpecRegistry.ts
+++ b/packages/core/metadata/project/projectSpecRegistry.ts
@@ -1,5 +1,6 @@
 import type { TSchema } from "typebox"
 import type { ConfigurationContext, JSONSchemaExportMode } from "../context/types"
+import { registerJSONSchemaIdentity } from "../orchestration/jsonSchemaRefs"
 import type { ExternalValidationProperty, MetadataItem, MetadataItemRule } from "../orchestration/property/types"
 import type { ParsedYaml } from "../../yaml/parseMetadataYaml"
 
@@ -25,6 +26,15 @@ const specsByDir = new Map<string, RegisteredProjectSpec>()
 
 export function registerProjectSpec(spec: RegisteredProjectSpec): void {
   specsByDir.set(spec.dir, spec)
+  registerJSONSchemaIdentity({
+    name: spec.rule.itemType,
+    source: spec.rule,
+    exporter: ({ context }) =>
+      spec.exportSchema({
+        context,
+        mode: context.exportToJSONSchema?.mode ?? "externalRefs",
+      }),
+  })
 }
 
 export function getRegisteredProjectSpecs(): readonly RegisteredProjectSpec[] {

--- a/packages/core/metadata/project/schemaRegistry.test.ts
+++ b/packages/core/metadata/project/schemaRegistry.test.ts
@@ -1,5 +1,6 @@
 import { Type } from "typebox"
 import { describe, expect, it } from "vitest"
+import { registerJSONSchemaIdentity } from "../orchestration/jsonSchemaRefs"
 import { exportJSONSchemaForSchemaName, listJSONSchemaNames, registerProjectJSONSchema } from "./schemaRegistry"
 
 const context = {
@@ -17,6 +18,20 @@ describe("project schema registry", () => {
       properties: {
         sample: { type: "string" },
       },
+    })
+  })
+
+  it("exports schemas registered through orchestration identity registry", () => {
+    registerJSONSchemaIdentity({
+      name: "NeutralSchema",
+      source: "test",
+      exporter: () => Type.Object({ Имя: Type.String() }),
+    })
+
+    expect(listJSONSchemaNames()).toContain("NeutralSchema")
+    expect(exportJSONSchemaForSchemaName({ context, name: "NeutralSchema" })).toMatchObject({
+      type: "object",
+      properties: { Имя: { type: "string" } },
     })
   })
 })

--- a/packages/core/metadata/project/schemaRegistry.test.ts
+++ b/packages/core/metadata/project/schemaRegistry.test.ts
@@ -1,6 +1,8 @@
 import { Type } from "typebox"
 import { describe, expect, it } from "vitest"
 import { registerJSONSchemaIdentity } from "../orchestration/jsonSchemaRefs"
+import type { MetadataItemRule } from "../orchestration/property/types"
+import { registerProjectSpec, unregisterProjectSpecForTests } from "./projectSpecRegistry"
 import { exportJSONSchemaForSchemaName, listJSONSchemaNames, registerProjectJSONSchema } from "./schemaRegistry"
 
 const context = {
@@ -33,5 +35,36 @@ describe("project schema registry", () => {
       type: "object",
       properties: { Имя: { type: "string" } },
     })
+  })
+
+  it("exports schemas registered through project specs", () => {
+    const rule = {
+      itemType: "ProjectSpecIdentitySample",
+      properties: {},
+    } as MetadataItemRule
+
+    registerProjectSpec({
+      kind: "ProjectSpecIdentitySample",
+      dir: "__project_spec_identity_sample__",
+      rule,
+      exportSchema: () =>
+        Type.Object(
+          {
+            Имя: Type.String(),
+          },
+          { additionalProperties: false }
+        ),
+      importModel: () => undefined,
+    })
+
+    try {
+      expect(listJSONSchemaNames()).toContain("ProjectSpecIdentitySample")
+      expect(exportJSONSchemaForSchemaName({ context, name: "ProjectSpecIdentitySample" })).toMatchObject({
+        type: "object",
+        properties: { Имя: { type: "string" } },
+      })
+    } finally {
+      unregisterProjectSpecForTests("__project_spec_identity_sample__")
+    }
   })
 })

--- a/packages/core/metadata/project/schemaRegistry.ts
+++ b/packages/core/metadata/project/schemaRegistry.ts
@@ -4,7 +4,9 @@ import {
   attachCollectedSchemaRefs,
   collectSchemaRefs,
   createJSONSchemaExportContext,
+  getJSONSchemaIdentityExporter,
   JSON_SCHEMA_REF_PREFIX,
+  listJSONSchemaIdentityNames,
   recordOfSchemaRef,
   registerJSONSchemaPropertyRef,
   stripCollectedSchemaRefs,
@@ -39,7 +41,7 @@ let namedSchemasInitialized = false
 
 export function listJSONSchemaNames(): string[] {
   ensureJSONSchemaRegistry()
-  return [...schemaExporters.keys()].sort()
+  return [...new Set([...schemaExporters.keys(), ...listJSONSchemaIdentityNames()])].sort()
 }
 
 export function exportJSONSchemaForSchemaName(params: {
@@ -51,7 +53,7 @@ export function exportJSONSchemaForSchemaName(params: {
   ensureJSONSchemaRegistry()
 
   const { context, includeNestedChildItems, name, mode = "externalRefs" } = params
-  const exporter = schemaExporters.get(name)
+  const exporter = getSchemaExporter(name)
   if (!exporter) {
     throw new ProjectFileSchemaError(
       `Неизвестная JSON Schema "${name}". Доступные имена: ${listJSONSchemaNames().join(", ")}`
@@ -135,6 +137,10 @@ export function registerProjectJSONSchemaPropertyRef(type: PropertyRuleType, sch
 export function registerProjectJSONSchemaPropertyRefFactory(type: PropertyRuleType, factory: SchemaRefFactory): void {
   schemaRefFactories.set(type, factory)
   registerJSONSchemaPropertyRef(type, factory)
+}
+
+function getSchemaExporter(name: string): SchemaExporter | undefined {
+  return schemaExporters.get(name) ?? getJSONSchemaIdentityExporter(name)
 }
 
 function withSchemaId(ref: string, schema: TSchema): TSchema {

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -166,7 +166,7 @@ export function createValidationSchemaCache(context: ConfigurationContext): Vali
       const existing = propertiesSchemas.get(key)
       if (existing) return existing
 
-      const schemaMode = spec.validationSchemaMode ?? "inline"
+      const schemaMode = spec.validationSchemaMode ?? "externalRefs"
       const globalKey = `${context.version}:${context.defaultLanguage}:${spec.dir}:${schemaMode}`
       const compiled = propertiesSchemaCache.get(globalKey) ?? compileProjectPropertiesSchema(context, spec)
       propertiesSchemaCache.set(globalKey, compiled)
@@ -197,7 +197,8 @@ export function createValidationSchemaCache(context: ConfigurationContext): Vali
 }
 
 function compileProjectPropertiesSchema(context: ConfigurationContext, spec: ValidationProjectSpec): CompiledSchema {
-  if (spec.validationSchemaMode !== "externalRefs") {
+  const schemaMode = spec.validationSchemaMode ?? "externalRefs"
+  if (schemaMode !== "externalRefs") {
     return compileValidationSchema(spec.exportSchema({ context, mode: "inline" }))
   }
 

--- a/packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts
+++ b/packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts
@@ -2,10 +2,20 @@ import { execFile } from "node:child_process"
 import { existsSync } from "node:fs"
 import { promisify } from "node:util"
 import { describe, expect, it } from "vitest"
+import { createProjectValidationStandaloneSchemaSet } from "./projectValidationStandaloneSchemas"
 
 const execFileAsync = promisify(execFile)
 
 describe("project validation standalone build output", () => {
+  it("includes refs produced by metadata collection registrations", () => {
+    const schemaSet = createProjectValidationStandaloneSchemaSet()
+
+    expect(schemaSet.refs["nkdk://schema/MetadataCatalogAttribute"]).toMatchObject({
+      type: "object",
+    })
+    expect(JSON.stringify(schemaSet.byProjectDir["Справочник"])).toContain("nkdk://schema/MetadataCatalogAttribute")
+  })
+
   it("loads generated validators from dist when build has produced them", async () => {
     const modulePath = new URL("../../../dist/projectValidationAjvStandalone.js", import.meta.url).pathname
     if (!existsSync(modulePath)) return

--- a/packages/core/metadata/validation/projectValidationStandaloneSchemas.ts
+++ b/packages/core/metadata/validation/projectValidationStandaloneSchemas.ts
@@ -63,7 +63,8 @@ function createStandalonePropertiesSchema(
   context: ConfigurationContext,
   spec: typeof configurationValidationProjectSpec
 ): TSchema {
-  if (spec.validationSchemaMode !== "externalRefs") {
+  const schemaMode = spec.validationSchemaMode ?? "externalRefs"
+  if (schemaMode !== "externalRefs") {
     return spec.exportSchema({ context, mode: "inline" })
   }
 

--- a/packages/core/metadata/validation/schemaRegistry.test.ts
+++ b/packages/core/metadata/validation/schemaRegistry.test.ts
@@ -6,7 +6,6 @@ import { beforeEach, describe, expect, it } from "vitest"
 import { MetadataConfigurationRules } from "../appliedObjects/configuration/rules"
 import { MetadataLanguageRules } from "../appliedObjects/metadataLanguage/rules"
 import { exportMetadataItemToJSONSchema } from "../orchestration/metadataItem/toJSONSchema"
-import { clearJSONSchemaRefRegistries } from "../orchestration/jsonSchemaRefs"
 import {
   ensureJSONSchemaRegistry,
   exportJSONSchemaForSchemaName,
@@ -471,8 +470,7 @@ describe("JSON Schema registry", { timeout: 30_000 }, () => {
     expect(json).toContain('"Истина"')
   })
 
-  it("restores property refs after generic ref registry is cleared", () => {
-    clearJSONSchemaRefRegistries()
+  it("exports registered property refs through project schema registry", () => {
     const schema = schemaForName("UsualGroup")
 
     expect(JSON.stringify(schema)).toContain("nkdk://schema/InputField")

--- a/packages/core/metadata/validation/schemaRegistry.test.ts
+++ b/packages/core/metadata/validation/schemaRegistry.test.ts
@@ -50,6 +50,23 @@ describe("JSON Schema registry", { timeout: 30_000 }, () => {
     expect(JSON.stringify(schema)).toContain("nkdk://schema/MetadataCatalogAttribute")
   })
 
+  it("resolves MetadataCatalogAttributes through collection registration", () => {
+    const graph = exportJSONSchemaGraph({
+      context,
+      roots: [{ key: "catalog", name: "MetadataCatalog" }],
+    })
+
+    const catalog = graph.roots.catalog as { properties?: Record<string, unknown> }
+    expect(catalog.properties?.Реквизиты).toMatchObject({
+      type: "object",
+      additionalProperties: { $ref: "nkdk://schema/MetadataCatalogAttribute" },
+    })
+    expect(graph.schemas["nkdk://schema/MetadataCatalogAttribute"]).toMatchObject({
+      $id: "nkdk://schema/MetadataCatalogAttribute",
+      type: "object",
+    })
+  })
+
   it("accepts keyed predefined catalog items without explicit code", () => {
     const schema = exportJSONSchemaForSchemaName({ context, name: "MetadataCatalog", mode: "inline" })
     const compiled = compileValidationSchema(schema)
@@ -212,9 +229,10 @@ describe("JSON Schema registry", { timeout: 30_000 }, () => {
       roots: [{ key: "form", name: "ClientApplicationForm", includeNestedChildItems: true }],
     })
     const formAttributeJson = JSON.stringify(graph.schemas["nkdk://schema/FormAttribute"])
+    const graphJson = JSON.stringify(graph)
     const visibilitySchemaName = "AppearanceSettingsParameterValue_Primitive__u0412_u0438_u0434_u0438_u043c_u043e_u0441_u0442_u044c"
 
-    expect(formAttributeJson).toContain(`nkdk://schema/${visibilitySchemaName}`)
+    expect(graphJson).toContain(`nkdk://schema/${visibilitySchemaName}`)
     expect(formAttributeJson).not.toContain("SettingsParameterValue_Primitive_Видимость/$defs")
     expect(graph.schemas[`nkdk://schema/${visibilitySchemaName}`]).toMatchObject({
       $id: `nkdk://schema/${visibilitySchemaName}`,


### PR DESCRIPTION
## Summary
- add schema identity registration for validation refs, including metadata item and collection rules
- wire orchestration to consume registered schema identities for standalone validation refs
- add validation-profile skill and runner for compiled standalone validation profiling
- stabilize schema identity tests against shuffled execution

## Test plan
- pnpm test
- pnpm --filter '@nakidka/core' test
- node .agents/skills/validation-profile/validation-profile.mjs /Users/nikita/git/nkdk-yaml --runs 1
- node .agents/skills/validation-profile/validation-profile.mjs /Users/nikita/git/nkdk-yaml --runs 1 --timing --json