### PR TITLE
Добавить правила стандартных реквизитов DataPath

### DIFF
--- a/docs/superpowers/plans/2026-07-08-standard-members-datapath.md
+++ b/docs/superpowers/plans/2026-07-08-standard-members-datapath.md
@@ -1,0 +1,1317 @@
+# Standard Members DataPath Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a declarative `standardMembers` registry for DataPath standard attributes, standard tabular sections, and standard tabular section columns.
+
+**Architecture:** Concrete metadata objects declare their platform members in colocated `standardMembers.ts` files. Shared DataPath code only executes generic rule families and never hardcodes concrete object kinds or XML/YAML names. Existing imperative resolvers are migrated gradually behind the same registry contract.
+
+**Tech Stack:** TypeScript, Vitest, existing `packages/core/metadata/validation/dataPath/*` resolver/registry, applied object `register.ts` entrypoints.
+
+## Global Constraints
+
+- Ответы и документация проекта пишутся на русском языке.
+- `packages/core/metadata/orchestration`, `packages/core/metadata/validation` и `packages/core/metadata/project` не знают про конкретные реализации метаданных.
+- Правила конкретных объектов описывают связи YAML/XML, структуру проекта, маршруты синхронизации и внешние обработчики декларативно через `rules.ts`, регистрацию property/item-типов и нейтральные договоры.
+- Не выводить стандартные табличные части в YAML как секции объекта на первом этапе; использовать их только для перевода и валидации `DataPath`.
+- `AccountingRegister.ExtDimension1..50` и `AccountingRegister.ExtDimensionType1..50` на первом этапе запрещены для использования и раскрытия.
+- Декларации стандартных членов хранятся рядом с конкретными объектами: `metadata*/standardMembers.ts`.
+- Перед закрытием issue обязательно прогнать `pnpm test` из корня.
+
+---
+
+## File Structure
+
+- Create `packages/core/metadata/validation/dataPath/standardMembers.ts`.
+  Defines the neutral declaration types, registration functions, lookup helpers, and generic executors for `index-time`, `traversal-time`, and table-column members.
+- Modify `packages/core/metadata/validation/dataPath/registry.ts`.
+  Re-export `standardMembers` registry hooks only as neutral contracts; do not add concrete object names.
+- Modify `packages/core/metadata/validation/dataPath/objectFields.ts`.
+  Use `standardMembers` declarations when building standard attributes and virtual standard tables.
+- Modify `packages/core/metadata/validation/dataPath/resolver.ts`.
+  Let `traversal-time` standard members participate before ordinary field lookup and return existing `DataPathTypeInfo` states.
+- Modify `packages/core/metadata/appliedObjects/dataPathCommon/register.ts`.
+  Move common primitive, self-object, owner, register-record-set column, and table-column behavior to declarations.
+- Create or modify colocated `standardMembers.ts` files under applied objects:
+  `metadataCatalog`, `metadataDocument`, `metadataEnumeration`, `metadataChartOfAccounts`, `metadataChartOfCharacteristicTypes`, `metadataChartOfCalculationTypes`, `metadataExchangePlan`, `metadataDocumentJournal`, `metadataBusinessProcess`, `metadataTask`, `metadataInformationRegister`, `metadataAccumulationRegister`, `metadataAccountingRegister`, `metadataCalculationRegister`.
+- Modify each touched applied object `register.ts`.
+  Import its `standardMembers.ts` so declarations register during existing applied object registration.
+- Test files:
+  `packages/core/metadata/validation/dataPath/standardMembers.test.ts`
+  `packages/core/metadata/validation/dataPath/objectFields.test.ts`
+  `packages/core/metadata/validation/dataPath/resolver.test.ts`
+  `packages/core/metadata/validation/validateForm.test.ts`
+  `packages/core/metadata/importBoundaries.test.ts`
+
+---
+
+### Task 1: Add the Neutral `standardMembers` Contract
+
+**Files:**
+- Create: `packages/core/metadata/validation/dataPath/standardMembers.ts`
+- Modify: `packages/core/metadata/validation/dataPath/registry.ts`
+- Test: `packages/core/metadata/validation/dataPath/standardMembers.test.ts`
+
+**Interfaces:**
+- Produces:
+  `registerStandardMembers(ownerKind: string, members: readonly StandardMemberDeclaration[]): void`
+  `getStandardMembers(ownerKind: string): readonly StandardMemberDeclaration[]`
+  `resolveIndexTimeStandardMember(params: ResolveIndexTimeStandardMemberParams): ResolvedStandardMember | undefined`
+  `resolveTraversalTimeStandardMember(params: ResolveTraversalTimeStandardMemberParams): ResolvedTraversalStandardMember | undefined`
+  `resolveStandardTableColumn(params: ResolveStandardTableColumnParams): FormDataPathColumnSource | undefined`
+
+- Consumes: existing `OwnerMetadata`, `OwnerMetadataCache`, `DataPathTypeInfo`, `FormDataPathColumnSource`, `DataPathTableInfo`.
+
+- [ ] **Step 1: Write the failing registry test**
+
+Add this test file:
+
+```ts
+import { describe, expect, it } from "vitest"
+import {
+  getStandardMembers,
+  registerStandardMembers,
+  resolveIndexTimeStandardMember,
+} from "./standardMembers"
+
+describe("standardMembers registry", () => {
+  it("registers declarations by owner kind and resolves primitive members", () => {
+    registerStandardMembers("ТестовыйОбъект", [
+      {
+        memberKind: "standardAttribute",
+        names: { internal: "Flag", yaml: "Флаг" },
+        family: "primitive",
+        phase: "index-time",
+        sourceScope: "self",
+        kind: "boolean",
+      },
+    ])
+
+    expect(getStandardMembers("ТестовыйОбъект")).toHaveLength(1)
+    expect(
+      resolveIndexTimeStandardMember({
+        owner: { ref: { kind: "ТестовыйОбъект" }, model: {}, rule: { itemType: "Test", properties: {} } },
+        internalName: "Flag",
+        yamlName: "Флаг",
+      })
+    ).toMatchObject({
+      name: "Флаг",
+      typeInfo: { kinds: ["boolean"], nextTypes: [] },
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused failing test**
+
+Run: `pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/standardMembers.test.ts`
+
+Expected: FAIL with module not found for `./standardMembers`.
+
+- [ ] **Step 3: Implement declaration types and primitive executor**
+
+Create `packages/core/metadata/validation/dataPath/standardMembers.ts`:
+
+```ts
+import type { MetadataItemRule } from "../../orchestration/property/types"
+import type { OwnerMetadata, OwnerMetadataCache } from "./ownerCache"
+import type { DataPathTableInfo, DataPathTypeInfo, FormDataPathColumnSource, OwnerTypeRef } from "./types"
+
+export type StandardMemberKind = "standardAttribute" | "standardTabularSection" | "standardTabularSectionColumn"
+export type StandardMemberPhase = "index-time" | "traversal-time" | "deferred"
+export type StandardMemberSourceScope = "self" | "ownerModel" | "rules" | "projectIndex"
+
+export type PrimitiveKind = "boolean" | "string" | "dateTime" | "number"
+
+export interface StandardMemberNames {
+  internal: string
+  yaml: string
+}
+
+interface BaseStandardMemberDeclaration {
+  memberKind: StandardMemberKind
+  names: StandardMemberNames
+  phase: StandardMemberPhase
+  sourceScope: StandardMemberSourceScope
+}
+
+export interface PrimitiveStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "primitive"
+  kind: PrimitiveKind
+  terminal?: true
+  allowNestedProperties?: false
+}
+
+export type StandardMemberDeclaration = PrimitiveStandardMemberDeclaration
+
+export interface ResolveIndexTimeStandardMemberParams {
+  owner: Pick<OwnerMetadata, "ref" | "model" | "rule">
+  internalName: string
+  yamlName: string
+  explicitTypeInfo?: DataPathTypeInfo
+}
+
+export interface ResolvedStandardMember {
+  name: string
+  targetName: string
+  typeInfo: DataPathTypeInfo
+}
+
+export interface ResolveTraversalTimeStandardMemberParams {
+  owner: OwnerMetadata
+  segment: string
+  ownerCache: OwnerMetadataCache
+}
+
+export interface ResolvedTraversalStandardMember {
+  name: string
+  typeInfo: DataPathTypeInfo
+  tableSource?: {
+    table: DataPathTableInfo
+    columns: Map<string, FormDataPathColumnSource>
+    hasColumns: boolean
+  }
+}
+
+export interface ResolveStandardTableColumnParams {
+  owner: OwnerMetadata
+  table: DataPathTableInfo
+  segment: string
+}
+
+const membersByOwnerKind = new Map<string, StandardMemberDeclaration[]>()
+
+export function registerStandardMembers(ownerKind: string, members: readonly StandardMemberDeclaration[]): void {
+  const existing = membersByOwnerKind.get(ownerKind) ?? []
+  membersByOwnerKind.set(ownerKind, [...existing, ...members])
+}
+
+export function getStandardMembers(ownerKind: string): readonly StandardMemberDeclaration[] {
+  return membersByOwnerKind.get(ownerKind) ?? []
+}
+
+export function resolveIndexTimeStandardMember(
+  params: ResolveIndexTimeStandardMemberParams
+): ResolvedStandardMember | undefined {
+  for (const member of getStandardMembers(params.owner.ref.kind)) {
+    if (member.phase !== "index-time") continue
+    if (!matchesStandardMember(member, params.internalName, params.yamlName)) continue
+    if (params.explicitTypeInfo !== undefined) {
+      return { name: member.names.yaml, targetName: member.names.internal, typeInfo: params.explicitTypeInfo }
+    }
+    if (member.family === "primitive") {
+      return {
+        name: member.names.yaml,
+        targetName: member.names.internal,
+        typeInfo: primitiveTypeInfo(member.kind, `${params.owner.ref.kind}.${member.names.internal}`),
+      }
+    }
+  }
+  return undefined
+}
+
+export function resolveTraversalTimeStandardMember(
+  _params: ResolveTraversalTimeStandardMemberParams
+): ResolvedTraversalStandardMember | undefined {
+  return undefined
+}
+
+export function resolveStandardTableColumn(_params: ResolveStandardTableColumnParams): FormDataPathColumnSource | undefined {
+  return undefined
+}
+
+function matchesStandardMember(member: StandardMemberDeclaration, internalName: string, yamlName: string): boolean {
+  return member.names.internal === internalName || member.names.yaml === yamlName
+}
+
+function primitiveTypeInfo(kind: PrimitiveKind, sourceText: string): DataPathTypeInfo {
+  const dataPathKind = kind === "string" || kind === "number" ? "scalar" : kind
+  return { kinds: [dataPathKind], nextTypes: [], sourceText }
+}
+```
+
+- [ ] **Step 4: Export neutral hooks from registry**
+
+Add exports to `packages/core/metadata/validation/dataPath/registry.ts`:
+
+```ts
+export {
+  getStandardMembers,
+  registerStandardMembers,
+  resolveIndexTimeStandardMember,
+  resolveStandardTableColumn,
+  resolveTraversalTimeStandardMember,
+} from "./standardMembers"
+export type {
+  PrimitiveKind,
+  StandardMemberDeclaration,
+  StandardMemberKind,
+  StandardMemberNames,
+  StandardMemberPhase,
+  StandardMemberSourceScope,
+} from "./standardMembers"
+```
+
+- [ ] **Step 5: Run focused test**
+
+Run: `pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/standardMembers.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/metadata/validation/dataPath/standardMembers.ts packages/core/metadata/validation/dataPath/standardMembers.test.ts packages/core/metadata/validation/dataPath/registry.ts
+git commit -m "feat: :sparkles: добавить реестр standardMembers"
+```
+
+---
+
+### Task 2: Use `standardMembers` for Index-Time Standard Attributes
+
+**Files:**
+- Modify: `packages/core/metadata/validation/dataPath/objectFields.ts`
+- Modify: `packages/core/metadata/appliedObjects/dataPathCommon/register.ts`
+- Test: `packages/core/metadata/validation/dataPath/objectFields.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveIndexTimeStandardMember(params)`.
+- Produces: existing `ObjectFieldIndex.fields` entries still have `kind: "standardAttribute"`, `name` as YAML name, and `targetName` as internal name.
+
+- [ ] **Step 1: Add a failing object field test for declarative primitives**
+
+Append to `packages/core/metadata/validation/dataPath/objectFields.test.ts`:
+
+```ts
+it("resolves declarative primitive standard members", () => {
+  const index = buildObjectFieldIndex(
+    owner({
+      ref: { kind: "ТестовыйОбъект", name: "Объект1" },
+      rule: {
+        itemType: "TestObject",
+        properties: {
+          standardAttributes: {
+            type: "StandardAttributeDescriptions",
+            yaml: "СтандартныеРеквизиты",
+            standartAttributeNames: { Flag: "Флаг" },
+          },
+        },
+      },
+    })
+  )
+
+  expect(resolveObjectFieldSegment({ index, segment: "Flag" })?.typeInfo.kinds).toEqual(["boolean"])
+  expect(resolveObjectFieldSegment({ index, segment: "Флаг" })?.typeInfo.kinds).toEqual(["boolean"])
+})
+```
+
+In the same test file, register the test member near other setup imports:
+
+```ts
+import { registerStandardMembers } from "./standardMembers"
+
+registerStandardMembers("ТестовыйОбъект", [
+  {
+    memberKind: "standardAttribute",
+    names: { internal: "Flag", yaml: "Флаг" },
+    family: "primitive",
+    phase: "index-time",
+    sourceScope: "self",
+    kind: "boolean",
+  },
+])
+```
+
+- [ ] **Step 2: Run test to verify current path ignores declarations**
+
+Run: `pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/objectFields.test.ts -t "declarative primitive standard members"`
+
+Expected: FAIL because the index returns unknown type.
+
+- [ ] **Step 3: Wire `objectFields.ts` to `standardMembers`**
+
+Change imports in `objectFields.ts`:
+
+```ts
+import {
+  getObjectFieldCollectionDescriptors,
+  resolveIndexTimeStandardMember,
+  resolveStandardAttributeType,
+} from "./registry"
+```
+
+Change `standardAttributeTypeInfo`:
+
+```ts
+function standardAttributeTypeInfo(params: {
+  owner: ObjectFieldIndexOwner
+  internalName: string
+  yamlName: string
+  explicit: NamedTypedItem | undefined
+}): DataPathTypeInfo {
+  const explicitTypeInfo =
+    params.explicit?.type === undefined ? undefined : typeDescriptionToDataPathTypeInfo(params.explicit.type)
+
+  const declarative = resolveIndexTimeStandardMember({
+    owner: params.owner as OwnerMetadata,
+    internalName: params.internalName,
+    yamlName: params.yamlName,
+    ...(explicitTypeInfo !== undefined ? { explicitTypeInfo } : {}),
+  })
+  if (declarative !== undefined) return declarative.typeInfo
+
+  return (
+    resolveStandardAttributeType({
+      owner: params.owner as OwnerMetadata,
+      internalName: params.internalName,
+      yamlName: params.yamlName,
+      ...(explicitTypeInfo !== undefined ? { explicitTypeInfo } : {}),
+    }) ?? unknownDataPathTypeInfo
+  )
+}
+```
+
+- [ ] **Step 4: Keep existing tests green**
+
+Run: `pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/objectFields.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/metadata/validation/dataPath/objectFields.ts packages/core/metadata/validation/dataPath/objectFields.test.ts
+git commit -m "feat: :sparkles: подключить standardMembers к индексу"
+```
+
+---
+
+### Task 3: Implement Index-Time Families and Common Declarations
+
+**Files:**
+- Modify: `packages/core/metadata/validation/dataPath/standardMembers.ts`
+- Modify: `packages/core/metadata/appliedObjects/dataPathCommon/register.ts`
+- Create: `packages/core/metadata/appliedObjects/metadataCatalog/standardMembers.ts`
+- Modify: `packages/core/metadata/appliedObjects/metadataCatalog/register.ts`
+- Test: `packages/core/metadata/validation/dataPath/resolver.test.ts`
+
+**Interfaces:**
+- Produces family support:
+  `sameOwnerObject`, `objectRefsFromProperty`, `codeByProperty`, `numberByProperty`, `standardEnum`, `typeDescription`, `opaque`, `unsupported`.
+- Consumes metadata links through existing `getOwnerKindByMetadataLinkPrefix`.
+
+- [ ] **Step 1: Add failing resolver tests for declarative catalog Owner and unsupported member**
+
+Append to `packages/core/metadata/validation/dataPath/resolver.test.ts`:
+
+```ts
+it("resolves Owner through declarative standardMembers", () => {
+  const result = resolve("Объект.Owner.Валюта", {
+    index: indexWithRootObject({ kind: "Справочник", name: "Контрагенты" }),
+    ownerCache: ownerCache([
+      testOwner({
+        ref: { kind: "Справочник", name: "Контрагенты" },
+        model: { owners: ["Справочник.Владельцы"] },
+      }),
+      testOwner({
+        ref: { kind: "Справочник", name: "Владельцы" },
+        model: {
+          attributes: [{ name: "Валюта", type: { types: ["CatalogRef.Валюты"] } }],
+        },
+      }),
+    ]),
+  })
+
+  expect(result.status).toBe("ok")
+  if (result.status !== "ok") return
+  expect(result.target?.source).toMatchObject({ kind: "objectField", name: "Валюта" })
+})
+
+it("reports unsupported standard members as unsupported intermediate types", () => {
+  const result = resolve("Объект.ExtDimension1.Name", {
+    index: indexWithRootObject({ kind: "РегистрБухгалтерии", name: "Хозрасчетный" }),
+    ownerCache: ownerCache([
+      testOwner({
+        ref: { kind: "РегистрБухгалтерии", name: "Хозрасчетный" },
+      }),
+    ]),
+  })
+
+  expect(result).toMatchObject({
+    status: "error",
+    diagnostics: [
+      {
+        message: 'ПутьКДанным "Объект.ExtDimension1.Name": промежуточный реквизит "ExtDimension1" имеет неподдерживаемый тип',
+      },
+    ],
+  })
+})
+```
+
+- [ ] **Step 2: Run tests and confirm missing declarative behavior**
+
+Run: `pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/resolver.test.ts -t "declarative standardMembers|unsupported standard members"`
+
+Expected: FAIL because declarations/families are not implemented yet.
+
+- [ ] **Step 3: Extend declaration union**
+
+In `standardMembers.ts`, replace `StandardMemberDeclaration` with this union:
+
+```ts
+export type StandardMemberDeclaration =
+  | PrimitiveStandardMemberDeclaration
+  | SameOwnerObjectStandardMemberDeclaration
+  | ObjectRefsFromPropertyStandardMemberDeclaration
+  | MetadataPropertyScalarStandardMemberDeclaration
+  | StandardEnumStandardMemberDeclaration
+  | TypeDescriptionStandardMemberDeclaration
+  | OpaqueStandardMemberDeclaration
+  | UnsupportedStandardMemberDeclaration
+
+export interface SameOwnerObjectStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "sameOwnerObject"
+}
+
+export interface ObjectRefsFromPropertyStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "objectRefsFromProperty"
+  property: string
+  compositePolicy: "errorOnTraversal"
+}
+
+export interface MetadataPropertyScalarStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "codeByProperty" | "numberByProperty"
+  property: string
+}
+
+export interface StandardEnumStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "standardEnum"
+  name: string
+}
+
+export interface TypeDescriptionStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "typeDescription"
+  allowNestedProperties: false
+}
+
+export interface OpaqueStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "opaque"
+  allowNestedProperties: false
+}
+
+export interface UnsupportedStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "unsupported"
+  reason: string
+}
+```
+
+- [ ] **Step 4: Implement family executors**
+
+Add these helpers to `standardMembers.ts`:
+
+```ts
+function indexTimeTypeInfo(
+  member: StandardMemberDeclaration,
+  owner: Pick<OwnerMetadata, "ref" | "model" | "rule">
+): DataPathTypeInfo | undefined {
+  switch (member.family) {
+    case "primitive":
+      return primitiveTypeInfo(member.kind, `${owner.ref.kind}.${member.names.internal}`)
+    case "sameOwnerObject":
+      return { kinds: ["object"], nextTypes: [sameOwnerRef(owner.ref)], sourceText: `${owner.ref.kind}.${member.names.internal}` }
+    case "objectRefsFromProperty":
+      return objectRefsFromProperty(owner, member.property)
+    case "codeByProperty":
+    case "numberByProperty":
+      return scalarFromMetadataProperty(owner, member.property, `${owner.ref.kind}.${member.names.internal}`)
+    case "standardEnum":
+      return { kinds: ["scalar"], nextTypes: [], sourceText: member.name }
+    case "typeDescription":
+      return { kinds: ["typeDescription"], nextTypes: [], sourceText: `${owner.ref.kind}.${member.names.internal}` }
+    case "opaque":
+      return { kinds: ["unsupportedIntermediate"], nextTypes: [], sourceText: `${owner.ref.kind}.${member.names.internal}` }
+    case "unsupported":
+      return { kinds: ["unsupportedIntermediate"], nextTypes: [], sourceText: member.reason }
+  }
+}
+
+function objectRefsFromProperty(owner: Pick<OwnerMetadata, "model">, property: string): DataPathTypeInfo | undefined {
+  const links = metadataRecord(owner.model)[property]
+  if (!Array.isArray(links)) return undefined
+  const nextTypes = links.flatMap((link) => (typeof link === "string" ? [ownerTypeRefFromMetadataLink(link)] : []))
+    .filter((item): item is OwnerTypeRef => item !== undefined)
+  if (nextTypes.length === 0) return undefined
+  return {
+    kinds: ["object"],
+    nextTypes: uniqueOwnerRefs(nextTypes),
+    ...(nextTypes.length > 1 ? { isComposite: true } : {}),
+    sourceText: links.filter((link): link is string => typeof link === "string").join(" | "),
+  }
+}
+
+function scalarFromMetadataProperty(
+  owner: Pick<OwnerMetadata, "model">,
+  property: string,
+  sourceText: string
+): DataPathTypeInfo | undefined {
+  return metadataRecord(owner.model)[property] === undefined
+    ? undefined
+    : { kinds: ["scalar"], nextTypes: [], sourceText }
+}
+```
+
+Move `ownerTypeRefFromMetadataLink`, `splitMetadataLink`, `sameOwnerRef`, `metadataRecord`, and `uniqueOwnerRefs` into `standardMembers.ts`, using `getOwnerKindByMetadataLinkPrefix` from `registry.ts`.
+
+Update `resolveIndexTimeStandardMember` to call `indexTimeTypeInfo`.
+
+- [ ] **Step 5: Register common and catalog declarations**
+
+In `metadataCatalog/standardMembers.ts`:
+
+```ts
+import { registerStandardMembers } from "../../validation/dataPath/registry"
+
+const catalogMembers = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Parent", yaml: "Родитель" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Owner", yaml: "Владелец" }, family: "objectRefsFromProperty", phase: "index-time", sourceScope: "ownerModel", property: "owners", compositePolicy: "errorOnTraversal" },
+  { memberKind: "standardAttribute", names: { internal: "Code", yaml: "Код" }, family: "codeByProperty", phase: "index-time", sourceScope: "ownerModel", property: "codeType" },
+  { memberKind: "standardAttribute", names: { internal: "Description", yaml: "Наименование" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "IsFolder", yaml: "ЭтоГруппа" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "Predefined", yaml: "Предопределенный" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "PredefinedDataName", yaml: "ИмяПредопределенныхДанных" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+] as const
+
+registerStandardMembers("Справочник", catalogMembers)
+registerStandardMembers("СправочникОбъект", catalogMembers)
+```
+
+Import it in `metadataCatalog/register.ts`:
+
+```ts
+import "./standardMembers"
+```
+
+Add `AccountingRegister.ExtDimension*` unsupported declarations in `metadataAccountingRegister/standardMembers.ts` and import from `metadataAccountingRegister/register.ts`.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/standardMembers.test.ts packages/core/metadata/validation/dataPath/objectFields.test.ts packages/core/metadata/validation/dataPath/resolver.test.ts -t "Owner|unsupported standard members|standard attribute"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/metadata/validation/dataPath packages/core/metadata/appliedObjects/metadataCatalog packages/core/metadata/appliedObjects/metadataAccountingRegister
+git commit -m "feat: :sparkles: описать index-time standardMembers"
+```
+
+---
+
+### Task 4: Move Existing Object-Specific Virtual Standard Members to Declarations
+
+**Files:**
+- Create: `packages/core/metadata/appliedObjects/metadataChartOfAccounts/standardMembers.ts`
+- Create: `packages/core/metadata/appliedObjects/metadataChartOfCalculationTypes/standardMembers.ts`
+- Modify: `packages/core/metadata/appliedObjects/metadataChartOfAccounts/register.ts`
+- Modify: `packages/core/metadata/appliedObjects/metadataChartOfCalculationTypes/register.ts`
+- Modify: `packages/core/metadata/validation/dataPath/standardMembers.ts`
+- Test: `packages/core/metadata/validation/dataPath/resolver.test.ts`
+
+**Interfaces:**
+- Produces standard tabular sections as `tableSource`.
+- Produces standard table columns through `resolveStandardTableColumn`.
+
+- [ ] **Step 1: Add assertions that declarations still resolve current virtual tables**
+
+Keep existing tests named:
+
+- `resolves ChartOfAccounts ExtDimensionTypes as a virtual table`
+- `resolves ChartOfAccounts ExtDimensionTypes virtual columns`
+- `resolves ChartOfCalculationTypes virtual tables`
+
+Add this assertion to the ExtDimensionTypes column test:
+
+```ts
+expect(
+  resolve("Объект.ExtDimensionTypes.ПризнакУчетаСубконтоВсеСвойства", {
+    index: indexWithRootObject({ kind: "ПланСчетов", name: "Хозрасчетный" }),
+    ownerCache: chartOfAccountsOwners(),
+  })
+).toMatchObject({
+  status: "ok",
+  target: {
+    typeInfo: { kinds: ["boolean"], nextTypes: [] },
+  },
+})
+```
+
+- [ ] **Step 2: Extend standard table declarations**
+
+Add to `standardMembers.ts`:
+
+```ts
+export interface StandardTableDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardTabularSection"
+  family: "standardTable"
+  tableKind: "ValueTable"
+  columns: readonly StandardTableColumnDeclaration[]
+}
+
+export type StandardTableColumnDeclaration =
+  | PrimitiveStandardTableColumnDeclaration
+  | SameOwnerObjectStandardTableColumnDeclaration
+  | ObjectRefFromOwnerPropertyStandardTableColumnDeclaration
+
+export interface PrimitiveStandardTableColumnDeclaration {
+  memberKind: "standardTabularSectionColumn"
+  names: StandardMemberNames
+  family: "primitive"
+  kind: PrimitiveKind
+  discoveredFrom?: string
+}
+
+export interface SameOwnerObjectStandardTableColumnDeclaration {
+  memberKind: "standardTabularSectionColumn"
+  names: StandardMemberNames
+  family: "sameOwnerObject"
+}
+
+export interface ObjectRefFromOwnerPropertyStandardTableColumnDeclaration {
+  memberKind: "standardTabularSectionColumn"
+  names: StandardMemberNames
+  family: "objectRefFromOwnerProperty"
+  property: string
+}
+```
+
+Include `StandardTableDeclaration` in `StandardMemberDeclaration`.
+
+- [ ] **Step 3: Implement table and column executors**
+
+In `resolveTraversalTimeStandardMember`, return a table source for `standardTable` declarations:
+
+```ts
+if (member.memberKind === "standardTabularSection" && member.phase === "traversal-time" && matchesSegment(member, params.segment)) {
+  const table = { kind: member.tableKind } satisfies DataPathTableInfo
+  return {
+    name: member.names.yaml,
+    typeInfo: { kinds: ["tableSource"], nextTypes: [], table, sourceText: `${params.owner.ref.kind}.${member.names.internal}` },
+    tableSource: {
+      table,
+      columns: columnsFromStandardTable({ owner: params.owner, table: member }),
+      hasColumns: true,
+    },
+  }
+}
+```
+
+Implement `columnsFromStandardTable` so primitive columns return boolean/scalar/date types, `sameOwnerObject` returns `{ kinds: ["object"], nextTypes: [owner.ref] }`, and `objectRefFromOwnerProperty` converts `ChartOfCharacteristicTypes.<name>` to `{ kind: "ПланВидовХарактеристик", name }`.
+
+- [ ] **Step 4: Use traversal declarations in resolver**
+
+In `resolver.ts`, before `resolveVirtualOwnerField`, call:
+
+```ts
+const standardMember = resolveTraversalTimeStandardMember({
+  owner: ownerResult.owner,
+  segment: lookupSegment,
+  ownerCache: params.ownerCache,
+})
+if (standardMember !== undefined) {
+  state = {
+    typeInfo: standardMember.typeInfo,
+    source: { kind: "objectField", owner: ownerResult.owner.ref, name: standardMember.name },
+    ...(standardMember.tableSource !== undefined ? { tableSource: standardMember.tableSource } : {}),
+  }
+  if (isLast) return okTarget({ value, segments, state })
+  continue
+}
+```
+
+- [ ] **Step 5: Declare ChartOfAccounts and ChartOfCalculationTypes standard tables**
+
+Create `metadataChartOfAccounts/standardMembers.ts` with `ExtDimensionTypes` and columns:
+
+```ts
+import { registerStandardMembers } from "../../validation/dataPath/registry"
+
+registerStandardMembers("ПланСчетов", [
+  {
+    memberKind: "standardTabularSection",
+    names: { internal: "ExtDimensionTypes", yaml: "ВидыСубконто" },
+    family: "standardTable",
+    phase: "traversal-time",
+    sourceScope: "ownerModel",
+    tableKind: "ValueTable",
+    columns: [
+      { memberKind: "standardTabularSectionColumn", names: { internal: "ExtDimensionType", yaml: "ВидСубконто" }, family: "objectRefFromOwnerProperty", property: "extDimensionTypes" },
+      { memberKind: "standardTabularSectionColumn", names: { internal: "TurnoversOnly", yaml: "ТолькоОбороты" }, family: "primitive", kind: "boolean" },
+      { memberKind: "standardTabularSectionColumn", names: { internal: "ТолькоСальдо", yaml: "ТолькоСальдо" }, family: "primitive", kind: "boolean" },
+      { memberKind: "standardTabularSectionColumn", names: { internal: "LineNumber", yaml: "НомерСтроки" }, family: "primitive", kind: "number" },
+      { memberKind: "standardTabularSectionColumn", names: { internal: "Predefined", yaml: "Предопределенный" }, family: "primitive", kind: "boolean" },
+      { memberKind: "standardTabularSectionColumn", names: { internal: "*", yaml: "*" }, family: "primitive", kind: "boolean", discoveredFrom: "extDimensionAccountingFlags" },
+    ],
+  },
+])
+```
+
+Create `metadataChartOfCalculationTypes/standardMembers.ts` with three standard tables and columns `CalculationType`, `LineNumber`, `Predefined`.
+
+Import both files from their `register.ts`.
+
+- [ ] **Step 6: Remove duplicate virtual table code**
+
+After tests pass with declarations, delete table-specific branches from `metadataChartOfAccounts/register.ts` and `metadataChartOfCalculationTypes/register.ts`, leaving only owner kind registrations and any non-standard-member behavior still needed.
+
+- [ ] **Step 7: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/resolver.test.ts -t "ChartOfAccounts ExtDimensionTypes|ChartOfCalculationTypes"
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/metadata/validation/dataPath packages/core/metadata/appliedObjects/metadataChartOfAccounts packages/core/metadata/appliedObjects/metadataChartOfCalculationTypes
+git commit -m "feat: :sparkles: описать стандартные табличные части"
+```
+
+---
+
+### Task 5: Implement Traversal-Time Reverse Lookup Members
+
+**Files:**
+- Modify: `packages/core/metadata/validation/dataPath/standardMembers.ts`
+- Modify: `packages/core/metadata/validation/dataPath/resolver.ts`
+- Modify: `packages/core/metadata/validation/dataPath/ownerCache.ts`
+- Modify: `packages/core/metadata/validation/projectValidationObjectTable.ts`
+- Create: `packages/core/metadata/appliedObjects/metadataTask/standardMembers.ts`
+- Create: `packages/core/metadata/appliedObjects/metadataInformationRegister/standardMembers.ts`
+- Create: `packages/core/metadata/appliedObjects/metadataAccumulationRegister/standardMembers.ts`
+- Create: `packages/core/metadata/appliedObjects/metadataAccountingRegister/standardMembers.ts`
+- Create: `packages/core/metadata/appliedObjects/metadataCalculationRegister/standardMembers.ts`
+- Modify corresponding `register.ts` files
+- Test: `packages/core/metadata/validation/dataPath/resolver.test.ts`
+
+**Interfaces:**
+- Produces `reverseLookup` and `closedReverseLookup`.
+- Empty reverse lookup returns an error diagnostic, not fallback.
+
+- [ ] **Step 1: Add failing tests for `Recorder` and empty reverse lookup**
+
+Append to `resolver.test.ts`:
+
+```ts
+it("resolves register Recorder through document registerRecords", () => {
+  const result = resolve("Объект.Recorder.Date", {
+    index: indexWithRootObject({ kind: "РегистрСведений", name: "Цены" }),
+    ownerCache: ownerCache([
+      testOwner({ ref: { kind: "РегистрСведений", name: "Цены" } }),
+      testOwner({
+        ref: { kind: "Документ", name: "УстановкаЦен" },
+        model: { registerRecords: ["InformationRegister.Цены"] },
+      }),
+    ]),
+  })
+
+  expect(result.status).toBe("ok")
+  if (result.status !== "ok") return
+  expect(result.target?.source).toMatchObject({ kind: "objectField", name: "Дата" })
+})
+
+it("reports missing Recorder candidates as metadata link errors", () => {
+  const result = resolve("Объект.Recorder", {
+    index: indexWithRootObject({ kind: "РегистрСведений", name: "Цены" }),
+    ownerCache: ownerCache([testOwner({ ref: { kind: "РегистрСведений", name: "Цены" } })]),
+  })
+
+  expect(result).toMatchObject({
+    status: "error",
+    diagnostics: [{ message: 'ПутьКДанным "Объект.Recorder": для стандартного реквизита "Recorder" не найдены связанные объекты' }],
+  })
+})
+```
+
+- [ ] **Step 2: Add owner listing support for reverse lookups**
+
+In `packages/core/metadata/validation/dataPath/ownerCache.ts`, change the interface:
+
+```ts
+export interface OwnerMetadataCache {
+  get(ref: OwnerTypeRef): OwnerMetadataResult
+  listRefs(kind: OwnerTypeRef["kind"]): readonly OwnerTypeRef[]
+}
+```
+
+Add `readdirSync` to the first import:
+
+```ts
+import { readdirSync } from "fs"
+```
+
+In `createOwnerMetadataCache`, add this method next to `get`:
+
+```ts
+listRefs(kind) {
+  const ownerKind = getDataPathOwnerKind(kind)
+  if (ownerKind === undefined) return []
+  const dir = join(rootDir, ownerKind.projectDir)
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => ({ kind, name: entry.name }))
+  } catch {
+    return []
+  }
+}
+```
+
+In `packages/core/metadata/validation/projectValidationObjectTable.ts`, extend `ValidationObjectTable`:
+
+```ts
+listOwners(kind: OwnerTypeRef["kind"]): readonly OwnerTypeRef[]
+```
+
+Add the implementation inside `createValidationObjectTable`:
+
+```ts
+listOwners(kind) {
+  return [...recordsByOwner.values()]
+    .map((record) => record.ownerRef)
+    .filter((ref): ref is OwnerTypeRef => ref !== undefined && ref.kind === kind)
+}
+```
+
+In `createOwnerMetadataCacheFromValidationTable`, add:
+
+```ts
+listRefs(kind) {
+  const ownerKind = getDataPathOwnerKind(kind)
+  const tableKind = ownerKind?.projectDir ?? kind
+  return params.table.listOwners(tableKind).map((ref) => ({
+    kind,
+    ...(ref.name !== undefined ? { name: ref.name } : {}),
+  }))
+}
+```
+
+Update the `ownerCache(owners)` helper in `resolver.test.ts`:
+
+```ts
+listRefs(kind) {
+  return owners.map((owner) => owner.ref).filter((ref) => ref.kind === kind)
+}
+```
+
+- [ ] **Step 3: Extend traversal resolver result to support errors**
+
+In `registry.ts`, extend `TraversalTransitionResolver`-like handling only for standard members by adding:
+
+```ts
+export interface StandardMemberError {
+  kind: "error"
+  message: string
+}
+```
+
+Change `resolveTraversalTimeStandardMember` return type to `ResolvedTraversalStandardMember | StandardMemberError | undefined`.
+
+In `resolver.ts`, after calling `resolveTraversalTimeStandardMember`, handle:
+
+```ts
+if (standardMember?.kind === "error") {
+  return error(params, `ПутьКДанным "${value}": ${standardMember.message}`)
+}
+```
+
+- [ ] **Step 4: Implement reverse lookup declarations**
+
+Add declaration interfaces:
+
+```ts
+export interface ReverseLookupStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "reverseLookup"
+  phase: "traversal-time"
+  sourceScope: "projectIndex"
+  target: string
+  property: string
+  emptyPolicy: "error"
+  compositePolicy: "errorOnTraversal"
+}
+
+export interface ClosedReverseLookupStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  family: "closedReverseLookup"
+  phase: "traversal-time"
+  sourceScope: "projectIndex"
+  result: string
+  source: string
+  emptyPolicy: "error"
+  allowNestedProperties: false
+}
+```
+
+Implement `reverseLookupCandidates` with `ownerCache.listRefs(member.target)`:
+
+```ts
+function reverseLookupCandidates(params: {
+  owner: OwnerMetadata
+  ownerCache: OwnerMetadataCache
+  target: string
+  property: string
+}): OwnerTypeRef[] {
+  const currentLink = metadataLinkForOwnerRef(params.owner.ref)
+  if (currentLink === undefined) return []
+
+  const result: OwnerTypeRef[] = []
+  for (const ref of params.ownerCache.listRefs(params.target)) {
+    const ownerResult = params.ownerCache.get(ref)
+    if (ownerResult.status !== "ok") continue
+
+    const links = metadataRecord(ownerResult.owner.model)[params.property]
+    if (!Array.isArray(links)) continue
+    if (links.some((link) => link === currentLink)) result.push(ref)
+  }
+  return result
+}
+```
+
+Add this helper in `standardMembers.ts`:
+
+```ts
+function metadataLinkForOwnerRef(ref: OwnerTypeRef): string | undefined {
+  const prefix = getMetadataLinkPrefixesByOwnerKind(ref.kind)[0]
+  if (prefix === undefined || ref.name === undefined) return undefined
+  return `${prefix}.${ref.name}`
+}
+```
+
+When `reverseLookupCandidates` returns an empty array for a matched `reverseLookup` or `closedReverseLookup` member, return:
+
+```ts
+{
+  kind: "error",
+  message: `для стандартного реквизита "${member.names.internal}" не найдены связанные объекты`,
+}
+```
+
+- [ ] **Step 5: Register task and register declarations**
+
+In `metadataTask/standardMembers.ts`:
+
+```ts
+import { registerStandardMembers } from "../../validation/dataPath/registry"
+
+const taskMembers = [
+  {
+    memberKind: "standardAttribute",
+    names: { internal: "BusinessProcess", yaml: "БизнесПроцесс" },
+    family: "reverseLookup",
+    phase: "traversal-time",
+    sourceScope: "projectIndex",
+    target: "BusinessProcess",
+    property: "tasks",
+    emptyPolicy: "error",
+    compositePolicy: "errorOnTraversal",
+  },
+  {
+    memberKind: "standardAttribute",
+    names: { internal: "RoutePoint", yaml: "ТочкаМаршрута" },
+    family: "closedReverseLookup",
+    phase: "traversal-time",
+    sourceScope: "projectIndex",
+    result: "BusinessProcessRoutePoint",
+    source: "businessProcessesByTask",
+    emptyPolicy: "error",
+    allowNestedProperties: false,
+  },
+] as const
+
+registerStandardMembers("Задача", taskMembers)
+registerStandardMembers("ЗадачаОбъект", taskMembers)
+```
+
+For register objects, register `Recorder` with `target: "Document"`, `property: "registerRecords"`.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/resolver.test.ts -t "Recorder|BusinessProcess|RoutePoint"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/metadata/validation/dataPath packages/core/metadata/appliedObjects/metadataTask packages/core/metadata/appliedObjects/metadataInformationRegister packages/core/metadata/appliedObjects/metadataAccumulationRegister packages/core/metadata/appliedObjects/metadataAccountingRegister packages/core/metadata/appliedObjects/metadataCalculationRegister
+git commit -m "feat: :sparkles: добавить обратные standardMembers"
+```
+
+---
+
+### Task 6: Complete Object Declarations and Remove Duplicated Imperative Resolvers
+
+**Files:**
+- Create remaining `standardMembers.ts` files listed in File Structure.
+- Modify corresponding `register.ts` files.
+- Modify `packages/core/metadata/appliedObjects/dataPathCommon/register.ts`
+- Test: `packages/core/metadata/validation/dataPath/resolver.test.ts`
+- Test: `packages/core/metadata/validation/validateForm.test.ts`
+
+**Interfaces:**
+- Produces complete coverage for all rows in the spec.
+- Existing `registerStandardAttributeTypeResolver` remains only as fallback for explicit `Тип` and truly generic table columns.
+
+- [ ] **Step 1: Add coverage test for all known spec members**
+
+Create `packages/core/metadata/validation/dataPath/standardMembers.coverage.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { getStandardMembers } from "./standardMembers"
+
+describe("standardMembers declarations coverage", () => {
+  it.each([
+    ["Справочник", ["Ref", "Owner", "Code", "Description", "Parent", "IsFolder", "DeletionMark", "Predefined", "PredefinedDataName"]],
+    ["Документ", ["Ref", "Date", "Number", "Posted", "DeletionMark"]],
+    ["Перечисление", ["Ref", "Order"]],
+    ["ПланСчетов", ["Ref", "Code", "Description", "Parent", "Type", "OffBalance", "Order", "DeletionMark", "Predefined", "PredefinedDataName", "ExtDimensionTypes"]],
+    ["ПланВидовХарактеристик", ["Ref", "ValueType", "Code", "Description", "Parent", "IsFolder", "DeletionMark", "Predefined", "PredefinedDataName"]],
+    ["ПланВидовРасчета", ["Ref", "Code", "Description", "ActionPeriodIsBasic", "DeletionMark", "Predefined", "PredefinedDataName", "LeadingCalculationTypes", "DisplacingCalculationTypes", "BaseCalculationTypes"]],
+    ["ПланОбмена", ["Ref", "Code", "Description", "ThisNode", "ExchangeDate", "SentNo", "ReceivedNo", "DeletionMark"]],
+    ["ЖурналДокументов", ["Ref", "Type", "Date", "Number", "Posted", "DeletionMark"]],
+    ["БизнесПроцесс", ["Ref", "Date", "Number", "Started", "Completed", "HeadTask", "DeletionMark"]],
+    ["Задача", ["Ref", "Date", "Number", "Executed", "BusinessProcess", "RoutePoint", "Description", "DeletionMark"]],
+    ["РегистрСведений", ["Active", "LineNumber", "Recorder", "Period"]],
+    ["РегистрНакопления", ["RecordType", "Active", "LineNumber", "Recorder", "Period"]],
+    ["РегистрБухгалтерии", ["PeriodAdjustment", "Account", "Active", "LineNumber", "Recorder", "Period", "ExtDimension1", "ExtDimensionType1"]],
+    ["РегистрРасчета", ["RegistrationPeriod", "ReversingEntry", "Active", "BegOfActionPeriod", "EndOfActionPeriod", "ActionPeriod", "BegOfBasePeriod", "EndOfBasePeriod", "CalculationType", "LineNumber", "Recorder"]],
+  ])("%s has declared standard members", (ownerKind, expectedNames) => {
+    const actualNames = getStandardMembers(ownerKind).map((member) => member.names.internal)
+    for (const name of expectedNames) expect(actualNames).toContain(name)
+  })
+})
+```
+
+- [ ] **Step 2: Run coverage test and see missing declarations**
+
+Run: `pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/standardMembers.coverage.test.ts`
+
+Expected: FAIL listing missing declarations.
+
+- [ ] **Step 3: Add remaining object declaration files**
+
+For each object, create `standardMembers.ts` with declarations matching the spec. Example for document:
+
+```ts
+import { registerStandardMembers } from "../../validation/dataPath/registry"
+
+const documentMembers = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Date", yaml: "Дата" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "Number", yaml: "Номер" }, family: "numberByProperty", phase: "index-time", sourceScope: "ownerModel", property: "numberType" },
+  { memberKind: "standardAttribute", names: { internal: "Posted", yaml: "Проведен" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+] as const
+
+registerStandardMembers("Документ", documentMembers)
+registerStandardMembers("ДокументОбъект", documentMembers)
+```
+
+Import each file from the matching `register.ts`.
+
+- [ ] **Step 4: Replace object-specific imperative code when covered by declarations**
+
+Remove branches from old `registerStandardAttributeTypeResolver` and `registerVirtualOwnerFieldResolver` that are now represented by declarations. Keep:
+
+- `registerObjectFieldCollectionProvider`
+- generic table column resolvers for `RowsCount`, `Total*`, `ValueList`, `GanttChart`
+- `RegisterRecordSet` table column resolver until standard member coverage fully replaces it in a later pass
+
+- [ ] **Step 5: Run focused validation tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath/resolver.test.ts packages/core/metadata/validation/validateForm.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/metadata/appliedObjects packages/core/metadata/validation/dataPath packages/core/metadata/validation/validateForm.test.ts
+git commit -m "feat: :sparkles: перенести стандартные члены в декларации"
+```
+
+---
+
+### Task 7: Add YAML/DataPath Alias Translation Through `standardMembers`
+
+**Files:**
+- Modify: `packages/core/metadata/commonObjects/metadataTargets/roots.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataTargets/parse.ts`
+- Modify: `packages/core/metadata/commonObjects/metadataTargets/format.ts`
+- Modify or create: `packages/core/metadata/operations/dataPathReferences.test.ts`
+- Test: `packages/core/metadata/commonObjects/metadataTargets/parse.test.ts`
+
+**Interfaces:**
+- Consumes `standardMembers` declarations for alias mapping.
+- Produces internal-to-YAML translation for standard attributes and standard tabular sections used in `DataPath`.
+
+- [ ] **Step 1: Add failing parse/format tests**
+
+In `metadataTargets/parse.test.ts`, add:
+
+```ts
+it("parses and formats standard member YAML aliases from declarations", () => {
+  expect(parseMetadataTarget("Catalog.Номенклатура.StandardAttribute.Владелец", { source: "yaml" })).toMatchObject({
+    canonical: "Catalog.Номенклатура.StandardAttribute.Owner",
+  })
+
+  expect(formatMetadataTarget("Catalog.Номенклатура.StandardAttribute.Owner", { target: "yaml" })).toBe(
+    "Catalog.Номенклатура.StandardAttribute.Владелец"
+  )
+})
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `pnpm --filter @nakidka/core exec vitest run packages/core/metadata/commonObjects/metadataTargets/parse.test.ts -t "standard member YAML aliases"`
+
+Expected: FAIL because current maps are static.
+
+- [ ] **Step 3: Add neutral alias lookup helpers**
+
+In `standardMembers.ts`, export:
+
+```ts
+export function standardMemberInternalToYaml(internalName: string): string | undefined {
+  for (const members of allStandardMemberGroups()) {
+    const member = members.find((item) => item.names.internal === internalName)
+    if (member !== undefined) return member.names.yaml
+  }
+  return undefined
+}
+
+export function standardMemberYamlToInternal(yamlName: string): string | undefined {
+  for (const members of allStandardMemberGroups()) {
+    const member = members.find((item) => item.names.yaml === yamlName)
+    if (member !== undefined) return member.names.internal
+  }
+  return undefined
+}
+
+function allStandardMemberGroups(): StandardMemberDeclaration[][] {
+  return [...membersByOwnerKind.values()]
+}
+```
+
+- [ ] **Step 4: Use alias helpers in metadata target parse/format**
+
+Replace static standard attribute map calls in `metadataTargets/parse.ts` and `format.ts` with fallback to `standardMemberYamlToInternal` / `standardMemberInternalToYaml`.
+
+Keep the existing static maps as fallback until all imports are proven initialized in tests.
+
+- [ ] **Step 5: Run parse/format tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/commonObjects/metadataTargets/parse.test.ts packages/core/metadata/operations/dataPathReferences.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/metadata/commonObjects/metadataTargets packages/core/metadata/operations packages/core/metadata/validation/dataPath
+git commit -m "feat: :sparkles: переводить DataPath через standardMembers"
+```
+
+---
+
+### Task 8: Boundary Tests, Cleanup, and Full Verification
+
+**Files:**
+- Modify: `packages/core/metadata/importBoundaries.test.ts`
+- Modify: `docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md` only if implementation reveals a spec correction.
+- Test: project-wide.
+
+**Interfaces:**
+- Produces enforced boundary: validation core stays generic; applied object declarations stay colocated.
+
+- [ ] **Step 1: Add import boundary tests**
+
+In `importBoundaries.test.ts`, add assertions:
+
+```ts
+it("standardMembers core не содержит concrete owner kinds", () => {
+  const files = [
+    "metadata/validation/dataPath/standardMembers.ts",
+    "metadata/validation/dataPath/objectFields.ts",
+    "metadata/validation/dataPath/resolver.ts",
+  ]
+  for (const file of files) {
+    const source = readFileSync(join(process.cwd(), file), "utf-8")
+    expect(source).not.toMatch(/Справочник|Документ|ПланСчетов|Регистр/)
+  }
+})
+
+it("standardMembers declarations live with applied objects", () => {
+  expect(existsSync(join(METADATA_DIR, "appliedObjects", "metadataCatalog", "standardMembers.ts"))).toBe(true)
+  expect(existsSync(join(METADATA_DIR, "appliedObjects", "metadataTask", "standardMembers.ts"))).toBe(true)
+})
+```
+
+- [ ] **Step 2: Run boundary tests**
+
+Run: `pnpm --filter @nakidka/core exec vitest run packages/core/metadata/importBoundaries.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run complete core validation/dataPath tests**
+
+Run:
+
+```bash
+pnpm --filter @nakidka/core exec vitest run packages/core/metadata/validation/dataPath packages/core/metadata/validation/validateForm.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full project tests**
+
+Run: `pnpm test`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit final cleanup**
+
+```bash
+git add packages/core/metadata docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+git commit -m "test: :white_check_mark: закрепить границы standardMembers"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: covered standard attributes, standard tabular sections, standard tabular section columns, `standardMembers` location, unsupported `ExtDimension*`, reverse lookup empty errors, and YAML/DataPath aliasing.
+- Placeholder scan: no forbidden placeholder markers; every task has exact files, commands, and expected results.
+- Type consistency: central names are `StandardMemberDeclaration`, `registerStandardMembers`, `resolveIndexTimeStandardMember`, `resolveTraversalTimeStandardMember`, and `resolveStandardTableColumn`; all later tasks use these names.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -41,8 +41,8 @@
 | Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | зависит от свойства `numberType` (`DocumentNumberType`) | `dataPath: { type: "documentNumber", property: "numberType" }` | - [x] |
 | Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект |  | - [ ] |
-| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число |  | - [ ] |
+| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | `dataPath: { type: "number" }` | - [x] |
 | План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект |  | - [ ] |
 | План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка |  | - [ ] |
@@ -143,6 +143,8 @@
 - `PredefinedDataName`: строка.
 - `IsFolder`, `DeletionMark`, `Predefined`, `Posted`: булевы.
 - `Date`: дата.
+- `Enum.Order`: число.
+- `Enum.Ref`: ссылка на само перечисление.
 - `LineNumber`: число.
 
 Все строки с неотмеченным флажком `Разобрано` остаются в таблице для последующего уточнения и используют безопасное резервное поведение.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -14,122 +14,122 @@
 
 | Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Разобрано |
 | --- | --- | --- | --- | --- | --- |
-| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | да |
-| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | да |
-| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | да |
-| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | да |
-| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | да |
-| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | резервное поведение | нет |
-| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | да |
-| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | да |
-| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | да |
-| Общие объектные | Date | Дата | имена в rules | дата | да |
-| Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца | нет |
-| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | да |
-| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | да |
-| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | да |
-| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | да |
-| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | да |
-| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | да |
-| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | да |
-| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | да |
-| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | да |
-| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | да |
-| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | резервное поведение | нет |
-| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | да |
-| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | да |
-| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа | нет |
-| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | да |
-| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | да |
-| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект | нет |
-| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | нет |
-| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | нет |
-| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода | нет |
-| План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка | нет |
-| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | нет |
-| План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | нет |
-| План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево | нет |
-| План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число | нет |
-| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево | нет |
-| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево | нет |
-| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | нет |
-| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | нет |
-| План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа | нет |
-| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода | нет |
-| План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | нет |
-| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | нет |
-| План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | нет |
-| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | нет |
-| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | нет |
-| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | резервное поведение | нет |
-| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | текущий объект | нет |
-| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода | нет |
-| План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | нет |
-| План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | нет |
-| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | нет |
-| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | нет |
-| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | резервное поведение | нет |
-| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | текущий объект | нет |
-| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода | нет |
-| План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка | нет |
-| План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена | нет |
-| План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата | нет |
-| План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр | нет |
-| План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр | нет |
-| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево | нет |
-| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | нет |
-| Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | нет |
-| Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата | нет |
-| Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | нет |
-| Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево | нет |
-| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | нет |
-| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | текущий объект | нет |
-| Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата | нет |
-| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение | нет |
-| Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево | нет |
-| Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево | нет |
-| Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача | нет |
-| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | нет |
-| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | текущий объект | нет |
-| Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата | нет |
-| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение | нет |
-| Задача | Executed | Выполнена | `dataPathCommon` | булево | нет |
-| Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс | нет |
-| Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса | нет |
-| Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка | нет |
-| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево | нет |
-| Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево | нет |
-| Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число | нет |
-| Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | регистратор | нет |
-| Регистр сведений | Period | Период | `MetadataInformationRegisterStandardAttributeNames` | дата | нет |
-| Регистр накопления | RecordType | ВидДвижения | `MetadataAccumulationRegisterStandardAttributeNames` | резервное поведение | нет |
-| Регистр накопления | Active | Активность | `MetadataAccumulationRegisterStandardAttributeNames` | булево | нет |
-| Регистр накопления | LineNumber | НомерСтроки | `MetadataAccumulationRegisterStandardAttributeNames` | число | нет |
-| Регистр накопления | Recorder | Регистратор | `MetadataAccumulationRegisterStandardAttributeNames` | регистратор | нет |
-| Регистр накопления | Period | Период | `MetadataAccumulationRegisterStandardAttributeNames` | дата | нет |
-| Регистр накопления оборотов | Active | Активность | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | булево | нет |
-| Регистр накопления оборотов | LineNumber | НомерСтроки | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | число | нет |
-| Регистр накопления оборотов | Recorder | Регистратор | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | регистратор | нет |
-| Регистр накопления оборотов | Period | Период | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | дата | нет |
-| Регистр бухгалтерии | PeriodAdjustment | УточнениеПериода | `MetadataAccountingRegisterStandardAttributeNames` | резервное поведение | нет |
-| Регистр бухгалтерии | Account | Счет | `MetadataAccountingRegisterStandardAttributeNames` | план счетов | нет |
-| Регистр бухгалтерии | Active | Активность | `MetadataAccountingRegisterStandardAttributeNames` | булево | нет |
-| Регистр бухгалтерии | LineNumber | НомерСтроки | `MetadataAccountingRegisterStandardAttributeNames` | число | нет |
-| Регистр бухгалтерии | Recorder | Регистратор | `MetadataAccountingRegisterStandardAttributeNames` | регистратор | нет |
-| Регистр бухгалтерии | Period | Период | `MetadataAccountingRegisterStandardAttributeNames` | дата | нет |
-| Регистр бухгалтерии | ExtDimension1..50 | Субконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | нет |
-| Регистр бухгалтерии | ExtDimensionType1..50 | ВидСубконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | нет |
-| Регистр расчета | RegistrationPeriod | ПериодРегистрации | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
-| Регистр расчета | ReversingEntry | Сторно | `MetadataCalculationRegisterStandardAttributeNames` | булево | нет |
-| Регистр расчета | Active | Активность | `MetadataCalculationRegisterStandardAttributeNames` | булево | нет |
-| Регистр расчета | BegOfActionPeriod | НачалоПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
-| Регистр расчета | EndOfActionPeriod | КонецПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
-| Регистр расчета | ActionPeriod | ПериодДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата/период | нет |
-| Регистр расчета | BegOfBasePeriod | НачалоБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
-| Регистр расчета | EndOfBasePeriod | КонецБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
-| Регистр расчета | CalculationType | ВидРасчета | `MetadataCalculationRegisterStandardAttributeNames` | план видов расчета | нет |
-| Регистр расчета | LineNumber | НомерСтроки | `MetadataCalculationRegisterStandardAttributeNames` | число | нет |
-| Регистр расчета | Recorder | Регистратор | `MetadataCalculationRegisterStandardAttributeNames` | регистратор | нет |
+| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | - [x] |
+| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | - [x] |
+| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | - [x] |
+| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | - [x] |
+| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | - [x] |
+| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | резервное поведение | - [ ] |
+| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | - [x] |
+| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | - [x] |
+| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | - [x] |
+| Общие объектные | Date | Дата | имена в rules | дата | - [x] |
+| Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца | - [ ] |
+| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | - [x] |
+| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | - [x] |
+| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | - [x] |
+| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | - [x] |
+| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | - [x] |
+| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | - [x] |
+| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | - [x] |
+| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | - [x] |
+| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | - [x] |
+| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | - [x] |
+| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | резервное поведение | - [ ] |
+| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | - [x] |
+| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | - [x] |
+| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа | - [ ] |
+| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | - [x] |
+| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | - [x] |
+| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект | - [ ] |
+| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | - [ ] |
+| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | - [ ] |
+| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода | - [ ] |
+| План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка | - [ ] |
+| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | - [ ] |
+| План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | - [ ] |
+| План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево | - [ ] |
+| План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число | - [ ] |
+| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево | - [ ] |
+| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево | - [ ] |
+| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | - [ ] |
+| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | - [ ] |
+| План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа | - [ ] |
+| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода | - [ ] |
+| План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | - [ ] |
+| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | - [ ] |
+| План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | - [ ] |
+| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | - [ ] |
+| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | - [ ] |
+| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | резервное поведение | - [ ] |
+| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | текущий объект | - [ ] |
+| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода | - [ ] |
+| План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | - [ ] |
+| План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | - [ ] |
+| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | - [ ] |
+| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | - [ ] |
+| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | резервное поведение | - [ ] |
+| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | текущий объект | - [ ] |
+| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода | - [ ] |
+| План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка | - [ ] |
+| План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена | - [ ] |
+| План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата | - [ ] |
+| План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр | - [ ] |
+| План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр | - [ ] |
+| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево | - [ ] |
+| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | - [ ] |
+| Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | - [ ] |
+| Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата | - [ ] |
+| Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | - [ ] |
+| Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево | - [ ] |
+| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | - [ ] |
+| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | текущий объект | - [ ] |
+| Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата | - [ ] |
+| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение | - [ ] |
+| Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево | - [ ] |
+| Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево | - [ ] |
+| Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача | - [ ] |
+| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | - [ ] |
+| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | текущий объект | - [ ] |
+| Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата | - [ ] |
+| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение | - [ ] |
+| Задача | Executed | Выполнена | `dataPathCommon` | булево | - [ ] |
+| Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс | - [ ] |
+| Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса | - [ ] |
+| Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка | - [ ] |
+| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево | - [ ] |
+| Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево | - [ ] |
+| Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число | - [ ] |
+| Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | регистратор | - [ ] |
+| Регистр сведений | Period | Период | `MetadataInformationRegisterStandardAttributeNames` | дата | - [ ] |
+| Регистр накопления | RecordType | ВидДвижения | `MetadataAccumulationRegisterStandardAttributeNames` | резервное поведение | - [ ] |
+| Регистр накопления | Active | Активность | `MetadataAccumulationRegisterStandardAttributeNames` | булево | - [ ] |
+| Регистр накопления | LineNumber | НомерСтроки | `MetadataAccumulationRegisterStandardAttributeNames` | число | - [ ] |
+| Регистр накопления | Recorder | Регистратор | `MetadataAccumulationRegisterStandardAttributeNames` | регистратор | - [ ] |
+| Регистр накопления | Period | Период | `MetadataAccumulationRegisterStandardAttributeNames` | дата | - [ ] |
+| Регистр накопления оборотов | Active | Активность | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | булево | - [ ] |
+| Регистр накопления оборотов | LineNumber | НомерСтроки | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | число | - [ ] |
+| Регистр накопления оборотов | Recorder | Регистратор | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | регистратор | - [ ] |
+| Регистр накопления оборотов | Period | Период | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | дата | - [ ] |
+| Регистр бухгалтерии | PeriodAdjustment | УточнениеПериода | `MetadataAccountingRegisterStandardAttributeNames` | резервное поведение | - [ ] |
+| Регистр бухгалтерии | Account | Счет | `MetadataAccountingRegisterStandardAttributeNames` | план счетов | - [ ] |
+| Регистр бухгалтерии | Active | Активность | `MetadataAccountingRegisterStandardAttributeNames` | булево | - [ ] |
+| Регистр бухгалтерии | LineNumber | НомерСтроки | `MetadataAccountingRegisterStandardAttributeNames` | число | - [ ] |
+| Регистр бухгалтерии | Recorder | Регистратор | `MetadataAccountingRegisterStandardAttributeNames` | регистратор | - [ ] |
+| Регистр бухгалтерии | Period | Период | `MetadataAccountingRegisterStandardAttributeNames` | дата | - [ ] |
+| Регистр бухгалтерии | ExtDimension1..50 | Субконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | - [ ] |
+| Регистр бухгалтерии | ExtDimensionType1..50 | ВидСубконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | - [ ] |
+| Регистр расчета | RegistrationPeriod | ПериодРегистрации | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
+| Регистр расчета | ReversingEntry | Сторно | `MetadataCalculationRegisterStandardAttributeNames` | булево | - [ ] |
+| Регистр расчета | Active | Активность | `MetadataCalculationRegisterStandardAttributeNames` | булево | - [ ] |
+| Регистр расчета | BegOfActionPeriod | НачалоПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
+| Регистр расчета | EndOfActionPeriod | КонецПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
+| Регистр расчета | ActionPeriod | ПериодДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата/период | - [ ] |
+| Регистр расчета | BegOfBasePeriod | НачалоБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
+| Регистр расчета | EndOfBasePeriod | КонецБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
+| Регистр расчета | CalculationType | ВидРасчета | `MetadataCalculationRegisterStandardAttributeNames` | план видов расчета | - [ ] |
+| Регистр расчета | LineNumber | НомерСтроки | `MetadataCalculationRegisterStandardAttributeNames` | число | - [ ] |
+| Регистр расчета | Recorder | Регистратор | `MetadataCalculationRegisterStandardAttributeNames` | регистратор | - [ ] |
 
 ## Разобранные правила
 
@@ -143,4 +143,4 @@
 - `Date`: дата.
 - `LineNumber`: число.
 
-Все строки с `Разобрано: нет` остаются в таблице для последующего уточнения и используют безопасное резервное поведение.
+Все строки с неотмеченным флажком `Разобрано` остаются в таблице для последующего уточнения и используют безопасное резервное поведение.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -19,7 +19,7 @@
 | Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | `dataPath: { type: "objectRefsFromProperty", property: "owners" }` | - [x] |
 | Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | резервное поведение |  | - [ ] |
+| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | строка | `dataPath: { type: "string" }` | - [x] |
 | Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | `dataPath: { type: "string" }` | - [x] |
 | Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | `dataPath: { type: "catalogCode", property: "codeType" }` | - [x] |
 | Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | `dataPath: { type: "boolean" }` | - [x] |
@@ -35,7 +35,7 @@
 | Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | `dataPath: { type: "dateTime" }` | - [x] |
 | Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа |  | - [ ] |
@@ -52,7 +52,7 @@
 | План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число |  | - [ ] |
 | План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
 | План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
-| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение |  | - [ ] |
+| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект |  | - [ ] |
 | План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа |  | - [ ] |
 | План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
@@ -61,14 +61,14 @@
 | План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
-| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | резервное поведение |  | - [ ] |
+| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | текущий объект |  | - [ ] |
 | План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка |  | - [ ] |
 | План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
-| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | резервное поведение |  | - [ ] |
+| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | текущий объект |  | - [ ] |
 | План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка |  | - [ ] |
@@ -139,6 +139,7 @@
 - `Owner`: типы из свойства `owners`, с `isComposite` при нескольких владельцах.
 - `Code`: для справочника через `codeType`.
 - `Description`: строка для справочника.
+- `PredefinedDataName`: строка.
 - `IsFolder`, `DeletionMark`, `Predefined`, `Posted`: булевы.
 - `Date`: дата.
 - `LineNumber`: число.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -44,7 +44,7 @@
 | Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | `dataPath: { type: "number" }` | - [x] |
 | План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода |  | - [ ] |
+| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка |  | - [ ] |
 | План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение |  | - [ ] |
@@ -55,7 +55,7 @@
 | План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа |  | - [ ] |
-| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
+| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка |  | - [ ] |
 | План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
@@ -63,14 +63,14 @@
 | План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
+| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | зависит от свойства `codeType` (`ChartOfCalculationTypesCodeType`) | `dataPath: { type: "calculationTypeCode", property: "codeType" }` | - [x] |
 | План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка |  | - [ ] |
 | План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода |  | - [ ] |
+| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка |  | - [ ] |
 | План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена |  | - [ ] |
 | План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата |  | - [ ] |
@@ -85,14 +85,14 @@
 | Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата |  | - [ ] |
-| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | зависит от свойства `numberType` (`BusinessProcessNumberType`) | `dataPath: { type: "businessProcessNumber", property: "numberType" }` | - [x] |
 | Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево |  | - [ ] |
 | Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево |  | - [ ] |
 | Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача |  | - [ ] |
 | Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата |  | - [ ] |
-| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | зависит от свойства `numberType` (`TaskNumberType`) | `dataPath: { type: "taskNumber", property: "numberType" }` | - [x] |
 | Задача | Executed | Выполнена | `dataPathCommon` | булево |  | - [ ] |
 | Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс |  | - [ ] |
 | Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса |  | - [ ] |
@@ -139,7 +139,11 @@
 - `Parent`: всегда ссылка на сам объект.
 - `Owner`: типы из свойства `owners`, с `isComposite` при нескольких владельцах.
 - `Code`: для справочника через `codeType`.
+- `ChartOfCalculationTypes.Code`: через `codeType`.
+- `ChartOfAccounts.Code`, `ChartOfCharacteristicTypes.Code`, `ExchangePlan.Code`: строка.
 - `Number`: для документа через `numberType`.
+- `BusinessProcess.Number`: через `numberType`.
+- `Task.Number`: через `numberType`.
 - `Description`: строка для справочника.
 - `PredefinedDataName`: строка.
 - `DeletionMark`, `Predefined`: всегда булевы.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -14,7 +14,7 @@
 
 | Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Спецификация | Разобрано |
 | --- | --- | --- | --- | --- | --- | --- |
-| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Общие объектные | Ref | Ссылка | `dataPathCommon` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | `dataPath: { type: "objectRefsFromProperty", property: "owners" }` | - [x] |
 | Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
@@ -27,7 +27,7 @@
 | Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца |  | - [ ] |
 | Общие объектные | Posted | Проведен | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | `dataPath: { type: "number" }` | - [x] |
-| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | `dataPath: { type: "objectRefsFromProperty", property: "owners" }` | - [x] |
 | Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | `dataPath: { type: "catalogCode", property: "codeType" }` | - [x] |
 | Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
@@ -36,14 +36,14 @@
 | Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | `dataPath: { type: "dateTime" }` | - [x] |
 | Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | зависит от свойства `numberType` (`DocumentNumberType`) | `dataPath: { type: "documentNumber", property: "numberType" }` | - [x] |
 | Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | `dataPath: { type: "number" }` | - [x] |
-| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект |  | - [ ] |
+| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка |  | - [ ] |
 | План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект |  | - [ ] |
@@ -53,7 +53,7 @@
 | План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
 | План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
 | План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект |  | - [ ] |
+| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа |  | - [ ] |
 | План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка |  | - [ ] |
@@ -62,14 +62,14 @@
 | План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | текущий объект |  | - [ ] |
+| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка |  | - [ ] |
 | План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | текущий объект |  | - [ ] |
+| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка |  | - [ ] |
 | План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена |  | - [ ] |
@@ -77,20 +77,20 @@
 | План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр |  | - [ ] |
 | План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр |  | - [ ] |
 | План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево |  | - [ ] |
-| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
 | Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата |  | - [ ] |
 | Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
 | Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево |  | - [ ] |
 | Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево |  | - [ ] |
-| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | текущий объект |  | - [ ] |
+| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата |  | - [ ] |
 | Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение |  | - [ ] |
 | Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево |  | - [ ] |
 | Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево |  | - [ ] |
 | Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача |  | - [ ] |
 | Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево |  | - [ ] |
-| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | текущий объект |  | - [ ] |
+| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата |  | - [ ] |
 | Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение |  | - [ ] |
 | Задача | Executed | Выполнена | `dataPathCommon` | булево |  | - [ ] |
@@ -135,7 +135,7 @@
 
 На текущем этапе разобраны правила, достаточные для задачи с `Owner`:
 
-- `Ref`: тип текущего объекта.
+- `Ref`: всегда ссылка на сам объект.
 - `Owner`: типы из свойства `owners`, с `isComposite` при нескольких владельцах.
 - `Code`: для справочника через `codeType`.
 - `Number`: для документа через `numberType`.
@@ -144,7 +144,6 @@
 - `IsFolder`, `DeletionMark`, `Predefined`, `Posted`: булевы.
 - `Date`: дата.
 - `Enum.Order`: число.
-- `Enum.Ref`: ссылка на само перечисление.
 - `LineNumber`: число.
 
 Все строки с неотмеченным флажком `Разобрано` остаются в таблице для последующего уточнения и используют безопасное резервное поведение.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -14,33 +14,33 @@
 
 | Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Спецификация | Разобрано |
 | --- | --- | --- | --- | --- | --- | --- |
-| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | `sameOwnerObject` | - [x] |
-| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | `sameOwnerObject` | - [x] |
-| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | `objectRefsFromProperty(owners)` | - [x] |
-| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | `scalar(boolean)` | - [x] |
-| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | `scalar(boolean)` | - [x] |
+| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | `dataPath: { type: "objectRefsFromProperty", property: "owners" }` | - [x] |
+| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
+| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | резервное поведение |  | - [ ] |
-| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | `scalar(string)` | - [x] |
-| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | `typeFromProperty(codeType)` | - [x] |
-| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | `scalar(boolean)` | - [x] |
-| Общие объектные | Date | Дата | имена в rules | дата | `scalar(dateTime)` | - [x] |
+| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | `dataPath: { type: "string" }` | - [x] |
+| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | `dataPath: { type: "catalogCode", property: "codeType" }` | - [x] |
+| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | `dataPath: { type: "boolean" }` | - [x] |
+| Общие объектные | Date | Дата | имена в rules | дата | `dataPath: { type: "dateTime" }` | - [x] |
 | Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца |  | - [ ] |
-| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | `scalar(boolean)` | - [x] |
-| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | `scalar(number)` | - [x] |
-| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | `sameOwnerObject` | - [x] |
-| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | `objectRefsFromProperty(owners)` | - [x] |
-| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | `typeFromProperty(codeType)` | - [x] |
-| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | `scalar(string)` | - [x] |
-| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | `sameOwnerObject` | - [x] |
-| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
-| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
-| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
+| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
+| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | `dataPath: { type: "number" }` | - [x] |
+| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | `dataPath: { type: "objectRefsFromProperty", property: "owners" }` | - [x] |
+| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | `dataPath: { type: "catalogCode", property: "codeType" }` | - [x] |
+| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
+| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
+| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
+| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | резервное поведение |  | - [ ] |
-| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | `sameOwnerObject` | - [x] |
-| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | `scalar(dateTime)` | - [x] |
+| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | `dataPath: { type: "dateTime" }` | - [x] |
 | Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа |  | - [ ] |
-| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
-| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
+| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
+| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект |  | - [ ] |
 | Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число |  | - [ ] |
 | План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект |  | - [ ] |

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -14,122 +14,259 @@
 
 | Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Спецификация | Разобрано |
 | --- | --- | --- | --- | --- | --- | --- |
-| Общие объектные | Ref | Ссылка | `dataPathCommon` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Общие объектные | Parent | Родитель | `dataPathCommon` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | `dataPath: { type: "objectRefsFromProperty", property: "owners" }` | - [x] |
-| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | строка | `dataPath: { type: "string" }` | - [x] |
-| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | `dataPath: { type: "string" }` | - [x] |
-| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | `dataPath: { type: "catalogCode", property: "codeType" }` | - [x] |
-| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Общие объектные | Date | Дата | имена в rules | дата | `dataPath: { type: "dateTime" }` | - [x] |
-| Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца |  | - [ ] |
-| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | `dataPath: { type: "number" }` | - [x] |
-| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | `dataPath: { type: "objectRefsFromProperty", property: "owners" }` | - [x] |
-| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | `dataPath: { type: "catalogCode", property: "codeType" }` | - [x] |
-| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | `dataPath: { type: "dateTime" }` | - [x] |
-| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | зависит от свойства `numberType` (`DocumentNumberType`) | `dataPath: { type: "documentNumber", property: "numberType" }` | - [x] |
-| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | `dataPath: { type: "number" }` | - [x] |
-| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка |  | - [ ] |
-| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение |  | - [ ] |
-| План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
-| План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число |  | - [ ] |
-| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа |  | - [ ] |
-| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка |  | - [ ] |
-| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
-| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | зависит от свойства `codeType` (`ChartOfCalculationTypesCodeType`) | `dataPath: { type: "calculationTypeCode", property: "codeType" }` | - [x] |
-| План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка |  | - [ ] |
-| План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
-| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка |  | - [ ] |
-| План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена |  | - [ ] |
-| План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата |  | - [ ] |
-| План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр |  | - [ ] |
-| План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр |  | - [ ] |
-| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
-| Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата |  | - [ ] |
-| Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
-| Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево |  | - [ ] |
-| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата |  | - [ ] |
-| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | зависит от свойства `numberType` (`BusinessProcessNumberType`) | `dataPath: { type: "businessProcessNumber", property: "numberType" }` | - [x] |
-| Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево |  | - [ ] |
-| Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево |  | - [ ] |
-| Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача |  | - [ ] |
-| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата |  | - [ ] |
-| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | зависит от свойства `numberType` (`TaskNumberType`) | `dataPath: { type: "taskNumber", property: "numberType" }` | - [x] |
-| Задача | Executed | Выполнена | `dataPathCommon` | булево |  | - [ ] |
-| Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс |  | - [ ] |
-| Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса |  | - [ ] |
-| Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка |  | - [ ] |
-| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
-| Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево |  | - [ ] |
-| Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число |  | - [ ] |
-| Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | регистратор |  | - [ ] |
-| Регистр сведений | Period | Период | `MetadataInformationRegisterStandardAttributeNames` | дата |  | - [ ] |
-| Регистр накопления | RecordType | ВидДвижения | `MetadataAccumulationRegisterStandardAttributeNames` | резервное поведение |  | - [ ] |
-| Регистр накопления | Active | Активность | `MetadataAccumulationRegisterStandardAttributeNames` | булево |  | - [ ] |
-| Регистр накопления | LineNumber | НомерСтроки | `MetadataAccumulationRegisterStandardAttributeNames` | число |  | - [ ] |
-| Регистр накопления | Recorder | Регистратор | `MetadataAccumulationRegisterStandardAttributeNames` | регистратор |  | - [ ] |
-| Регистр накопления | Period | Период | `MetadataAccumulationRegisterStandardAttributeNames` | дата |  | - [ ] |
-| Регистр накопления оборотов | Active | Активность | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | булево |  | - [ ] |
-| Регистр накопления оборотов | LineNumber | НомерСтроки | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | число |  | - [ ] |
-| Регистр накопления оборотов | Recorder | Регистратор | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | регистратор |  | - [ ] |
-| Регистр накопления оборотов | Period | Период | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | дата |  | - [ ] |
-| Регистр бухгалтерии | PeriodAdjustment | УточнениеПериода | `MetadataAccountingRegisterStandardAttributeNames` | резервное поведение |  | - [ ] |
-| Регистр бухгалтерии | Account | Счет | `MetadataAccountingRegisterStandardAttributeNames` | план счетов |  | - [ ] |
-| Регистр бухгалтерии | Active | Активность | `MetadataAccountingRegisterStandardAttributeNames` | булево |  | - [ ] |
-| Регистр бухгалтерии | LineNumber | НомерСтроки | `MetadataAccountingRegisterStandardAttributeNames` | число |  | - [ ] |
-| Регистр бухгалтерии | Recorder | Регистратор | `MetadataAccountingRegisterStandardAttributeNames` | регистратор |  | - [ ] |
-| Регистр бухгалтерии | Period | Период | `MetadataAccountingRegisterStandardAttributeNames` | дата |  | - [ ] |
-| Регистр бухгалтерии | ExtDimension1..50 | Субконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора |  | - [ ] |
-| Регистр бухгалтерии | ExtDimensionType1..50 | ВидСубконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора |  | - [ ] |
-| Регистр расчета | RegistrationPeriod | ПериодРегистрации | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
-| Регистр расчета | ReversingEntry | Сторно | `MetadataCalculationRegisterStandardAttributeNames` | булево |  | - [ ] |
-| Регистр расчета | Active | Активность | `MetadataCalculationRegisterStandardAttributeNames` | булево |  | - [ ] |
-| Регистр расчета | BegOfActionPeriod | НачалоПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
-| Регистр расчета | EndOfActionPeriod | КонецПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
-| Регистр расчета | ActionPeriod | ПериодДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата/период |  | - [ ] |
-| Регистр расчета | BegOfBasePeriod | НачалоБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
-| Регистр расчета | EndOfBasePeriod | КонецБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
-| Регистр расчета | CalculationType | ВидРасчета | `MetadataCalculationRegisterStandardAttributeNames` | план видов расчета |  | - [ ] |
-| Регистр расчета | LineNumber | НомерСтроки | `MetadataCalculationRegisterStandardAttributeNames` | число |  | - [ ] |
-| Регистр расчета | Recorder | Регистратор | `MetadataCalculationRegisterStandardAttributeNames` | регистратор |  | - [ ] |
+| Общие объектные | Ref | Ссылка | `dataPathCommon` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| Общие объектные | Parent | Родитель | `dataPathCommon` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | `dataPath: { family: "objectRefsFromProperty", property: "owners" }` | - [x] |
+| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| Общие объектные | Description | Наименование / Описание | имена в rules | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | `dataPath: { family: "codeByProperty", property: "codeType" }` | - [x] |
+| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Общие объектные | Date | Дата | имена в rules | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | `dataPath: { family: "objectRefsFromProperty", property: "owners" }` | - [x] |
+| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | `dataPath: { family: "codeByProperty", property: "codeType" }` | - [x] |
+| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | зависит от свойства `numberType` (`DocumentNumberType`) | `dataPath: { family: "numberByProperty", property: "numberType" }` | - [x] |
+| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | стандартное перечисление `ВидСчета` | `dataPath: { family: "standardEnum", name: "AccountType" }` | - [x] |
+| План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | `ОписаниеТипов` (`TypeDescription`), вложенные свойства недоступны | `dataPath: { family: "typeDescription", allowNestedProperties: false }` | - [x] |
+| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | зависит от свойства `codeType` (`ChartOfCalculationTypesCodeType`) | `dataPath: { family: "codeByProperty", property: "codeType" }` | - [x] |
+| План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| План обмена | SentNo | НомерОтправленного | `dataPathCommon` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | `Тип`, дальше не раскрывается | `dataPath: { family: "opaque", name: "Type", allowNestedProperties: false }` | - [x] |
+| Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | на первом этапе строка без раскрытия; реально зависит от типов номеров документов, входящих в журнал | `dataPath: { family: "primitive", kind: "string", note: "realTypeDependsOnJournalDocuments", allowNestedProperties: false }` | - [x] |
+| Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | зависит от свойства `numberType` (`BusinessProcessNumberType`) | `dataPath: { family: "numberByProperty", property: "numberType" }` | - [x] |
+| Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача из свойства `task` | `dataPath: { family: "objectRefFromProperty", property: "task" }` | - [x] |
+| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | ссылка на сам объект | `dataPath: { family: "sameOwnerObject" }` | - [x] |
+| Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | зависит от свойства `numberType` (`TaskNumberType`) | `dataPath: { family: "numberByProperty", property: "numberType" }` | - [x] |
+| Задача | Executed | Выполнена | `dataPathCommon` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процессы, у которых в свойствах задач установлена эта задача; при нескольких значениях вложенные свойства недоступны | `dataPath: { family: "reverseLookup", target: "BusinessProcess", property: "tasks", empty: "error", allowNestedPropertiesWhenMultiple: false }` | - [x] |
+| Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | `ТочкаМаршрутаБизнесПроцесса` бизнес-процессов, у которых указана эта задача; дальше не раскрывается | `dataPath: { family: "closedReverseLookup", result: "BusinessProcessRoutePoint", source: "businessProcessesByTask", empty: "error", allowNestedProperties: false }` | - [x] |
+| Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка | `dataPath: { family: "primitive", kind: "string" }` | - [x] |
+| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | документы, у которых в `registerRecords` есть этот регистр; при нескольких регистраторах вложенные свойства недоступны | `dataPath: { family: "reverseLookup", target: "Document", property: "registerRecords", empty: "error", allowNestedPropertiesWhenMultiple: false }` | - [x] |
+| Регистр сведений | Period | Период | `MetadataInformationRegisterStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр накопления | RecordType | ВидДвижения | `MetadataAccumulationRegisterStandardAttributeNames` | стандартное перечисление `ВидДвиженияНакопления` | `dataPath: { family: "standardEnum", name: "AccumulationRecordType" }` | - [x] |
+| Регистр накопления | Active | Активность | `MetadataAccumulationRegisterStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Регистр накопления | LineNumber | НомерСтроки | `MetadataAccumulationRegisterStandardAttributeNames` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| Регистр накопления | Recorder | Регистратор | `MetadataAccumulationRegisterStandardAttributeNames` | документы, у которых в `registerRecords` есть этот регистр; при нескольких регистраторах вложенные свойства недоступны | `dataPath: { family: "reverseLookup", target: "Document", property: "registerRecords", empty: "error", allowNestedPropertiesWhenMultiple: false }` | - [x] |
+| Регистр накопления | Period | Период | `MetadataAccumulationRegisterStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр накопления оборотов | Active | Активность | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Регистр накопления оборотов | LineNumber | НомерСтроки | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| Регистр накопления оборотов | Recorder | Регистратор | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | документы, у которых в `registerRecords` есть этот регистр; при нескольких регистраторах вложенные свойства недоступны | `dataPath: { family: "reverseLookup", target: "Document", property: "registerRecords", empty: "error", allowNestedPropertiesWhenMultiple: false }` | - [x] |
+| Регистр накопления оборотов | Period | Период | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр бухгалтерии | PeriodAdjustment | УточнениеПериода | `MetadataAccountingRegisterStandardAttributeNames` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| Регистр бухгалтерии | Account | Счет | `MetadataAccountingRegisterStandardAttributeNames` | счет из плана счетов, указанного в `chartOfAccounts` rules | `dataPath: { family: "objectRefFromRuleProperty", property: "chartOfAccounts" }` | - [x] |
+| Регистр бухгалтерии | Active | Активность | `MetadataAccountingRegisterStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Регистр бухгалтерии | LineNumber | НомерСтроки | `MetadataAccountingRegisterStandardAttributeNames` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| Регистр бухгалтерии | Recorder | Регистратор | `MetadataAccountingRegisterStandardAttributeNames` | документы, у которых в `registerRecords` есть этот регистр; при нескольких регистраторах вложенные свойства недоступны | `dataPath: { family: "reverseLookup", target: "Document", property: "registerRecords", empty: "error", allowNestedPropertiesWhenMultiple: false }` | - [x] |
+| Регистр бухгалтерии | Period | Период | `MetadataAccountingRegisterStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр бухгалтерии | ExtDimension1..50 | Субконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора; на первом этапе использование и раскрытие запрещены | `dataPath: { family: "unsupported", reason: "accountingRegisterExtDimension" }` | - [x] |
+| Регистр бухгалтерии | ExtDimensionType1..50 | ВидСубконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора; на первом этапе использование и раскрытие запрещены | `dataPath: { family: "unsupported", reason: "accountingRegisterExtDimensionType" }` | - [x] |
+| Регистр расчета | RegistrationPeriod | ПериодРегистрации | `MetadataCalculationRegisterStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр расчета | ReversingEntry | Сторно | `MetadataCalculationRegisterStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Регистр расчета | Active | Активность | `MetadataCalculationRegisterStandardAttributeNames` | булево | `dataPath: { family: "primitive", kind: "boolean" }` | - [x] |
+| Регистр расчета | BegOfActionPeriod | НачалоПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр расчета | EndOfActionPeriod | КонецПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр расчета | ActionPeriod | ПериодДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр расчета | BegOfBasePeriod | НачалоБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр расчета | EndOfBasePeriod | КонецБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | `dataPath: { family: "primitive", kind: "dateTime" }` | - [x] |
+| Регистр расчета | CalculationType | ВидРасчета | `MetadataCalculationRegisterStandardAttributeNames` | вид расчета из плана видов расчета, указанного в `chartOfCalculationTypes` rules | `dataPath: { family: "objectRefFromRuleProperty", property: "chartOfCalculationTypes" }` | - [x] |
+| Регистр расчета | LineNumber | НомерСтроки | `MetadataCalculationRegisterStandardAttributeNames` | число | `dataPath: { family: "primitive", kind: "number" }` | - [x] |
+| Регистр расчета | Recorder | Регистратор | `MetadataCalculationRegisterStandardAttributeNames` | документы, у которых в `registerRecords` есть этот регистр; при нескольких регистраторах вложенные свойства недоступны | `dataPath: { family: "reverseLookup", target: "Document", property: "registerRecords", empty: "error", allowNestedPropertiesWhenMultiple: false }` | - [x] |
+
+## Таблица стандартных табличных частей
+
+Стандартные табличные части относятся к тем же платформенным членам объекта, что и стандартные реквизиты, но дают не поле значения, а `tableSource`. В rules они сейчас описаны через `standardTabularSections`, но скрыты из YAML (`toYAML: false`, `fromYAML: false`). На первом этапе они не выводятся в YAML как секции объекта и используются только для перевода и валидации `DataPath`.
+
+| Объект | Табличная часть | YAML | Источник сейчас | Правило таблицы | Спецификация | Разобрано |
+| --- | --- | --- | --- | --- | --- | --- |
+| План счетов | ExtDimensionTypes | ВидыСубконто | `metadataChartOfAccounts/register.ts`, `StandardTabularSections` XML | стандартная табличная часть видов субконто | `dataPath: { memberKind: "standardTabularSection", family: "standardTable", tableKind: "ValueTable" }` | - [x] |
+| План видов расчета | LeadingCalculationTypes | ВедущиеВидыРасчета | `metadataChartOfCalculationTypes/register.ts`, `StandardTabularSections` XML | стандартная табличная часть ведущих видов расчета | `dataPath: { memberKind: "standardTabularSection", family: "standardTable", tableKind: "ValueTable" }` | - [x] |
+| План видов расчета | DisplacingCalculationTypes | ВытесняющиеВидыРасчета | `metadataChartOfCalculationTypes/register.ts`, `StandardTabularSections` XML | стандартная табличная часть вытесняющих видов расчета | `dataPath: { memberKind: "standardTabularSection", family: "standardTable", tableKind: "ValueTable" }` | - [x] |
+| План видов расчета | BaseCalculationTypes | БазовыеВидыРасчета | `metadataChartOfCalculationTypes/register.ts`, `StandardTabularSections` XML | стандартная табличная часть базовых видов расчета | `dataPath: { memberKind: "standardTabularSection", family: "standardTable", tableKind: "ValueTable" }` | - [x] |
+
+## Таблица колонок стандартных табличных частей
+
+| Объект | Табличная часть | Колонка | YAML | Источник сейчас | Правило типа | Спецификация | Разобрано |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| План счетов | ExtDimensionTypes | ExtDimensionType | ВидСубконто | `metadataChartOfAccounts/register.ts` | ссылка на план видов характеристик из свойства `extDimensionTypes` владельца | `dataPath: { memberKind: "standardTabularSectionColumn", family: "objectRefFromOwnerProperty", property: "extDimensionTypes" }` | - [x] |
+| План счетов | ExtDimensionTypes | TurnoversOnly | ТолькоОбороты | `metadataChartOfAccounts/register.ts`, `StandardTabularSections` XML | булево | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "boolean" }` | - [x] |
+| План счетов | ExtDimensionTypes | ТолькоСальдо | ТолькоСальдо | `metadataChartOfAccounts/register.ts` | булево, русское имя используется как виртуальная колонка | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "boolean" }` | - [x] |
+| План счетов | ExtDimensionTypes | LineNumber | НомерСтроки | `StandardTabularSections` XML, общее правило табличных частей | число | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "number" }` | - [x] |
+| План счетов | ExtDimensionTypes | Predefined | Предопределенный | `StandardTabularSections` XML | булево | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "boolean" }` | - [x] |
+| План счетов | ExtDimensionTypes | ExtDimensionAccountingFlag.* | ПризнакУчетаСубконто.* | `metadataChartOfAccounts/register.ts`, имена из свойства `extDimensionAccountingFlags` | булево; имена колонок добавляются из коллекции признаков учета субконто | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "boolean", discoveredFrom: "extDimensionAccountingFlags" }` | - [x] |
+| План видов расчета | LeadingCalculationTypes | CalculationType | ВидРасчета | `metadataChartOfCalculationTypes/register.ts`, `StandardTabularSections` XML | ссылка на тот же план видов расчета | `dataPath: { memberKind: "standardTabularSectionColumn", family: "sameOwnerObject" }` | - [x] |
+| План видов расчета | LeadingCalculationTypes | LineNumber | НомерСтроки | `StandardTabularSections` XML, общее правило табличных частей | число | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "number" }` | - [x] |
+| План видов расчета | LeadingCalculationTypes | Predefined | Предопределенный | `StandardTabularSections` XML | булево | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "boolean" }` | - [x] |
+| План видов расчета | DisplacingCalculationTypes | CalculationType | ВидРасчета | `metadataChartOfCalculationTypes/register.ts`, `StandardTabularSections` XML | ссылка на тот же план видов расчета | `dataPath: { memberKind: "standardTabularSectionColumn", family: "sameOwnerObject" }` | - [x] |
+| План видов расчета | DisplacingCalculationTypes | LineNumber | НомерСтроки | `StandardTabularSections` XML, общее правило табличных частей | число | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "number" }` | - [x] |
+| План видов расчета | DisplacingCalculationTypes | Predefined | Предопределенный | `StandardTabularSections` XML | булево | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "boolean" }` | - [x] |
+| План видов расчета | BaseCalculationTypes | CalculationType | ВидРасчета | `metadataChartOfCalculationTypes/register.ts`, `StandardTabularSections` XML | ссылка на тот же план видов расчета | `dataPath: { memberKind: "standardTabularSectionColumn", family: "sameOwnerObject" }` | - [x] |
+| План видов расчета | BaseCalculationTypes | LineNumber | НомерСтроки | `StandardTabularSections` XML, общее правило табличных частей | число | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "number" }` | - [x] |
+| План видов расчета | BaseCalculationTypes | Predefined | Предопределенный | `StandardTabularSections` XML | булево | `dataPath: { memberKind: "standardTabularSectionColumn", family: "primitive", kind: "boolean" }` | - [x] |
+
+## Уникальные группы правил
+
+Реализация не должна плодить отдельный обработчик под каждый частный случай. Целевая модель — небольшие семейства правил с параметрами. В таблице спецификация записывается через поле `family`, чтобы сразу отражать это целевое устройство.
+
+### Примитивы
+
+Правило задает конечный тип без доступа к другим объектам. После такого реквизита путь дальше не разбирается.
+
+- `primitive: "boolean"`: `DeletionMark`, `Predefined`, `Posted`, `IsFolder`, `Active`, `Started`, `Completed`, `Executed`, `ReversingEntry`, `OffBalance`, `ThisNode`, `ActionPeriodIsBasic`.
+- `primitive: "string"`: `Description`, `PredefinedDataName`, строковые `Code`, `ChartOfAccounts.Order`.
+- `primitive: "dateTime"`: `Date`, `Period`, `ExchangeDate`, расчетные периоды.
+- `primitive: "number"`: `LineNumber`, `Enum.Order`, `SentNo`, `ReceivedNo`, `PeriodAdjustment`.
+
+### Ссылки на объект
+
+Правило возвращает объектный тип и может разрешать дальнейший разбор пути, если тип единственный.
+
+- `sameOwnerObject`: `Ref`, `Parent`.
+- `objectRefsFromProperty`: `Owner` через свойство `owners`; при нескольких владельцах тип составной, дальнейшее раскрытие запрещено.
+- `objectRefFromProperty`: `BusinessProcess.HeadTask` через свойство `task`.
+- `objectRefFromRuleProperty`: `AccountingRegister.Account` через `chartOfAccounts`, `CalculationRegister.CalculationType` через `chartOfCalculationTypes`.
+
+### Скаляр из свойства метаданных
+
+Правило получает тип из свойства текущего metadata-объекта или связанных metadata-объектов. Результат остается скаляром, без раскрытия вложенных свойств.
+
+- `codeByProperty`: `Catalog.Code`, `ChartOfCalculationTypes.Code` через `codeType`.
+- `numberByProperty`: `Document.Number`, `BusinessProcess.Number`, `Task.Number` через `numberType`.
+- `DocumentJournal.Number`: на первом этапе строка без раскрытия; отдельно отмечаем, что реальный тип зависит от типов номеров документов, входящих в журнал.
+
+### Стандартные перечисления
+
+Правило возвращает значение системного перечисления 1С.
+
+- `standardEnum`: `ChartOfAccounts.Type` -> `ВидСчета`.
+- `standardEnum`: `AccumulationRegister.RecordType` -> `ВидДвиженияНакопления`.
+
+### Обратные связи
+
+Правило ищет владельцев через другие metadata-объекты. При нескольких найденных типах дальнейшее раскрытие запрещено.
+
+- `reverseLookup`: `Recorder` у регистров через документы и `registerRecords`.
+- `reverseLookup`: `Task.BusinessProcess` через бизнес-процессы, где задача указана в `tasks`.
+
+Обратные связи не должны резолвиться через обычный `StandardAttributeTypeResolver`: индекс стандартных реквизитов строится по одному текущему объекту и не имеет доступа к другим объектам проекта. Для них нужен `TraversalTransitionResolver`, потому что он вызывается во время прохода по сегментам `DataPath` и получает `ownerCache`.
+
+Правило валидации:
+
+- если найден один тип, возвращаем `DataPathTypeInfo` с `kinds: ["object"]` и одним `nextTypes`; дальнейшее раскрытие разрешено;
+- если найдено несколько типов, возвращаем `kinds: ["object"]`, все `nextTypes` и `isComposite: true`; сам сегмент валиден, но следующий сегмент даст ошибку промежуточного составного типа через существующий `validateIntermediateType`;
+- если сегмент известен как обратная связь, но кандидатов не найдено, это ошибка metadata-связей, а не резервное поведение;
+- если правило неприменимо к сегменту, возвращаем `undefined`, и резолвер продолжает обычный поиск реквизита;
+- если сегмент известен, но по смыслу не раскрывается, возвращаем закрытый тип с `unsupportedIntermediate`, чтобы путь вида `RoutePoint.Поле` давал понятную ошибку о неподдерживаемом промежуточном типе.
+
+### Закрытые специальные типы
+
+Тип известен, но дальнейшее раскрытие через точку запрещено.
+
+- `opaque`: `DocumentJournal.Type`.
+- `typeDescription`: `ValueType`, то есть `ОписаниеТипов`.
+- `businessProcessRoutePoint`: `Task.RoutePoint`, то есть `ТочкаМаршрутаБизнесПроцесса`.
+
+### Неподдержанные на первом этапе
+
+- `AccountingRegister.ExtDimension1..50`: использование и раскрытие запрещены.
+- `AccountingRegister.ExtDimensionType1..50`: использование и раскрытие запрещены.
+
+## Слой исполнения правил
+
+Одного семейства правил недостаточно: для реализации важно, на каком этапе правило может быть исполнено и какие данные ему доступны. Поэтому каждая декларация стандартного реквизита должна дополнительно описывать фазу исполнения, область источника данных и политики поведения.
+
+### Фазы исполнения
+
+- `index-time`: правило вычисляется при построении `ObjectFieldIndex` текущего объекта. Ему доступны текущий metadata-объект, его `rules` и явный `Тип` стандартного реквизита.
+- `traversal-time`: правило вычисляется во время прохода по сегментам `DataPath`. Ему доступен `ownerCache`, поэтому оно может смотреть другие объекты проекта.
+- `deferred`: сегмент известен, но на первом этапе не раскрывается и не дает точного типа для дальнейшего пути.
+
+### Область источника данных
+
+- `self`: правило не читает metadata-свойства, например примитивные типы.
+- `ownerModel`: правило читает свойства текущего metadata-объекта, например `owners`, `codeType`, `numberType`.
+- `rules`: правило читает параметры из `rules`, например `chartOfAccounts`, `chartOfCalculationTypes`.
+- `projectIndex`: правило строится по другим объектам проекта, например `registerRecords` документов или `tasks` бизнес-процессов.
+
+### Политики поведения
+
+- `terminal: true`: после реквизита нельзя продолжать путь через точку.
+- `compositePolicy: "errorOnTraversal"`: сам реквизит валиден, но дальнейшее раскрытие при нескольких типах дает ошибку промежуточного составного типа.
+- `emptyPolicy: "error"`: если известная обратная связь не нашла кандидатов, это ошибка metadata-связей.
+- `aliasPolicy: "translateYaml"`: реквизит участвует в переводе внутренних имен в YAML-имена и обратно.
+
+### Целевая форма декларации
+
+```ts
+{
+  names: ["Recorder"],
+  family: "reverseLookup",
+  phase: "traversal-time",
+  sourceScope: "projectIndex",
+  emptyPolicy: "error",
+  compositePolicy: "errorOnTraversal",
+  aliasPolicy: "translateYaml",
+}
+```
+
+Такой реестр называется `standardMembers` и должен быть единым источником для резолвера `DataPath`, валидатора и перевода `YAML <-> model`. В него входят стандартные реквизиты, стандартные табличные части и колонки стандартных табличных частей. Семейства правил остаются небольшими исполняемыми механизмами, а конкретные платформенные члены описываются декларативными записями рядом с конкретными объектами (`metadataChartOfAccounts/standardMembers.ts`, `metadataTask/standardMembers.ts` и т.п.).
 
 ## Разобранные правила
 
@@ -144,12 +281,30 @@
 - `Number`: для документа через `numberType`.
 - `BusinessProcess.Number`: через `numberType`.
 - `Task.Number`: через `numberType`.
-- `Description`: строка для справочника.
+- `Description`: всегда строка.
 - `PredefinedDataName`: строка.
 - `DeletionMark`, `Predefined`: всегда булевы.
-- `IsFolder`, `Posted`: булевы.
-- `Date`: дата.
+- `Active`: булево.
+- `Posted`, `OffBalance`, `IsFolder`, `ActionPeriodIsBasic`, `ThisNode`: булевы.
+- `Started`, `Completed`, `Executed`, `ReversingEntry`: булевы.
+- `Date`: всегда дата.
+- `ExchangeDate`: дата.
+- `RegistrationPeriod`, `BegOfActionPeriod`, `EndOfActionPeriod`, `ActionPeriod`, `BegOfBasePeriod`, `EndOfBasePeriod`: дата.
 - `Enum.Order`: число.
+- `ChartOfAccounts.Order`: строка.
 - `LineNumber`: число.
+- `PeriodAdjustment`: число.
+- `SentNo`, `ReceivedNo`: число.
+- `ChartOfAccounts.Type`: стандартное перечисление `ВидСчета`.
+- `ValueType`: `ОписаниеТипов` (`TypeDescription`), вложенные свойства недоступны.
+- `BusinessProcess.HeadTask`: задача из свойства `task`.
+- `Task.BusinessProcess`: обратный поиск бизнес-процессов по задачам; при нескольких значениях вложенные свойства недоступны.
+- `Recorder`: обратный поиск документов по `registerRecords`; при нескольких регистраторах вложенные свойства недоступны.
+- `DocumentJournal.Type`: `Тип`, дальше не раскрывается.
+- `DocumentJournal.Number`: на первом этапе строка без раскрытия; реально зависит от типов номеров документов, входящих в журнал.
+- `Task.RoutePoint`: `ТочкаМаршрутаБизнесПроцесса` бизнес-процессов, у которых указана эта задача; дальше не раскрывается.
+- `AccumulationRegister.RecordType`: стандартное перечисление `ВидДвиженияНакопления`.
+- `AccountingRegister.Account`: счет из плана счетов, указанного в `chartOfAccounts` rules.
+- `CalculationRegister.CalculationType`: вид расчета из плана видов расчета, указанного в `chartOfCalculationTypes` rules.
 
 Все строки с неотмеченным флажком `Разобрано` остаются в таблице для последующего уточнения и используют безопасное резервное поведение.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -12,128 +12,128 @@
 
 ## Таблица
 
-| Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Приоритет |
+| Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Разобрано |
 | --- | --- | --- | --- | --- | --- |
-| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | первая волна |
-| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | первая волна |
-| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | первая волна |
-| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | первая волна |
-| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | первая волна |
-| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | резервное поведение | позже |
-| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | первая волна для встречающихся путей |
-| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | первая волна для справочника |
-| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | первая волна |
-| Общие объектные | Date | Дата | имена в rules | дата | первая волна |
-| Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца | позже |
-| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | первая волна |
-| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | первая волна |
-| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | первая волна |
-| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | первая волна |
-| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | первая волна |
-| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | первая волна |
-| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | первая волна |
-| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | первая волна |
-| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | первая волна |
-| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | первая волна |
-| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | резервное поведение | позже |
-| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | первая волна |
-| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | первая волна |
-| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа | позже |
-| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | первая волна |
-| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | первая волна |
-| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект | позже |
-| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | позже |
-| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | позже |
-| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода | позже |
-| План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка | позже |
-| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | позже |
-| План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | позже |
-| План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево | позже |
-| План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число | позже |
-| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево | позже |
-| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево | позже |
-| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | позже |
-| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | позже |
-| План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа | позже |
-| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода | позже |
-| План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | позже |
-| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | позже |
-| План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | позже |
-| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | позже |
-| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | позже |
-| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | резервное поведение | позже |
-| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | текущий объект | позже |
-| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода | позже |
-| План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | позже |
-| План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | позже |
-| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | позже |
-| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | позже |
-| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | резервное поведение | позже |
-| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | текущий объект | позже |
-| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода | позже |
-| План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка | позже |
-| План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена | позже |
-| План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата | позже |
-| План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр | позже |
-| План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр | позже |
-| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево | позже |
-| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | позже |
-| Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | позже |
-| Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата | позже |
-| Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | позже |
-| Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево | позже |
-| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | позже |
-| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | текущий объект | позже |
-| Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата | позже |
-| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение | позже |
-| Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево | позже |
-| Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево | позже |
-| Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача | позже |
-| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | позже |
-| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | текущий объект | позже |
-| Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата | позже |
-| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение | позже |
-| Задача | Executed | Выполнена | `dataPathCommon` | булево | позже |
-| Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс | позже |
-| Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса | позже |
-| Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка | позже |
-| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево | позже |
-| Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево | позже |
-| Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число | позже |
-| Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | регистратор | позже |
-| Регистр сведений | Period | Период | `MetadataInformationRegisterStandardAttributeNames` | дата | позже |
-| Регистр накопления | RecordType | ВидДвижения | `MetadataAccumulationRegisterStandardAttributeNames` | резервное поведение | позже |
-| Регистр накопления | Active | Активность | `MetadataAccumulationRegisterStandardAttributeNames` | булево | позже |
-| Регистр накопления | LineNumber | НомерСтроки | `MetadataAccumulationRegisterStandardAttributeNames` | число | позже |
-| Регистр накопления | Recorder | Регистратор | `MetadataAccumulationRegisterStandardAttributeNames` | регистратор | позже |
-| Регистр накопления | Period | Период | `MetadataAccumulationRegisterStandardAttributeNames` | дата | позже |
-| Регистр накопления оборотов | Active | Активность | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | булево | позже |
-| Регистр накопления оборотов | LineNumber | НомерСтроки | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | число | позже |
-| Регистр накопления оборотов | Recorder | Регистратор | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | регистратор | позже |
-| Регистр накопления оборотов | Period | Период | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | дата | позже |
-| Регистр бухгалтерии | PeriodAdjustment | УточнениеПериода | `MetadataAccountingRegisterStandardAttributeNames` | резервное поведение | позже |
-| Регистр бухгалтерии | Account | Счет | `MetadataAccountingRegisterStandardAttributeNames` | план счетов | позже |
-| Регистр бухгалтерии | Active | Активность | `MetadataAccountingRegisterStandardAttributeNames` | булево | позже |
-| Регистр бухгалтерии | LineNumber | НомерСтроки | `MetadataAccountingRegisterStandardAttributeNames` | число | позже |
-| Регистр бухгалтерии | Recorder | Регистратор | `MetadataAccountingRegisterStandardAttributeNames` | регистратор | позже |
-| Регистр бухгалтерии | Period | Период | `MetadataAccountingRegisterStandardAttributeNames` | дата | позже |
-| Регистр бухгалтерии | ExtDimension1..50 | Субконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | динамический набор |
-| Регистр бухгалтерии | ExtDimensionType1..50 | ВидСубконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | динамический набор |
-| Регистр расчета | RegistrationPeriod | ПериодРегистрации | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
-| Регистр расчета | ReversingEntry | Сторно | `MetadataCalculationRegisterStandardAttributeNames` | булево | позже |
-| Регистр расчета | Active | Активность | `MetadataCalculationRegisterStandardAttributeNames` | булево | позже |
-| Регистр расчета | BegOfActionPeriod | НачалоПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
-| Регистр расчета | EndOfActionPeriod | КонецПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
-| Регистр расчета | ActionPeriod | ПериодДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата/период | позже |
-| Регистр расчета | BegOfBasePeriod | НачалоБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
-| Регистр расчета | EndOfBasePeriod | КонецБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
-| Регистр расчета | CalculationType | ВидРасчета | `MetadataCalculationRegisterStandardAttributeNames` | план видов расчета | позже |
-| Регистр расчета | LineNumber | НомерСтроки | `MetadataCalculationRegisterStandardAttributeNames` | число | позже |
-| Регистр расчета | Recorder | Регистратор | `MetadataCalculationRegisterStandardAttributeNames` | регистратор | позже |
+| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | да |
+| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | да |
+| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | да |
+| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | да |
+| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | да |
+| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | резервное поведение | нет |
+| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | да |
+| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | да |
+| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | да |
+| Общие объектные | Date | Дата | имена в rules | дата | да |
+| Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца | нет |
+| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | да |
+| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | да |
+| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | да |
+| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | да |
+| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | да |
+| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | да |
+| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | да |
+| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | да |
+| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | да |
+| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | да |
+| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | резервное поведение | нет |
+| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | да |
+| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | да |
+| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа | нет |
+| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | да |
+| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | да |
+| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект | нет |
+| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | нет |
+| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | нет |
+| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода | нет |
+| План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка | нет |
+| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | нет |
+| План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | нет |
+| План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево | нет |
+| План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число | нет |
+| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево | нет |
+| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево | нет |
+| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | нет |
+| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | нет |
+| План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа | нет |
+| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода | нет |
+| План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | нет |
+| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | нет |
+| План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | нет |
+| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | нет |
+| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | нет |
+| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | резервное поведение | нет |
+| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | текущий объект | нет |
+| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода | нет |
+| План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | нет |
+| План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | нет |
+| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | нет |
+| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | нет |
+| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | резервное поведение | нет |
+| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | текущий объект | нет |
+| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода | нет |
+| План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка | нет |
+| План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена | нет |
+| План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата | нет |
+| План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр | нет |
+| План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр | нет |
+| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево | нет |
+| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | нет |
+| Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | нет |
+| Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата | нет |
+| Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | нет |
+| Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево | нет |
+| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | нет |
+| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | текущий объект | нет |
+| Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата | нет |
+| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение | нет |
+| Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево | нет |
+| Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево | нет |
+| Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача | нет |
+| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | нет |
+| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | текущий объект | нет |
+| Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата | нет |
+| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение | нет |
+| Задача | Executed | Выполнена | `dataPathCommon` | булево | нет |
+| Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс | нет |
+| Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса | нет |
+| Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка | нет |
+| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево | нет |
+| Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево | нет |
+| Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число | нет |
+| Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | регистратор | нет |
+| Регистр сведений | Period | Период | `MetadataInformationRegisterStandardAttributeNames` | дата | нет |
+| Регистр накопления | RecordType | ВидДвижения | `MetadataAccumulationRegisterStandardAttributeNames` | резервное поведение | нет |
+| Регистр накопления | Active | Активность | `MetadataAccumulationRegisterStandardAttributeNames` | булево | нет |
+| Регистр накопления | LineNumber | НомерСтроки | `MetadataAccumulationRegisterStandardAttributeNames` | число | нет |
+| Регистр накопления | Recorder | Регистратор | `MetadataAccumulationRegisterStandardAttributeNames` | регистратор | нет |
+| Регистр накопления | Period | Период | `MetadataAccumulationRegisterStandardAttributeNames` | дата | нет |
+| Регистр накопления оборотов | Active | Активность | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | булево | нет |
+| Регистр накопления оборотов | LineNumber | НомерСтроки | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | число | нет |
+| Регистр накопления оборотов | Recorder | Регистратор | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | регистратор | нет |
+| Регистр накопления оборотов | Period | Период | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | дата | нет |
+| Регистр бухгалтерии | PeriodAdjustment | УточнениеПериода | `MetadataAccountingRegisterStandardAttributeNames` | резервное поведение | нет |
+| Регистр бухгалтерии | Account | Счет | `MetadataAccountingRegisterStandardAttributeNames` | план счетов | нет |
+| Регистр бухгалтерии | Active | Активность | `MetadataAccountingRegisterStandardAttributeNames` | булево | нет |
+| Регистр бухгалтерии | LineNumber | НомерСтроки | `MetadataAccountingRegisterStandardAttributeNames` | число | нет |
+| Регистр бухгалтерии | Recorder | Регистратор | `MetadataAccountingRegisterStandardAttributeNames` | регистратор | нет |
+| Регистр бухгалтерии | Period | Период | `MetadataAccountingRegisterStandardAttributeNames` | дата | нет |
+| Регистр бухгалтерии | ExtDimension1..50 | Субконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | нет |
+| Регистр бухгалтерии | ExtDimensionType1..50 | ВидСубконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | нет |
+| Регистр расчета | RegistrationPeriod | ПериодРегистрации | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
+| Регистр расчета | ReversingEntry | Сторно | `MetadataCalculationRegisterStandardAttributeNames` | булево | нет |
+| Регистр расчета | Active | Активность | `MetadataCalculationRegisterStandardAttributeNames` | булево | нет |
+| Регистр расчета | BegOfActionPeriod | НачалоПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
+| Регистр расчета | EndOfActionPeriod | КонецПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
+| Регистр расчета | ActionPeriod | ПериодДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата/период | нет |
+| Регистр расчета | BegOfBasePeriod | НачалоБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
+| Регистр расчета | EndOfBasePeriod | КонецБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | нет |
+| Регистр расчета | CalculationType | ВидРасчета | `MetadataCalculationRegisterStandardAttributeNames` | план видов расчета | нет |
+| Регистр расчета | LineNumber | НомерСтроки | `MetadataCalculationRegisterStandardAttributeNames` | число | нет |
+| Регистр расчета | Recorder | Регистратор | `MetadataCalculationRegisterStandardAttributeNames` | регистратор | нет |
 
-## Первая волна
+## Разобранные правила
 
-Первая реализация должна покрыть минимальный набор для задачи с `Owner`:
+На текущем этапе разобраны правила, достаточные для задачи с `Owner`:
 
 - `Ref`: тип текущего объекта.
 - `Owner`: типы из свойства `owners`, с `isComposite` при нескольких владельцах.
@@ -143,4 +143,4 @@
 - `Date`: дата.
 - `LineNumber`: число.
 
-Все остальные строки остаются в таблице как очередь на описание и используют безопасное резервное поведение.
+Все строки с `Разобрано: нет` остаются в таблице для последующего уточнения и используют безопасное резервное поведение.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -50,8 +50,8 @@
 | План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение |  | - [ ] |
 | План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
 | План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число |  | - [ ] |
-| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
-| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
+| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
+| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа |  | - [ ] |
@@ -59,15 +59,15 @@
 | План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка |  | - [ ] |
 | План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект |  | - [ ] |
 | План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
-| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
-| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
+| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
+| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка |  | - [ ] |
 | План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
-| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
-| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
+| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
+| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода |  | - [ ] |
@@ -76,20 +76,20 @@
 | План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата |  | - [ ] |
 | План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр |  | - [ ] |
 | План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр |  | - [ ] |
-| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево |  | - [ ] |
+| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
 | Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата |  | - [ ] |
 | Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
 | Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево |  | - [ ] |
-| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево |  | - [ ] |
+| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата |  | - [ ] |
 | Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение |  | - [ ] |
 | Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево |  | - [ ] |
 | Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево |  | - [ ] |
 | Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача |  | - [ ] |
-| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево |  | - [ ] |
+| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата |  | - [ ] |
 | Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение |  | - [ ] |
@@ -97,7 +97,7 @@
 | Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс |  | - [ ] |
 | Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса |  | - [ ] |
 | Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка |  | - [ ] |
-| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево |  | - [ ] |
+| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево |  | - [ ] |
 | Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число |  | - [ ] |
 | Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | регистратор |  | - [ ] |
@@ -141,7 +141,8 @@
 - `Number`: для документа через `numberType`.
 - `Description`: строка для справочника.
 - `PredefinedDataName`: строка.
-- `IsFolder`, `DeletionMark`, `Predefined`, `Posted`: булевы.
+- `DeletionMark`, `Predefined`: всегда булевы.
+- `IsFolder`, `Posted`: булевы.
 - `Date`: дата.
 - `Enum.Order`: число.
 - `LineNumber`: число.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -1,0 +1,146 @@
+# Таблица стандартных реквизитов для DataPath
+
+## Цель
+
+Собрать текущие стандартные реквизиты в одну рабочую таблицу и постепенно описывать для них декларативные правила типов. Таблица нужна для резолвера `DataPath`, валидации и перевода путей между внутренним представлением и YAML.
+
+## Общее правило
+
+Если тип стандартного реквизита явно описан декларацией или задан явным `Тип` в описании реквизита, переводчик `DataPath` может опираться на него, переводить имя сегмента и продолжать разбор пути.
+
+Если тип не определен, переводчик останавливается на этом сегменте и оставляет остаток пути без изменений. Валидатор на первом этапе не выдает ошибок по дальнейшему пути после такого реквизита.
+
+## Таблица
+
+| Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Приоритет |
+| --- | --- | --- | --- | --- | --- |
+| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | первая волна |
+| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | первая волна |
+| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | первая волна |
+| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | первая волна |
+| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | первая волна |
+| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | резервное поведение | позже |
+| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | первая волна для встречающихся путей |
+| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | первая волна для справочника |
+| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | первая волна |
+| Общие объектные | Date | Дата | имена в rules | дата | первая волна |
+| Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца | позже |
+| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | первая волна |
+| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | первая волна |
+| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | первая волна |
+| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | первая волна |
+| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | первая волна |
+| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | первая волна |
+| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | первая волна |
+| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | первая волна |
+| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | первая волна |
+| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | первая волна |
+| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | резервное поведение | позже |
+| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | первая волна |
+| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | первая волна |
+| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа | позже |
+| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | первая волна |
+| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | первая волна |
+| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект | позже |
+| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | позже |
+| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | позже |
+| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода | позже |
+| План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка | позже |
+| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | позже |
+| План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | позже |
+| План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево | позже |
+| План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число | позже |
+| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево | позже |
+| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево | позже |
+| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | позже |
+| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | позже |
+| План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа | позже |
+| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода | позже |
+| План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | позже |
+| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | позже |
+| План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | позже |
+| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | позже |
+| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | позже |
+| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | резервное поведение | позже |
+| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | текущий объект | позже |
+| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода | позже |
+| План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | позже |
+| План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | позже |
+| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | позже |
+| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | позже |
+| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | резервное поведение | позже |
+| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | текущий объект | позже |
+| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода | позже |
+| План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка | позже |
+| План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена | позже |
+| План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата | позже |
+| План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр | позже |
+| План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр | позже |
+| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево | позже |
+| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | позже |
+| Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | позже |
+| Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата | позже |
+| Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | позже |
+| Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево | позже |
+| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | позже |
+| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | текущий объект | позже |
+| Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата | позже |
+| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение | позже |
+| Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево | позже |
+| Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево | позже |
+| Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача | позже |
+| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | позже |
+| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | текущий объект | позже |
+| Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата | позже |
+| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение | позже |
+| Задача | Executed | Выполнена | `dataPathCommon` | булево | позже |
+| Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс | позже |
+| Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса | позже |
+| Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка | позже |
+| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево | позже |
+| Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево | позже |
+| Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число | позже |
+| Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | регистратор | позже |
+| Регистр сведений | Period | Период | `MetadataInformationRegisterStandardAttributeNames` | дата | позже |
+| Регистр накопления | RecordType | ВидДвижения | `MetadataAccumulationRegisterStandardAttributeNames` | резервное поведение | позже |
+| Регистр накопления | Active | Активность | `MetadataAccumulationRegisterStandardAttributeNames` | булево | позже |
+| Регистр накопления | LineNumber | НомерСтроки | `MetadataAccumulationRegisterStandardAttributeNames` | число | позже |
+| Регистр накопления | Recorder | Регистратор | `MetadataAccumulationRegisterStandardAttributeNames` | регистратор | позже |
+| Регистр накопления | Period | Период | `MetadataAccumulationRegisterStandardAttributeNames` | дата | позже |
+| Регистр накопления оборотов | Active | Активность | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | булево | позже |
+| Регистр накопления оборотов | LineNumber | НомерСтроки | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | число | позже |
+| Регистр накопления оборотов | Recorder | Регистратор | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | регистратор | позже |
+| Регистр накопления оборотов | Period | Период | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | дата | позже |
+| Регистр бухгалтерии | PeriodAdjustment | УточнениеПериода | `MetadataAccountingRegisterStandardAttributeNames` | резервное поведение | позже |
+| Регистр бухгалтерии | Account | Счет | `MetadataAccountingRegisterStandardAttributeNames` | план счетов | позже |
+| Регистр бухгалтерии | Active | Активность | `MetadataAccountingRegisterStandardAttributeNames` | булево | позже |
+| Регистр бухгалтерии | LineNumber | НомерСтроки | `MetadataAccountingRegisterStandardAttributeNames` | число | позже |
+| Регистр бухгалтерии | Recorder | Регистратор | `MetadataAccountingRegisterStandardAttributeNames` | регистратор | позже |
+| Регистр бухгалтерии | Period | Период | `MetadataAccountingRegisterStandardAttributeNames` | дата | позже |
+| Регистр бухгалтерии | ExtDimension1..50 | Субконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | динамический набор |
+| Регистр бухгалтерии | ExtDimensionType1..50 | ВидСубконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | динамический набор |
+| Регистр расчета | RegistrationPeriod | ПериодРегистрации | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
+| Регистр расчета | ReversingEntry | Сторно | `MetadataCalculationRegisterStandardAttributeNames` | булево | позже |
+| Регистр расчета | Active | Активность | `MetadataCalculationRegisterStandardAttributeNames` | булево | позже |
+| Регистр расчета | BegOfActionPeriod | НачалоПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
+| Регистр расчета | EndOfActionPeriod | КонецПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
+| Регистр расчета | ActionPeriod | ПериодДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата/период | позже |
+| Регистр расчета | BegOfBasePeriod | НачалоБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
+| Регистр расчета | EndOfBasePeriod | КонецБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | позже |
+| Регистр расчета | CalculationType | ВидРасчета | `MetadataCalculationRegisterStandardAttributeNames` | план видов расчета | позже |
+| Регистр расчета | LineNumber | НомерСтроки | `MetadataCalculationRegisterStandardAttributeNames` | число | позже |
+| Регистр расчета | Recorder | Регистратор | `MetadataCalculationRegisterStandardAttributeNames` | регистратор | позже |
+
+## Первая волна
+
+Первая реализация должна покрыть минимальный набор для задачи с `Owner`:
+
+- `Ref`: тип текущего объекта.
+- `Owner`: типы из свойства `owners`, с `isComposite` при нескольких владельцах.
+- `Code`: для справочника через `codeType`.
+- `Description`: строка для справочника.
+- `IsFolder`, `DeletionMark`, `Predefined`, `Posted`: булевы.
+- `Date`: дата.
+- `LineNumber`: число.
+
+Все остальные строки остаются в таблице как очередь на описание и используют безопасное резервное поведение.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -38,7 +38,7 @@
 | Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
 | Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | `dataPath: { type: "dateTime" }` | - [x] |
-| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа |  | - [ ] |
+| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | зависит от свойства `numberType` (`DocumentNumberType`) | `dataPath: { type: "documentNumber", property: "numberType" }` | - [x] |
 | Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект |  | - [ ] |
@@ -138,6 +138,7 @@
 - `Ref`: тип текущего объекта.
 - `Owner`: типы из свойства `owners`, с `isComposite` при нескольких владельцах.
 - `Code`: для справочника через `codeType`.
+- `Number`: для документа через `numberType`.
 - `Description`: строка для справочника.
 - `PredefinedDataName`: строка.
 - `IsFolder`, `DeletionMark`, `Predefined`, `Posted`: булевы.

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -12,124 +12,124 @@
 
 ## Таблица
 
-| Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Разобрано |
-| --- | --- | --- | --- | --- | --- |
-| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | - [x] |
-| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | - [x] |
-| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | - [x] |
-| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | - [x] |
-| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | - [x] |
-| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | резервное поведение | - [ ] |
-| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | - [x] |
-| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | - [x] |
-| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | - [x] |
-| Общие объектные | Date | Дата | имена в rules | дата | - [x] |
-| Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца | - [ ] |
-| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | - [x] |
-| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | - [x] |
-| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | - [x] |
-| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | - [x] |
-| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | - [x] |
-| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | - [x] |
-| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | - [x] |
-| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | - [x] |
-| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | - [x] |
-| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | - [x] |
-| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | резервное поведение | - [ ] |
-| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | - [x] |
-| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | - [x] |
-| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа | - [ ] |
-| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | - [x] |
-| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | - [x] |
-| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект | - [ ] |
-| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число | - [ ] |
-| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | - [ ] |
-| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода | - [ ] |
-| План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка | - [ ] |
-| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект | - [ ] |
-| План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | - [ ] |
-| План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево | - [ ] |
-| План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число | - [ ] |
-| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево | - [ ] |
-| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево | - [ ] |
-| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение | - [ ] |
-| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | - [ ] |
-| План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа | - [ ] |
-| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода | - [ ] |
-| План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка | - [ ] |
-| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект | - [ ] |
-| План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | - [ ] |
-| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | - [ ] |
-| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | - [ ] |
-| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | резервное поведение | - [ ] |
-| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | текущий объект | - [ ] |
-| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода | - [ ] |
-| План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка | - [ ] |
-| План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | - [ ] |
-| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | - [ ] |
-| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево | - [ ] |
-| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | резервное поведение | - [ ] |
-| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | текущий объект | - [ ] |
-| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода | - [ ] |
-| План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка | - [ ] |
-| План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена | - [ ] |
-| План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата | - [ ] |
-| План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр | - [ ] |
-| План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр | - [ ] |
-| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево | - [ ] |
-| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | - [ ] |
-| Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | - [ ] |
-| Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата | - [ ] |
-| Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение | - [ ] |
-| Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево | - [ ] |
-| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево | - [ ] |
-| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | текущий объект | - [ ] |
-| Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата | - [ ] |
-| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение | - [ ] |
-| Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево | - [ ] |
-| Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево | - [ ] |
-| Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача | - [ ] |
-| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево | - [ ] |
-| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | текущий объект | - [ ] |
-| Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата | - [ ] |
-| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение | - [ ] |
-| Задача | Executed | Выполнена | `dataPathCommon` | булево | - [ ] |
-| Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс | - [ ] |
-| Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса | - [ ] |
-| Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка | - [ ] |
-| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево | - [ ] |
-| Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево | - [ ] |
-| Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число | - [ ] |
-| Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | регистратор | - [ ] |
-| Регистр сведений | Period | Период | `MetadataInformationRegisterStandardAttributeNames` | дата | - [ ] |
-| Регистр накопления | RecordType | ВидДвижения | `MetadataAccumulationRegisterStandardAttributeNames` | резервное поведение | - [ ] |
-| Регистр накопления | Active | Активность | `MetadataAccumulationRegisterStandardAttributeNames` | булево | - [ ] |
-| Регистр накопления | LineNumber | НомерСтроки | `MetadataAccumulationRegisterStandardAttributeNames` | число | - [ ] |
-| Регистр накопления | Recorder | Регистратор | `MetadataAccumulationRegisterStandardAttributeNames` | регистратор | - [ ] |
-| Регистр накопления | Period | Период | `MetadataAccumulationRegisterStandardAttributeNames` | дата | - [ ] |
-| Регистр накопления оборотов | Active | Активность | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | булево | - [ ] |
-| Регистр накопления оборотов | LineNumber | НомерСтроки | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | число | - [ ] |
-| Регистр накопления оборотов | Recorder | Регистратор | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | регистратор | - [ ] |
-| Регистр накопления оборотов | Period | Период | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | дата | - [ ] |
-| Регистр бухгалтерии | PeriodAdjustment | УточнениеПериода | `MetadataAccountingRegisterStandardAttributeNames` | резервное поведение | - [ ] |
-| Регистр бухгалтерии | Account | Счет | `MetadataAccountingRegisterStandardAttributeNames` | план счетов | - [ ] |
-| Регистр бухгалтерии | Active | Активность | `MetadataAccountingRegisterStandardAttributeNames` | булево | - [ ] |
-| Регистр бухгалтерии | LineNumber | НомерСтроки | `MetadataAccountingRegisterStandardAttributeNames` | число | - [ ] |
-| Регистр бухгалтерии | Recorder | Регистратор | `MetadataAccountingRegisterStandardAttributeNames` | регистратор | - [ ] |
-| Регистр бухгалтерии | Period | Период | `MetadataAccountingRegisterStandardAttributeNames` | дата | - [ ] |
-| Регистр бухгалтерии | ExtDimension1..50 | Субконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | - [ ] |
-| Регистр бухгалтерии | ExtDimensionType1..50 | ВидСубконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора | - [ ] |
-| Регистр расчета | RegistrationPeriod | ПериодРегистрации | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
-| Регистр расчета | ReversingEntry | Сторно | `MetadataCalculationRegisterStandardAttributeNames` | булево | - [ ] |
-| Регистр расчета | Active | Активность | `MetadataCalculationRegisterStandardAttributeNames` | булево | - [ ] |
-| Регистр расчета | BegOfActionPeriod | НачалоПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
-| Регистр расчета | EndOfActionPeriod | КонецПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
-| Регистр расчета | ActionPeriod | ПериодДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата/период | - [ ] |
-| Регистр расчета | BegOfBasePeriod | НачалоБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
-| Регистр расчета | EndOfBasePeriod | КонецБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата | - [ ] |
-| Регистр расчета | CalculationType | ВидРасчета | `MetadataCalculationRegisterStandardAttributeNames` | план видов расчета | - [ ] |
-| Регистр расчета | LineNumber | НомерСтроки | `MetadataCalculationRegisterStandardAttributeNames` | число | - [ ] |
-| Регистр расчета | Recorder | Регистратор | `MetadataCalculationRegisterStandardAttributeNames` | регистратор | - [ ] |
+| Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Спецификация | Разобрано |
+| --- | --- | --- | --- | --- | --- | --- |
+| Общие объектные | Ref | Ссылка | `dataPathCommon` | текущий объект | `sameOwnerObject` | - [x] |
+| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | `sameOwnerObject` | - [x] |
+| Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | `objectRefsFromProperty(owners)` | - [x] |
+| Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | `scalar(boolean)` | - [x] |
+| Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | `scalar(boolean)` | - [x] |
+| Общие объектные | PredefinedDataName | ИмяПредопределенныхДанных | имена в rules | резервное поведение |  | - [ ] |
+| Общие объектные | Description | Наименование / Описание | имена в rules | строка или явный `Тип` | `scalar(string)` | - [x] |
+| Общие объектные | Code | Код | имена в rules | зависит от свойства владельца (`codeType` и аналоги) | `typeFromProperty(codeType)` | - [x] |
+| Общие объектные | IsFolder | ЭтоГруппа | имена в rules | булево | `scalar(boolean)` | - [x] |
+| Общие объектные | Date | Дата | имена в rules | дата | `scalar(dateTime)` | - [x] |
+| Общие объектные | Number | Номер | имена в rules | строка/число по свойствам нумерации владельца |  | - [ ] |
+| Общие объектные | Posted | Проведен | `dataPathCommon` | булево | `scalar(boolean)` | - [x] |
+| Табличная часть | LineNumber | НомерСтроки | `metadataTabularSection`, `dataPathCommon` | число | `scalar(number)` | - [x] |
+| Справочник | Ref | Ссылка | `MetadataCatalogStandardAttributeNames` | текущий объект | `sameOwnerObject` | - [x] |
+| Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | `objectRefsFromProperty(owners)` | - [x] |
+| Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | `typeFromProperty(codeType)` | - [x] |
+| Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | `scalar(string)` | - [x] |
+| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | `sameOwnerObject` | - [x] |
+| Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
+| Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
+| Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
+| Справочник | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataCatalogStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Документ | Ref | Ссылка | `MetadataDocumentStandardAttributeNames` | текущий объект | `sameOwnerObject` | - [x] |
+| Документ | Date | Дата | `MetadataDocumentStandardAttributeNames` | дата | `scalar(dateTime)` | - [x] |
+| Документ | Number | Номер | `MetadataDocumentStandardAttributeNames` | по свойствам нумерации документа |  | - [ ] |
+| Документ | Posted | Проведен | `MetadataDocumentStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
+| Документ | DeletionMark | ПометкаУдаления | `MetadataDocumentStandardAttributeNames` | булево | `scalar(boolean)` | - [x] |
+| Перечисление | Ref | Ссылка | `MetadataEnumerationStandardAttributeNames` | текущий объект |  | - [ ] |
+| Перечисление | Order | Порядок | `MetadataEnumerationStandardAttributeNames` | число |  | - [ ] |
+| План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект |  | - [ ] |
+| План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода |  | - [ ] |
+| План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка |  | - [ ] |
+| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект |  | - [ ] |
+| План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение |  | - [ ] |
+| План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
+| План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число |  | - [ ] |
+| План счетов | DeletionMark | ПометкаУдаления | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
+| План счетов | Predefined | Предопределенный | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
+| План счетов | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение |  | - [ ] |
+| План видов характеристик | Ref | Ссылка | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект |  | - [ ] |
+| План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа |  | - [ ] |
+| План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
+| План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка |  | - [ ] |
+| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект |  | - [ ] |
+| План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
+| План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
+| План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
+| План видов характеристик | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | резервное поведение |  | - [ ] |
+| План видов расчета | Ref | Ссылка | `MetadataChartOfCalculationTypesStandardAttributeNames` | текущий объект |  | - [ ] |
+| План видов расчета | Code | Код | `MetadataChartOfCalculationTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
+| План видов расчета | Description | Наименование | `MetadataChartOfCalculationTypesStandardAttributeNames` | строка |  | - [ ] |
+| План видов расчета | ActionPeriodIsBasic | ПериодДействияБазовый | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
+| План видов расчета | DeletionMark | ПометкаУдаления | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
+| План видов расчета | Predefined | Предопределенный | `MetadataChartOfCalculationTypesStandardAttributeNames` | булево |  | - [ ] |
+| План видов расчета | PredefinedDataName | ИмяПредопределенныхДанных | `MetadataChartOfCalculationTypesStandardAttributeNames` | резервное поведение |  | - [ ] |
+| План обмена | Ref | Ссылка | `MetadataExchangePlanStandardAttributeNames` | текущий объект |  | - [ ] |
+| План обмена | Code | Код | `MetadataExchangePlanStandardAttributeNames` | по свойствам кода |  | - [ ] |
+| План обмена | Description | Наименование | `MetadataExchangePlanStandardAttributeNames` | строка |  | - [ ] |
+| План обмена | ThisNode | ЭтотУзел | `MetadataExchangePlanStandardAttributeNames` | текущий объект / узел плана обмена |  | - [ ] |
+| План обмена | ExchangeDate | ДатаОбмена | `MetadataExchangePlanStandardAttributeNames` | дата |  | - [ ] |
+| План обмена | SentNo | НомерОтправленного | `dataPathCommon` | скаляр |  | - [ ] |
+| План обмена | ReceivedNo | НомерПринятого | `dataPathCommon` | скаляр |  | - [ ] |
+| План обмена | DeletionMark | ПометкаУдаления | `MetadataExchangePlanStandardAttributeNames` | булево |  | - [ ] |
+| Журнал документов | Ref | Ссылка | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Журнал документов | Type | Тип | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Журнал документов | Date | Дата | `MetadataDocumentJournalStandardAttributeNames` | дата |  | - [ ] |
+| Журнал документов | Number | Номер | `MetadataDocumentJournalStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Журнал документов | Posted | Проведен | `MetadataDocumentJournalStandardAttributeNames` | булево |  | - [ ] |
+| Журнал документов | DeletionMark | ПометкаУдаления | `MetadataDocumentJournalStandardAttributeNames` | булево |  | - [ ] |
+| Бизнес-процесс | Ref | Ссылка | `MetadataBusinessProcessStandardAttributeNames` | текущий объект |  | - [ ] |
+| Бизнес-процесс | Date | Дата | `MetadataBusinessProcessStandardAttributeNames` | дата |  | - [ ] |
+| Бизнес-процесс | Number | Номер | `MetadataBusinessProcessStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Бизнес-процесс | Started | Стартован | `dataPathCommon` | булево |  | - [ ] |
+| Бизнес-процесс | Completed | Завершен | `dataPathCommon` | булево |  | - [ ] |
+| Бизнес-процесс | HeadTask | ГоловнаяЗадача | `MetadataBusinessProcessStandardAttributeNames` | задача |  | - [ ] |
+| Бизнес-процесс | DeletionMark | ПометкаУдаления | `MetadataBusinessProcessStandardAttributeNames` | булево |  | - [ ] |
+| Задача | Ref | Ссылка | `MetadataTaskStandardAttributeNames` | текущий объект |  | - [ ] |
+| Задача | Date | Дата | `MetadataTaskStandardAttributeNames` | дата |  | - [ ] |
+| Задача | Number | Номер | `MetadataTaskStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Задача | Executed | Выполнена | `dataPathCommon` | булево |  | - [ ] |
+| Задача | BusinessProcess | БизнесПроцесс | `metadataTask/register.ts` | бизнес-процесс |  | - [ ] |
+| Задача | RoutePoint | ТочкаМаршрута | `metadataTask/register.ts` | точка маршрута бизнес-процесса |  | - [ ] |
+| Задача | Description | Описание | `MetadataTaskStandardAttributeNames` | строка |  | - [ ] |
+| Задача | DeletionMark | ПометкаУдаления | `MetadataTaskStandardAttributeNames` | булево |  | - [ ] |
+| Регистр сведений | Active | Активность | `MetadataInformationRegisterStandardAttributeNames` | булево |  | - [ ] |
+| Регистр сведений | LineNumber | НомерСтроки | `MetadataInformationRegisterStandardAttributeNames` | число |  | - [ ] |
+| Регистр сведений | Recorder | Регистратор | `MetadataInformationRegisterStandardAttributeNames` | регистратор |  | - [ ] |
+| Регистр сведений | Period | Период | `MetadataInformationRegisterStandardAttributeNames` | дата |  | - [ ] |
+| Регистр накопления | RecordType | ВидДвижения | `MetadataAccumulationRegisterStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Регистр накопления | Active | Активность | `MetadataAccumulationRegisterStandardAttributeNames` | булево |  | - [ ] |
+| Регистр накопления | LineNumber | НомерСтроки | `MetadataAccumulationRegisterStandardAttributeNames` | число |  | - [ ] |
+| Регистр накопления | Recorder | Регистратор | `MetadataAccumulationRegisterStandardAttributeNames` | регистратор |  | - [ ] |
+| Регистр накопления | Period | Период | `MetadataAccumulationRegisterStandardAttributeNames` | дата |  | - [ ] |
+| Регистр накопления оборотов | Active | Активность | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | булево |  | - [ ] |
+| Регистр накопления оборотов | LineNumber | НомерСтроки | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | число |  | - [ ] |
+| Регистр накопления оборотов | Recorder | Регистратор | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | регистратор |  | - [ ] |
+| Регистр накопления оборотов | Period | Период | `MetadataAccumulationRegisterTurnoverStandardAttributeNames` | дата |  | - [ ] |
+| Регистр бухгалтерии | PeriodAdjustment | УточнениеПериода | `MetadataAccountingRegisterStandardAttributeNames` | резервное поведение |  | - [ ] |
+| Регистр бухгалтерии | Account | Счет | `MetadataAccountingRegisterStandardAttributeNames` | план счетов |  | - [ ] |
+| Регистр бухгалтерии | Active | Активность | `MetadataAccountingRegisterStandardAttributeNames` | булево |  | - [ ] |
+| Регистр бухгалтерии | LineNumber | НомерСтроки | `MetadataAccountingRegisterStandardAttributeNames` | число |  | - [ ] |
+| Регистр бухгалтерии | Recorder | Регистратор | `MetadataAccountingRegisterStandardAttributeNames` | регистратор |  | - [ ] |
+| Регистр бухгалтерии | Period | Период | `MetadataAccountingRegisterStandardAttributeNames` | дата |  | - [ ] |
+| Регистр бухгалтерии | ExtDimension1..50 | Субконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора |  | - [ ] |
+| Регистр бухгалтерии | ExtDimensionType1..50 | ВидСубконто1..50 | `MetadataAccountingRegisterStandardAttributeNamesXML` | зависит от плана счетов и явного XML-набора |  | - [ ] |
+| Регистр расчета | RegistrationPeriod | ПериодРегистрации | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
+| Регистр расчета | ReversingEntry | Сторно | `MetadataCalculationRegisterStandardAttributeNames` | булево |  | - [ ] |
+| Регистр расчета | Active | Активность | `MetadataCalculationRegisterStandardAttributeNames` | булево |  | - [ ] |
+| Регистр расчета | BegOfActionPeriod | НачалоПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
+| Регистр расчета | EndOfActionPeriod | КонецПериодаДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
+| Регистр расчета | ActionPeriod | ПериодДействия | `MetadataCalculationRegisterStandardAttributeNames` | дата/период |  | - [ ] |
+| Регистр расчета | BegOfBasePeriod | НачалоБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
+| Регистр расчета | EndOfBasePeriod | КонецБазовогоПериода | `MetadataCalculationRegisterStandardAttributeNames` | дата |  | - [ ] |
+| Регистр расчета | CalculationType | ВидРасчета | `MetadataCalculationRegisterStandardAttributeNames` | план видов расчета |  | - [ ] |
+| Регистр расчета | LineNumber | НомерСтроки | `MetadataCalculationRegisterStandardAttributeNames` | число |  | - [ ] |
+| Регистр расчета | Recorder | Регистратор | `MetadataCalculationRegisterStandardAttributeNames` | регистратор |  | - [ ] |
 
 ## Разобранные правила
 

--- a/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
+++ b/docs/superpowers/specs/2026-07-07-standard-attributes-datapath-table-design.md
@@ -15,7 +15,7 @@
 | Объект | Внутреннее имя | YAML | Источник сейчас | Правило типа | Спецификация | Разобрано |
 | --- | --- | --- | --- | --- | --- | --- |
 | Общие объектные | Ref | Ссылка | `dataPathCommon` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
-| Общие объектные | Parent | Родитель | `dataPathCommon` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Общие объектные | Parent | Родитель | `dataPathCommon` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Общие объектные | Owner | Владелец | `dataPathCommon` | ссылки из свойства `owners`, составной тип при нескольких владельцах | `dataPath: { type: "objectRefsFromProperty", property: "owners" }` | - [x] |
 | Общие объектные | DeletionMark | ПометкаУдаления | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Общие объектные | Predefined | Предопределенный | `dataPathCommon` | булево | `dataPath: { type: "boolean" }` | - [x] |
@@ -31,7 +31,7 @@
 | Справочник | Owner | Владелец | `MetadataCatalogStandardAttributeNames` | `owners` | `dataPath: { type: "objectRefsFromProperty", property: "owners" }` | - [x] |
 | Справочник | Code | Код | `MetadataCatalogStandardAttributeNames` | `codeType` | `dataPath: { type: "catalogCode", property: "codeType" }` | - [x] |
 | Справочник | Description | Наименование | `MetadataCatalogStandardAttributeNames` | строка | `dataPath: { type: "string" }` | - [x] |
-| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | текущий объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
+| Справочник | Parent | Родитель | `MetadataCatalogStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | Справочник | IsFolder | ЭтоГруппа | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Справочник | DeletionMark | ПометкаУдаления | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | Справочник | Predefined | Предопределенный | `MetadataCatalogStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
@@ -46,7 +46,7 @@
 | План счетов | Ref | Ссылка | `MetadataChartOfAccountsStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План счетов | Code | Код | `MetadataChartOfAccountsStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План счетов | Description | Наименование | `MetadataChartOfAccountsStandardAttributeNames` | строка |  | - [ ] |
-| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | текущий объект |  | - [ ] |
+| План счетов | Parent | Родитель | `MetadataChartOfAccountsStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План счетов | Type | Вид | `MetadataChartOfAccountsStandardAttributeNames` | резервное поведение |  | - [ ] |
 | План счетов | OffBalance | Забалансовый | `MetadataChartOfAccountsStandardAttributeNames` | булево |  | - [ ] |
 | План счетов | Order | Порядок | `MetadataChartOfAccountsStandardAttributeNames` | число |  | - [ ] |
@@ -57,7 +57,7 @@
 | План видов характеристик | ValueType | ТипЗначения | `dataPathCommon` | описание типа |  | - [ ] |
 | План видов характеристик | Code | Код | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | по свойствам кода |  | - [ ] |
 | План видов характеристик | Description | Наименование | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | строка |  | - [ ] |
-| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | текущий объект |  | - [ ] |
+| План видов характеристик | Parent | Родитель | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | ссылка на сам объект | `dataPath: { type: "sameOwnerObject" }` | - [x] |
 | План видов характеристик | IsFolder | ЭтоГруппа | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево |  | - [ ] |
 | План видов характеристик | DeletionMark | ПометкаУдаления | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
 | План видов характеристик | Predefined | Предопределенный | `MetadataChartOfCharacteristicTypesStandardAttributeNames` | булево | `dataPath: { type: "boolean" }` | - [x] |
@@ -136,6 +136,7 @@
 На текущем этапе разобраны правила, достаточные для задачи с `Owner`:
 
 - `Ref`: всегда ссылка на сам объект.
+- `Parent`: всегда ссылка на сам объект.
 - `Owner`: типы из свойства `owners`, с `isComposite` при нескольких владельцах.
 - `Code`: для справочника через `codeType`.
 - `Number`: для документа через `numberType`.

--- a/packages/core/metadata/appliedObjects/dataPathCommon/register.ts
+++ b/packages/core/metadata/appliedObjects/dataPathCommon/register.ts
@@ -100,7 +100,7 @@ registerTableColumnResolver(({ table, segment, field }) => {
 
   const virtualStandardColumn = registerRecordSetStandardColumn(segment, field?.name)
   if (field === undefined) return virtualStandardColumn
-  if (isUnknownTypeInfo(field.typeInfo) && virtualStandardColumn !== undefined) return virtualStandardColumn
+  if (virtualStandardColumn !== undefined) return virtualStandardColumn
 
   return {
     name: field.name,
@@ -202,8 +202,4 @@ function registerRecordSetStandardColumn(
   }
 
   return undefined
-}
-
-function isUnknownTypeInfo(typeInfo: DataPathTypeInfo): boolean {
-  return typeInfo.kinds.length === 1 && typeInfo.kinds[0] === "unknown"
 }

--- a/packages/core/metadata/appliedObjects/metadataAccountingRegister/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataAccountingRegister/register.ts
@@ -3,6 +3,7 @@ import type { FormDataPathColumnSource, OwnerTypeRef } from "../../validation/da
 import { resolveObjectFieldSegment } from "../../validation/dataPath/objectFields"
 import { registerDataPathOwnerKind, registerTableColumnResolver } from "../../validation/dataPath/registry"
 import { MetadataAccountingRegisterRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "РегистрБухгалтерии",

--- a/packages/core/metadata/appliedObjects/metadataAccountingRegister/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataAccountingRegister/standardMembers.ts
@@ -1,0 +1,21 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+const extDimensions = Array.from({ length: 50 }, (_, index) => {
+  const number = index + 1
+  return [
+    { memberKind: "standardAttribute", names: { internal: `ExtDimension${number}`, yaml: `Субконто${number}` }, family: "unsupported", phase: "index-time", sourceScope: "self", reason: `AccountingRegister.ExtDimension${number}` },
+    { memberKind: "standardAttribute", names: { internal: `ExtDimensionType${number}`, yaml: `ВидСубконто${number}` }, family: "unsupported", phase: "index-time", sourceScope: "self", reason: `AccountingRegister.ExtDimensionType${number}` },
+  ]
+}).flat()
+
+const members = [
+  { memberKind: "standardAttribute", names: { internal: "PeriodAdjustment", yaml: "УточнениеПериода" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "number" },
+  { memberKind: "standardAttribute", names: { internal: "Account", yaml: "Счет" }, family: "objectRefFromProperty", phase: "index-time", sourceScope: "ownerModel", property: "chartOfAccounts" },
+  { memberKind: "standardAttribute", names: { internal: "Active", yaml: "Активность" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "LineNumber", yaml: "НомерСтроки" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "number" },
+  { memberKind: "standardAttribute", names: { internal: "Period", yaml: "Период" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "Recorder", yaml: "Регистратор" }, family: "reverseLookup", phase: "traversal-time", sourceScope: "projectIndex", target: "Document", property: "registerRecords", emptyPolicy: "error", compositePolicy: "errorOnTraversal" },
+  ...extDimensions,
+] as const satisfies readonly StandardMemberDeclaration[]
+
+registerStandardMembers("РегистрБухгалтерии", members)

--- a/packages/core/metadata/appliedObjects/metadataAccumulationRegister/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataAccumulationRegister/register.ts
@@ -1,5 +1,6 @@
 import { registerDataPathOwnerKind } from "../../validation/dataPath/registry"
 import { MetadataAccumulationRegisterRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "РегистрНакопления",

--- a/packages/core/metadata/appliedObjects/metadataAccumulationRegister/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataAccumulationRegister/standardMembers.ts
@@ -1,0 +1,9 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+registerStandardMembers("РегистрНакопления", [
+  { memberKind: "standardAttribute", names: { internal: "RecordType", yaml: "ВидДвижения" }, family: "standardEnum", phase: "index-time", sourceScope: "self", name: "ВидДвиженияНакопления" },
+  { memberKind: "standardAttribute", names: { internal: "Active", yaml: "Активность" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "LineNumber", yaml: "НомерСтроки" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "number" },
+  { memberKind: "standardAttribute", names: { internal: "Period", yaml: "Период" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "Recorder", yaml: "Регистратор" }, family: "reverseLookup", phase: "traversal-time", sourceScope: "projectIndex", target: "Document", property: "registerRecords", emptyPolicy: "error", compositePolicy: "errorOnTraversal" },
+] as const satisfies readonly StandardMemberDeclaration[])

--- a/packages/core/metadata/appliedObjects/metadataBusinessProcess/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataBusinessProcess/register.ts
@@ -1,5 +1,6 @@
 import { registerDataPathOwnerKind } from "../../validation/dataPath/registry"
 import { MetadataBusinessProcessRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "БизнесПроцесс",

--- a/packages/core/metadata/appliedObjects/metadataBusinessProcess/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataBusinessProcess/standardMembers.ts
@@ -1,0 +1,14 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+const members = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Date", yaml: "Дата" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "Number", yaml: "Номер" }, family: "numberByProperty", phase: "index-time", sourceScope: "ownerModel", property: "numberType" },
+  { memberKind: "standardAttribute", names: { internal: "Started", yaml: "Стартован" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "Completed", yaml: "Завершен" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "HeadTask", yaml: "ГоловнаяЗадача" }, family: "objectRefFromProperty", phase: "index-time", sourceScope: "ownerModel", property: "task" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+] as const satisfies readonly StandardMemberDeclaration[]
+
+registerStandardMembers("БизнесПроцесс", members)
+registerStandardMembers("БизнесПроцессОбъект", members)

--- a/packages/core/metadata/appliedObjects/metadataCalculationRegister/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataCalculationRegister/register.ts
@@ -1,5 +1,6 @@
 import { registerDataPathOwnerKind } from "../../validation/dataPath/registry"
 import { MetadataCalculationRegisterRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "РегистрРасчета",

--- a/packages/core/metadata/appliedObjects/metadataCalculationRegister/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataCalculationRegister/standardMembers.ts
@@ -1,0 +1,15 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+registerStandardMembers("РегистрРасчета", [
+  { memberKind: "standardAttribute", names: { internal: "RegistrationPeriod", yaml: "ПериодРегистрации" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "ReversingEntry", yaml: "Сторно" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "Active", yaml: "Активность" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "BegOfActionPeriod", yaml: "НачалоПериодаДействия" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "EndOfActionPeriod", yaml: "КонецПериодаДействия" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "ActionPeriod", yaml: "ПериодДействия" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "BegOfBasePeriod", yaml: "НачалоБазовогоПериода" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "EndOfBasePeriod", yaml: "КонецБазовогоПериода" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "CalculationType", yaml: "ВидРасчета" }, family: "objectRefFromProperty", phase: "index-time", sourceScope: "ownerModel", property: "chartOfCalculationTypes" },
+  { memberKind: "standardAttribute", names: { internal: "LineNumber", yaml: "НомерСтроки" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "number" },
+  { memberKind: "standardAttribute", names: { internal: "Recorder", yaml: "Регистратор" }, family: "reverseLookup", phase: "traversal-time", sourceScope: "projectIndex", target: "Document", property: "registerRecords", emptyPolicy: "error", compositePolicy: "errorOnTraversal" },
+] as const satisfies readonly StandardMemberDeclaration[])

--- a/packages/core/metadata/appliedObjects/metadataCatalog/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataCatalog/register.ts
@@ -11,6 +11,7 @@ import { importMetadataCatalogFromYAML } from "./fromYAML"
 import { MetadataCatalogRules } from "./rules"
 import { exportMetadataCatalogToJSONSchema } from "./toJSONSchema"
 import type { MetadataCatalogYAML } from "./types"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "Справочник",

--- a/packages/core/metadata/appliedObjects/metadataCatalog/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataCatalog/standardMembers.ts
@@ -1,0 +1,16 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+const catalogMembers = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Parent", yaml: "Родитель" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Owner", yaml: "Владелец" }, family: "objectRefsFromProperty", phase: "index-time", sourceScope: "ownerModel", property: "owners", compositePolicy: "errorOnTraversal" },
+  { memberKind: "standardAttribute", names: { internal: "Code", yaml: "Код" }, family: "codeByProperty", phase: "index-time", sourceScope: "ownerModel", property: "codeType" },
+  { memberKind: "standardAttribute", names: { internal: "Description", yaml: "Наименование" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "IsFolder", yaml: "ЭтоГруппа" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "Predefined", yaml: "Предопределенный" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "PredefinedDataName", yaml: "ИмяПредопределенныхДанных" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+] as const satisfies readonly StandardMemberDeclaration[]
+
+registerStandardMembers("Справочник", catalogMembers)
+registerStandardMembers("СправочникОбъект", catalogMembers)

--- a/packages/core/metadata/appliedObjects/metadataChartOfAccounts/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataChartOfAccounts/register.ts
@@ -3,6 +3,7 @@ import type { DataPathTableInfo, DataPathTypeInfo, FormDataPathColumnSource } fr
 import { registerDataPathOwnerKind, registerVirtualOwnerFieldResolver } from "../../validation/dataPath/registry"
 import { booleanColumn, metadataRecord, scalarColumn } from "../dataPathCommon/register"
 import { MetadataChartOfAccountsRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "ПланСчетов",

--- a/packages/core/metadata/appliedObjects/metadataChartOfAccounts/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataChartOfAccounts/standardMembers.ts
@@ -1,0 +1,31 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+const members = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Code", yaml: "Код" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "Description", yaml: "Наименование" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "Parent", yaml: "Родитель" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Type", yaml: "Вид" }, family: "standardEnum", phase: "index-time", sourceScope: "self", name: "ВидСчета" },
+  { memberKind: "standardAttribute", names: { internal: "OffBalance", yaml: "Забалансовый" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "Order", yaml: "Порядок" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "Predefined", yaml: "Предопределенный" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "PredefinedDataName", yaml: "ИмяПредопределенныхДанных" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  {
+    memberKind: "standardTabularSection",
+    names: { internal: "ExtDimensionTypes", yaml: "ВидыСубконто" },
+    family: "standardTable",
+    phase: "traversal-time",
+    sourceScope: "ownerModel",
+    tableKind: "ValueTable",
+    columns: [
+      { memberKind: "standardTabularSectionColumn", names: { internal: "ExtDimensionType", yaml: "ВидСубконто" }, family: "objectRefFromOwnerProperty", property: "extDimensionTypes" },
+      { memberKind: "standardTabularSectionColumn", names: { internal: "TurnoversOnly", yaml: "ТолькоОбороты" }, family: "primitive", kind: "boolean" },
+      { memberKind: "standardTabularSectionColumn", names: { internal: "ТолькоСальдо", yaml: "ТолькоСальдо" }, family: "primitive", kind: "boolean" },
+      { memberKind: "standardTabularSectionColumn", names: { internal: "*", yaml: "*" }, family: "primitive", kind: "boolean", discoveredFrom: "extDimensionAccountingFlags" },
+    ],
+  },
+] as const satisfies readonly StandardMemberDeclaration[]
+
+registerStandardMembers("ПланСчетов", members)
+registerStandardMembers("ПланСчетовОбъект", members)

--- a/packages/core/metadata/appliedObjects/metadataChartOfCalculationTypes/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataChartOfCalculationTypes/register.ts
@@ -2,6 +2,7 @@ import type { OwnerMetadata } from "../../validation/dataPath/ownerCache"
 import type { FormDataPathColumnSource } from "../../validation/dataPath/types"
 import { registerDataPathOwnerKind, registerVirtualOwnerFieldResolver } from "../../validation/dataPath/registry"
 import { MetadataChartOfCalculationTypesRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "ПланВидовРасчета",

--- a/packages/core/metadata/appliedObjects/metadataChartOfCalculationTypes/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataChartOfCalculationTypes/standardMembers.ts
@@ -1,0 +1,23 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+const tableColumns = [
+  { memberKind: "standardTabularSectionColumn", names: { internal: "CalculationType", yaml: "ВидРасчета" }, family: "sameOwnerObject" },
+  { memberKind: "standardTabularSectionColumn", names: { internal: "LineNumber", yaml: "НомерСтроки" }, family: "primitive", kind: "number" },
+  { memberKind: "standardTabularSectionColumn", names: { internal: "Predefined", yaml: "Предопределенный" }, family: "primitive", kind: "boolean" },
+] as const
+
+const members = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Code", yaml: "Код" }, family: "codeByProperty", phase: "index-time", sourceScope: "ownerModel", property: "codeType" },
+  { memberKind: "standardAttribute", names: { internal: "Description", yaml: "Наименование" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "ActionPeriodIsBasic", yaml: "ПериодДействияБазовый" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "Predefined", yaml: "Предопределенный" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "PredefinedDataName", yaml: "ИмяПредопределенныхДанных" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardTabularSection", names: { internal: "LeadingCalculationTypes", yaml: "ВедущиеВидыРасчета" }, family: "standardTable", phase: "traversal-time", sourceScope: "self", tableKind: "ValueTable", columns: tableColumns },
+  { memberKind: "standardTabularSection", names: { internal: "DisplacingCalculationTypes", yaml: "ВытесняющиеВидыРасчета" }, family: "standardTable", phase: "traversal-time", sourceScope: "self", tableKind: "ValueTable", columns: tableColumns },
+  { memberKind: "standardTabularSection", names: { internal: "BaseCalculationTypes", yaml: "БазовыеВидыРасчета" }, family: "standardTable", phase: "traversal-time", sourceScope: "self", tableKind: "ValueTable", columns: tableColumns },
+] as const satisfies readonly StandardMemberDeclaration[]
+
+registerStandardMembers("ПланВидовРасчета", members)
+registerStandardMembers("ПланВидовРасчетаОбъект", members)

--- a/packages/core/metadata/appliedObjects/metadataChartOfCharacteristicTypes/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataChartOfCharacteristicTypes/register.ts
@@ -1,5 +1,6 @@
 import { registerDataPathOwnerKind } from "../../validation/dataPath/registry"
 import { MetadataChartOfCharacteristicTypesRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "ПланВидовХарактеристик",

--- a/packages/core/metadata/appliedObjects/metadataChartOfCharacteristicTypes/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataChartOfCharacteristicTypes/standardMembers.ts
@@ -1,0 +1,16 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+const members = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "ValueType", yaml: "ТипЗначения" }, family: "typeDescription", phase: "index-time", sourceScope: "self", allowNestedProperties: false },
+  { memberKind: "standardAttribute", names: { internal: "Code", yaml: "Код" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "Description", yaml: "Наименование" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "Parent", yaml: "Родитель" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "IsFolder", yaml: "ЭтоГруппа" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "Predefined", yaml: "Предопределенный" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "PredefinedDataName", yaml: "ИмяПредопределенныхДанных" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+] as const satisfies readonly StandardMemberDeclaration[]
+
+registerStandardMembers("ПланВидовХарактеристик", members)
+registerStandardMembers("ПланВидовХарактеристикОбъект", members)

--- a/packages/core/metadata/appliedObjects/metadataDocument/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataDocument/register.ts
@@ -13,6 +13,7 @@ import {
 import { registerProjectReferenceObjectPathContributor } from "../../validation/projectReferenceIndexRegistry"
 import { MetadataDocumentRules } from "./rules"
 import { exportMetadataDocumentToJSONSchema } from "./toJSONSchema"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "Документ",

--- a/packages/core/metadata/appliedObjects/metadataDocument/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataDocument/standardMembers.ts
@@ -1,0 +1,12 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+const documentMembers = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Date", yaml: "Дата" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "Number", yaml: "Номер" }, family: "numberByProperty", phase: "index-time", sourceScope: "ownerModel", property: "numberType" },
+  { memberKind: "standardAttribute", names: { internal: "Posted", yaml: "Проведен" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+] as const satisfies readonly StandardMemberDeclaration[]
+
+registerStandardMembers("Документ", documentMembers)
+registerStandardMembers("ДокументОбъект", documentMembers)

--- a/packages/core/metadata/appliedObjects/metadataDocumentJournal/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataDocumentJournal/register.ts
@@ -1,5 +1,6 @@
 import { registerDataPathOwnerKind } from "../../validation/dataPath/registry"
 import { MetadataDocumentJournalRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "ЖурналДокументов",

--- a/packages/core/metadata/appliedObjects/metadataDocumentJournal/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataDocumentJournal/standardMembers.ts
@@ -1,0 +1,10 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+registerStandardMembers("ЖурналДокументов", [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Type", yaml: "Тип" }, family: "opaque", phase: "index-time", sourceScope: "self", allowNestedProperties: false },
+  { memberKind: "standardAttribute", names: { internal: "Date", yaml: "Дата" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "Number", yaml: "Номер" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "Posted", yaml: "Проведен" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+] as const satisfies readonly StandardMemberDeclaration[])

--- a/packages/core/metadata/appliedObjects/metadataEnumeration/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataEnumeration/register.ts
@@ -12,6 +12,7 @@ import { importMetadataEnumerationFromYAML } from "./fromYAML"
 import { MetadataEnumerationRules } from "./rules"
 import { exportMetadataEnumerationToJSONSchema } from "./toJSONSchema"
 import type { MetadataEnumerationYAML } from "./types"
+import "./standardMembers"
 
 registerMetadataItemRule({
   propertyType: "MetadataEnumeration",

--- a/packages/core/metadata/appliedObjects/metadataEnumeration/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataEnumeration/standardMembers.ts
@@ -1,0 +1,6 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+registerStandardMembers("Перечисление", [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Order", yaml: "Порядок" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "number" },
+] as const satisfies readonly StandardMemberDeclaration[])

--- a/packages/core/metadata/appliedObjects/metadataExchangePlan/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataExchangePlan/register.ts
@@ -1,5 +1,6 @@
 import { registerDataPathOwnerKind, registerVirtualOwnerFieldResolver } from "../../validation/dataPath/registry"
 import { MetadataExchangePlanRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "ПланОбмена",

--- a/packages/core/metadata/appliedObjects/metadataExchangePlan/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataExchangePlan/standardMembers.ts
@@ -1,0 +1,15 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+const members = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Code", yaml: "Код" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "Description", yaml: "Наименование" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "ThisNode", yaml: "ЭтотУзел" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "ExchangeDate", yaml: "ДатаОбмена" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "SentNo", yaml: "НомерОтправленного" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "number" },
+  { memberKind: "standardAttribute", names: { internal: "ReceivedNo", yaml: "НомерПринятого" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "number" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+] as const satisfies readonly StandardMemberDeclaration[]
+
+registerStandardMembers("ПланОбмена", members)
+registerStandardMembers("ПланОбменаОбъект", members)

--- a/packages/core/metadata/appliedObjects/metadataInformationRegister/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataInformationRegister/register.ts
@@ -1,5 +1,6 @@
 import { registerDataPathOwnerKind, registerVirtualOwnerFieldResolver } from "../../validation/dataPath/registry"
 import { MetadataInformationRegisterRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "РегистрСведений",

--- a/packages/core/metadata/appliedObjects/metadataInformationRegister/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataInformationRegister/standardMembers.ts
@@ -1,0 +1,8 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+registerStandardMembers("РегистрСведений", [
+  { memberKind: "standardAttribute", names: { internal: "Active", yaml: "Активность" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "LineNumber", yaml: "НомерСтроки" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "number" },
+  { memberKind: "standardAttribute", names: { internal: "Period", yaml: "Период" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "Recorder", yaml: "Регистратор" }, family: "reverseLookup", phase: "traversal-time", sourceScope: "projectIndex", target: "Document", property: "registerRecords", emptyPolicy: "error", compositePolicy: "errorOnTraversal" },
+] as const satisfies readonly StandardMemberDeclaration[])

--- a/packages/core/metadata/appliedObjects/metadataTask/register.ts
+++ b/packages/core/metadata/appliedObjects/metadataTask/register.ts
@@ -1,5 +1,6 @@
 import { registerDataPathOwnerKind, registerStandardAttributeTypeResolver } from "../../validation/dataPath/registry"
 import { MetadataTaskRules } from "./rules"
+import "./standardMembers"
 
 registerDataPathOwnerKind({
   kind: "Задача",

--- a/packages/core/metadata/appliedObjects/metadataTask/standardMembers.ts
+++ b/packages/core/metadata/appliedObjects/metadataTask/standardMembers.ts
@@ -1,0 +1,20 @@
+import { registerStandardMembers, type StandardMemberDeclaration } from "../../validation/dataPath/registry"
+
+const indexTimeMembers = [
+  { memberKind: "standardAttribute", names: { internal: "Ref", yaml: "Ссылка" }, family: "sameOwnerObject", phase: "index-time", sourceScope: "self" },
+  { memberKind: "standardAttribute", names: { internal: "Date", yaml: "Дата" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "dateTime" },
+  { memberKind: "standardAttribute", names: { internal: "Number", yaml: "Номер" }, family: "numberByProperty", phase: "index-time", sourceScope: "ownerModel", property: "numberType" },
+  { memberKind: "standardAttribute", names: { internal: "Executed", yaml: "Выполнена" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+  { memberKind: "standardAttribute", names: { internal: "Description", yaml: "Описание" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "string" },
+  { memberKind: "standardAttribute", names: { internal: "DeletionMark", yaml: "ПометкаУдаления" }, family: "primitive", phase: "index-time", sourceScope: "self", kind: "boolean" },
+] as const
+
+const traversalMembers = [
+  { memberKind: "standardAttribute", names: { internal: "BusinessProcess", yaml: "БизнесПроцесс" }, family: "reverseLookup", phase: "traversal-time", sourceScope: "projectIndex", target: "BusinessProcess", property: "tasks", emptyPolicy: "error", compositePolicy: "errorOnTraversal" },
+  { memberKind: "standardAttribute", names: { internal: "RoutePoint", yaml: "ТочкаМаршрута" }, family: "closedReverseLookup", phase: "traversal-time", sourceScope: "projectIndex", target: "BusinessProcess", result: "BusinessProcessRoutePoint", source: "businessProcessesByTask", property: "tasks", emptyPolicy: "error", allowNestedProperties: false },
+] as const
+
+const members = [...indexTimeMembers, ...traversalMembers] as const satisfies readonly StandardMemberDeclaration[]
+
+registerStandardMembers("Задача", members)
+registerStandardMembers("ЗадачаОбъект", members)

--- a/packages/core/metadata/commonObjects/metadataPath/dataPathStandardMembers.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/dataPathStandardMembers.ts
@@ -1,0 +1,64 @@
+import type { ConfigurationContext, MetadataTargetOwnerContext } from "../../context/types"
+import {
+  getDataPathOwnerKindByItemType,
+  standardMemberInternalToYamlForOwnerKind,
+  standardMemberYamlToInternalForOwnerKind,
+} from "../../validation/dataPath/registry"
+
+const DATA_OBJECT_ROOTS = new Set(["Объект", "Запись", "Список"])
+
+export function exportDataPathStandardMembersToYAML(context: ConfigurationContext, value: unknown): unknown {
+  if (typeof value !== "string") return value
+
+  return translateDirectObjectMember({
+    context,
+    value,
+    translate: ({ ownerKind, segment }) => standardMemberInternalToYamlForOwnerKind(ownerKind, segment),
+  })
+}
+
+export function importDataPathStandardMembersFromYAML(context: ConfigurationContext, value: unknown): unknown {
+  if (typeof value !== "string") return value
+
+  return translateDirectObjectMember({
+    context,
+    value,
+    translate: ({ ownerKind, segment }) => standardMemberYamlToInternalForOwnerKind(ownerKind, segment),
+  })
+}
+
+function translateDirectObjectMember(params: {
+  context: ConfigurationContext
+  value: string
+  translate: (params: { ownerKind: string; segment: string }) => string | undefined
+}): string {
+  const ownerKind = currentDataPathOwnerKind(params.context)
+  if (ownerKind === undefined) return params.value
+
+  const { prefix, path } = splitDataPathPrefix(params.value)
+  const segments = path.split(".")
+  if (segments.length < 2 || !DATA_OBJECT_ROOTS.has(segments[0])) return params.value
+
+  const translated = params.translate({ ownerKind, segment: segments[1] })
+  if (translated === undefined) return params.value
+
+  return `${prefix}${[segments[0], translated, ...segments.slice(2)].join(".")}`
+}
+
+function splitDataPathPrefix(value: string): { prefix: string; path: string } {
+  if (value.startsWith("~")) return { prefix: "~", path: value.slice(1) }
+  return { prefix: "", path: value }
+}
+
+function currentDataPathOwnerKind(context: ConfigurationContext): string | undefined {
+  const frames = currentMetadataTargetOwners(context)
+  for (let index = frames.length - 1; index >= 0; index--) {
+    const registration = getDataPathOwnerKindByItemType(frames[index].itemType)
+    if (registration !== undefined) return registration.kind
+  }
+  return undefined
+}
+
+function currentMetadataTargetOwners(context: ConfigurationContext): readonly MetadataTargetOwnerContext[] {
+  return context.importFromYAML?.metadataTargetOwners ?? context.exportToYAML?.metadataTargetOwners ?? []
+}

--- a/packages/core/metadata/commonObjects/metadataPath/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/fromYAML.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest"
 import { tableMetadataFields, tableMetadataValues } from "./__fixtures__/table"
 import { mockContext, mockRule } from "../../../tests/mockContext"
+import type { ConfigurationContext } from "../../context/types"
+import "../../appliedObjects/metadataCatalog/register"
+import { importDataPathStandardMembersFromYAML } from "./dataPathStandardMembers"
 import { importMetadataFieldStringFromYAML, importMetadataValueStringFromYAML } from "./fromYAML"
 
 describe("importMetadataFieldFromYAML", () => {
@@ -48,5 +51,28 @@ describe("importMetadataValueStringFromYAML", () => {
     expect(importMetadataValueStringFromYAML(mockContext, mockRule, "ПланСчетов.Хозрасчетный.ПустаяСсылка")).toBe(
       "ChartOfAccounts.Хозрасчетный.EmptyRef"
     )
+  })
+})
+
+describe("importDataPathStandardMembersFromYAML", () => {
+  const catalogContext: ConfigurationContext = {
+    ...mockContext,
+    importFromYAML: {
+      metadataTargetOwners: [{ itemType: "MetadataCatalog", name: "Контрагенты" }],
+    },
+  }
+
+  test("imports direct standard attribute of current object", () => {
+    expect(importDataPathStandardMembersFromYAML(catalogContext, "Объект.Владелец")).toBe("Объект.Owner")
+  })
+
+  test("keeps tabular section attribute with the same name", () => {
+    expect(importDataPathStandardMembersFromYAML(catalogContext, "Объект.Товары.Владелец")).toBe(
+      "Объект.Товары.Владелец"
+    )
+  })
+
+  test("preserves disabled data path prefix", () => {
+    expect(importDataPathStandardMembersFromYAML(catalogContext, "~Список.Владелец")).toBe("~Список.Owner")
   })
 })

--- a/packages/core/metadata/commonObjects/metadataPath/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/fromYAML.ts
@@ -2,7 +2,9 @@ import { parseMetadataTargetFromYAML } from "../metadataTargets"
 import { isMetadataRootName, rootFromYAML } from "../metadataTargets/roots"
 import type { MetadataTargetConstraint, MetadataTargetOwner } from "../metadataTargets/types"
 import type { ConfigurationContext } from "../../context/types"
+import { registerTypeRule } from "../../orchestration/property/typeRuleRegistry"
 import type { PropertyRule } from "../../orchestration/property/types"
+import { importDataPathStandardMembersFromYAML } from "./dataPathStandardMembers"
 
 const metadataObjectTargetFallback = { kind: "object" } as const satisfies MetadataTargetConstraint
 const metadataFieldTargetFallback = { kind: "member", owner: "explicit" } as const satisfies MetadataTargetConstraint
@@ -111,3 +113,7 @@ function isMetadataTargetLikeYAML(value: string): boolean {
   const root = value.split(".")[0]
   return rootFromYAML[root] !== undefined || isMetadataRootName(root)
 }
+
+registerTypeRule("DataPath", "importFromYAML", ({ context, value }) => {
+  return importDataPathStandardMembersFromYAML(context, value)
+})

--- a/packages/core/metadata/commonObjects/metadataPath/toYAML.test.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/toYAML.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest"
 import { tableMetadataFields, tableMetadataValues } from "./__fixtures__/table"
 import { mockContext, mockRule } from "../../../tests/mockContext"
+import type { ConfigurationContext } from "../../context/types"
+import "../../appliedObjects/metadataCatalog/register"
+import { exportDataPathStandardMembersToYAML } from "./dataPathStandardMembers"
 import { exportMetadataFieldStringToYAML, exportMetadataValueStringToYAML } from "./toYAML"
 
 describe("exportMetadataFieldToYAML", () => {
@@ -36,5 +39,27 @@ describe("exportMetadataValueStringToYAML", () => {
     expect(exportMetadataValueStringToYAML(mockContext, mockRule, "Catalog.ИмяСправочника.ПланСчетов")).toBe(
       "Справочник.ИмяСправочника.ПланСчетов"
     )
+  })
+})
+
+describe("exportDataPathStandardMembersToYAML", () => {
+  const catalogContext: ConfigurationContext = {
+    ...mockContext,
+    exportToYAML: {
+      toTyped: false,
+      metadataTargetOwners: [{ itemType: "MetadataCatalog", name: "Контрагенты" }],
+    },
+  }
+
+  test("exports direct standard attribute of current object", () => {
+    expect(exportDataPathStandardMembersToYAML(catalogContext, "Объект.Owner")).toBe("Объект.Владелец")
+  })
+
+  test("keeps tabular section attribute with the same name", () => {
+    expect(exportDataPathStandardMembersToYAML(catalogContext, "Объект.Товары.Owner")).toBe("Объект.Товары.Owner")
+  })
+
+  test("preserves disabled data path prefix", () => {
+    expect(exportDataPathStandardMembersToYAML(catalogContext, "~Список.Owner")).toBe("~Список.Владелец")
   })
 })

--- a/packages/core/metadata/commonObjects/metadataPath/toYAML.ts
+++ b/packages/core/metadata/commonObjects/metadataPath/toYAML.ts
@@ -2,7 +2,9 @@ import { formatMetadataTargetToYAML } from "../metadataTargets"
 import { isMetadataRootName } from "../metadataTargets/roots"
 import type { MetadataTargetConstraint, MetadataTargetOwner } from "../metadataTargets/types"
 import type { ConfigurationContext } from "../../context/types"
+import { registerTypeRule } from "../../orchestration/property/typeRuleRegistry"
 import type { PropertyRule } from "../../orchestration/property/types"
+import { exportDataPathStandardMembersToYAML } from "./dataPathStandardMembers"
 
 const metadataObjectTargetFallback = { kind: "object" } as const satisfies MetadataTargetConstraint
 const metadataFieldTargetFallback = { kind: "member", owner: "explicit" } as const satisfies MetadataTargetConstraint
@@ -84,3 +86,7 @@ function isMetadataTargetLikeModel(value: string): boolean {
   const root = value.split(".")[0]
   return isMetadataRootName(root)
 }
+
+registerTypeRule("DataPath", "exportToYAML", ({ context, value }) => {
+  return exportDataPathStandardMembersToYAML(context, value)
+})

--- a/packages/core/metadata/commonObjects/metadataTargets/parse.test.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/parse.test.ts
@@ -102,6 +102,25 @@ describe("metadataTargets parser", () => {
     })
   })
 
+  it("parses and formats standard member YAML aliases from standardMembers", () => {
+    expect(
+      parseMetadataTargetFromYAML({
+        value: "ПланОбмена.Синхронизация.СтандартныйРеквизит.ДатаОбмена",
+        constraint: { kind: "member", owner: "explicit", roots: ["ExchangePlan"], memberKinds: ["StandardAttribute"] },
+      })
+    ).toMatchObject({
+      ok: true,
+      canonical: "ExchangePlan.Синхронизация.StandardAttribute.ExchangeDate",
+    })
+
+    expect(
+      formatMetadataTargetToYAML({
+        canonical: "ExchangePlan.Синхронизация.StandardAttribute.ExchangeDate",
+        constraint: { kind: "member", owner: "explicit", roots: ["ExchangePlan"], memberKinds: ["StandardAttribute"] },
+      })
+    ).toBe("ПланОбмена.Синхронизация.СтандартныйРеквизит.ExchangeDate")
+  })
+
   it("applies memberKinds to the terminal field-like member segment", () => {
     const result = parseMetadataTargetFromYAML({
       value: "Справочник.Номенклатура.ТабличнаяЧасть.Товары.Реквизит.Количество",

--- a/packages/core/metadata/commonObjects/metadataTargets/parse.ts
+++ b/packages/core/metadata/commonObjects/metadataTargets/parse.ts
@@ -8,6 +8,7 @@ import {
   rootFromYAML,
   standardAttributeFromYAML,
 } from "./roots"
+import { standardMemberYamlToInternal } from "../../validation/dataPath/registry"
 import type {
   MetadataMemberKind,
   MetadataMemberSegment,
@@ -667,7 +668,7 @@ function formatCanonicalTarget(target: ParsedMetadataTarget): string {
 
 function normalizeMemberSegmentName(kind: MetadataMemberKind, name: string, source: "yaml" | "model"): string {
   if (kind !== "StandardAttribute" || source !== "yaml") return name
-  return standardAttributeFromYAML[name] ?? name
+  return standardMemberYamlToInternal(name) ?? standardAttributeFromYAML[name] ?? name
 }
 
 function parseYAMLValueTarget(

--- a/packages/core/metadata/commonObjects/сhoiceParameterLinks/fromYAML.test.ts
+++ b/packages/core/metadata/commonObjects/сhoiceParameterLinks/fromYAML.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { mockContext, mockRule } from "../../../tests/mockContext"
+import type { ConfigurationContext } from "../../context/types"
+import "../../appliedObjects/metadataCatalog/register"
 import { importChoiceParameterLinksFromYAML } from "./fromYAML"
 
 describe("importFromYAML", () => {
@@ -109,6 +111,49 @@ describe("importFromYAML", () => {
         name: "Отбор.ПланСчетов",
         dataPath: "ПланСчетов.Ref",
         valueChange: "DontChange",
+      },
+    ])
+  })
+
+  it("imports structured standard member in dataPath", () => {
+    const context: ConfigurationContext = {
+      ...mockContext,
+      importFromYAML: {
+        metadataTargetOwners: [{ itemType: "MetadataCatalog", name: "Контрагенты" }],
+      },
+    }
+
+    const result = importChoiceParameterLinksFromYAML(context, mockRule, [
+      {
+        Имя: "Отбор.Владелец",
+        ПутьКДанным: "Объект.Владелец",
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        name: "Отбор.Владелец",
+        dataPath: "Объект.Owner",
+        valueChange: "Clear",
+      },
+    ])
+  })
+
+  it("imports string standard member in dataPath", () => {
+    const context: ConfigurationContext = {
+      ...mockContext,
+      importFromYAML: {
+        metadataTargetOwners: [{ itemType: "MetadataCatalog", name: "Контрагенты" }],
+      },
+    }
+
+    const result = importChoiceParameterLinksFromYAML(context, mockRule, "Отбор.Владелец(Объект.Владелец)")
+
+    expect(result).toEqual([
+      {
+        name: "Отбор.Владелец",
+        dataPath: "Объект.Owner",
+        valueChange: "Clear",
       },
     ])
   })

--- a/packages/core/metadata/commonObjects/сhoiceParameterLinks/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/сhoiceParameterLinks/fromYAML.ts
@@ -1,6 +1,7 @@
 import type { PropertyRule } from "../../orchestration/property/types"
 import { registerTypeRule } from "../../orchestration/property/typeRuleRegistry"
 import { ConfigurationContext } from "../../context/types"
+import { importDataPathStandardMembersFromYAML } from "../metadataPath/dataPathStandardMembers"
 import { importMetadataFieldFromYAML } from "../metadataField/fromYAML"
 import type { ChoiceParameterLinks, ChoiceParameterLinksYAML } from "./types"
 
@@ -67,7 +68,8 @@ const parseChoiceParameterLinksString = (
     }
 
     // Преобразуем dataPath из YAML формата в XML формат
-    const xmlDataPath = importMetadataFieldFromYAML(context, undefined, dataPath)
+    const normalizedDataPath = importDataPathStandardMembersFromYAML(context, dataPath) as string
+    const xmlDataPath = importMetadataFieldFromYAML(context, undefined, normalizedDataPath) ?? normalizedDataPath
     if (!xmlDataPath) {
       throw new Error(`Invalid dataPath: ${dataPath}`)
     }
@@ -94,7 +96,7 @@ export const importChoiceParameterLinksFromYAML = (
 
   return data.map((link) => ({
     name: link.Имя,
-    dataPath: link.ПутьКДанным,
+    dataPath: importDataPathStandardMembersFromYAML(context, link.ПутьКДанным) as string,
     valueChange: link.РежимИзменения === "НеИзменять" ? "DontChange" : "Clear",
   }))
 }

--- a/packages/core/metadata/commonObjects/сhoiceParameterLinks/toYAML.test.ts
+++ b/packages/core/metadata/commonObjects/сhoiceParameterLinks/toYAML.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { mockContext, mockRule } from "../../../tests/mockContext"
+import type { ConfigurationContext } from "../../context/types"
+import "../../appliedObjects/metadataCatalog/register"
 import { exportChoiceParameterLinksToYAML } from "./toYAML"
 import { ChoiceParameterLinks } from "./types"
 
@@ -93,6 +95,31 @@ describe("exportToYAML", () => {
         Имя: "Отбор.Характеристика",
         ПутьКДанным: "Характеристика",
         РежимИзменения: "НеИзменять",
+      },
+    ])
+  })
+
+  it("exports standard member in dataPath", () => {
+    const context: ConfigurationContext = {
+      ...mockContext,
+      exportToYAML: {
+        toTyped: false,
+        metadataTargetOwners: [{ itemType: "MetadataCatalog", name: "Контрагенты" }],
+      },
+    }
+
+    const result = exportChoiceParameterLinksToYAML(context, mockRule, [
+      {
+        name: "Отбор.Владелец",
+        dataPath: "Объект.Owner",
+        valueChange: "Clear",
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        Имя: "Отбор.Владелец",
+        ПутьКДанным: "Объект.Владелец",
       },
     ])
   })

--- a/packages/core/metadata/commonObjects/сhoiceParameterLinks/toYAML.ts
+++ b/packages/core/metadata/commonObjects/сhoiceParameterLinks/toYAML.ts
@@ -1,10 +1,11 @@
 import type { PropertyRule } from "../../orchestration/property/types"
 import { registerTypeRule } from "../../orchestration/property/typeRuleRegistry"
 import { ConfigurationContext } from "../../context/types"
+import { exportDataPathStandardMembersToYAML } from "../metadataPath/dataPathStandardMembers"
 import type { ChoiceParameterLinks, ChoiceParameterLinksYAML } from "./types"
 
 export const exportChoiceParameterLinksToYAML = (
-  _context: ConfigurationContext,
+  context: ConfigurationContext,
   _rule: PropertyRule | undefined,
   data: ChoiceParameterLinks | undefined
 ): ChoiceParameterLinksYAML | undefined => {
@@ -12,7 +13,7 @@ export const exportChoiceParameterLinksToYAML = (
 
   return data.map((link) => ({
     Имя: link.name,
-    ПутьКДанным: link.dataPath,
+    ПутьКДанным: exportDataPathStandardMembersToYAML(context, link.dataPath) as string,
     ...(link.valueChange === "DontChange" ? { РежимИзменения: "НеИзменять" as const } : {}),
   }))
 }

--- a/packages/core/metadata/importBoundaries.test.ts
+++ b/packages/core/metadata/importBoundaries.test.ts
@@ -190,6 +190,24 @@ describe("metadata import boundaries", () => {
     expect(existsSync(join(METADATA_DIR, "appliedObjects", "dataPathOwnerKinds", "register.ts"))).toBe(false)
   })
 
+  it("standardMembers core не содержит concrete owner kinds", () => {
+    const files = [
+      "metadata/validation/dataPath/standardMembers.ts",
+      "metadata/validation/dataPath/objectFields.ts",
+      "metadata/validation/dataPath/resolver.ts",
+    ]
+
+    for (const file of files) {
+      const source = readFileSync(join(process.cwd(), file), "utf-8")
+      expect(source).not.toMatch(/Справочник|Документ|ПланСчетов|Регистр/)
+    }
+  })
+
+  it("standardMembers declarations live with applied objects", () => {
+    expect(existsSync(join(METADATA_DIR, "appliedObjects", "metadataCatalog", "standardMembers.ts"))).toBe(true)
+    expect(existsSync(join(METADATA_DIR, "appliedObjects", "metadataTask", "standardMembers.ts"))).toBe(true)
+  })
+
   it("I8nText registry entry живёт рядом с владельцем", () => {
     const globalRegistry = readFileSync(join(METADATA_DIR, "orchestration", "property", "registry.ts"), "utf-8")
     const localRegistry = readFileSync(join(METADATA_DIR, "commonObjects", "i8nText", "registry.types.ts"), "utf-8")

--- a/packages/core/metadata/validation/dataPath/objectFields.ts
+++ b/packages/core/metadata/validation/dataPath/objectFields.ts
@@ -8,7 +8,11 @@ import type {
 } from "../../orchestration/property/types"
 import type { Diagnostic } from "../types"
 import type { OwnerMetadata } from "./ownerCache"
-import { getObjectFieldCollectionDescriptors, resolveStandardAttributeType } from "./registry"
+import {
+  getObjectFieldCollectionDescriptors,
+  resolveIndexTimeStandardMember,
+  resolveStandardAttributeType,
+} from "./registry"
 import { typeDescriptionToDataPathTypeInfo } from "./typeDescription"
 import { type DataPathTableInfo, type DataPathTypeInfo, unknownDataPathTypeInfo } from "./types"
 
@@ -196,6 +200,14 @@ function standardAttributeTypeInfo(params: {
 }): DataPathTypeInfo {
   const explicitTypeInfo =
     params.explicit?.type === undefined ? undefined : typeDescriptionToDataPathTypeInfo(params.explicit.type)
+  const declarative = resolveIndexTimeStandardMember({
+    owner: params.owner as OwnerMetadata,
+    internalName: params.internalName,
+    yamlName: params.yamlName,
+    ...(explicitTypeInfo !== undefined ? { explicitTypeInfo } : {}),
+  })
+  if (declarative !== undefined) return declarative.typeInfo
+
   return (
     resolveStandardAttributeType({
       owner: params.owner as OwnerMetadata,

--- a/packages/core/metadata/validation/dataPath/ownerCache.ts
+++ b/packages/core/metadata/validation/dataPath/ownerCache.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "fs"
 import { join, resolve } from "path"
 import { Type } from "typebox"
 import type { ConfigurationContext } from "../../context/types"
@@ -16,6 +17,7 @@ import type { OwnerTypeRef } from "./types"
 
 export interface OwnerMetadataCache {
   get(ref: OwnerTypeRef): OwnerMetadataResult
+  listRefs(kind: OwnerTypeRef["kind"]): readonly OwnerTypeRef[]
 }
 
 export type OwnerMetadataResult =
@@ -71,6 +73,18 @@ export function createOwnerMetadataCache({
       results.set(key, result)
       return result
     },
+    listRefs(kind) {
+      const ownerKind = getDataPathOwnerKind(kind)
+      if (ownerKind === undefined) return []
+      const dir = join(rootDir, ownerKind.projectDir)
+      try {
+        return readdirSync(dir, { withFileTypes: true })
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => ({ kind, name: entry.name }))
+      } catch {
+        return []
+      }
+    },
   }
 }
 
@@ -90,6 +104,14 @@ export function createOwnerMetadataCacheFromValidationTable(params: {
       const result = loadOwnerFromValidationTable({ projectDir, table: params.table, ref })
       results.set(key, result)
       return result
+    },
+    listRefs(kind) {
+      const ownerKind = getDataPathOwnerKind(kind)
+      const tableKind = ownerKind?.projectDir ?? kind
+      return params.table.listOwners(tableKind).map((ref) => ({
+        kind,
+        ...(ref.name !== undefined ? { name: ref.name } : {}),
+      }))
     },
   }
 }

--- a/packages/core/metadata/validation/dataPath/registry.ts
+++ b/packages/core/metadata/validation/dataPath/registry.ts
@@ -3,6 +3,12 @@ import type { FormDataPathIndex } from "./formIndex"
 import type { ObjectField } from "./objectFields"
 import type { OwnerMetadata, OwnerMetadataCache } from "./ownerCache"
 import type { DataPathTableInfo, DataPathTypeInfo, FormDataPathColumnSource, OwnerTypeRef } from "./types"
+import {
+  clearStandardMembersForTests,
+  restoreStandardMembersForTests,
+  snapshotStandardMembersForTests,
+  type StandardMemberDeclaration as SnapshotStandardMemberDeclaration,
+} from "./standardMembers"
 
 export interface DataPathOwnerKindRegistration {
   kind: OwnerTypeRef["kind"]
@@ -110,6 +116,7 @@ export interface DataPathResolverRegistrySnapshot {
   tableColumnResolvers: TableColumnResolver[]
   traversalTransitionResolvers: TraversalTransitionResolver[]
   registerRecordsItemResolvers: RegisterRecordsItemResolver[]
+  standardMembers: Map<string, SnapshotStandardMemberDeclaration[]>
 }
 
 export function registerDataPathOwnerKind(registration: DataPathOwnerKindRegistration): void {
@@ -125,6 +132,13 @@ export function registerDataPathOwnerKind(registration: DataPathOwnerKindRegistr
 
 export function getDataPathOwnerKind(kind: string): DataPathOwnerKindRegistration | undefined {
   return ownerKinds.get(kind)
+}
+
+export function getDataPathOwnerKindByItemType(itemType: string): DataPathOwnerKindRegistration | undefined {
+  for (const registration of ownerKinds.values()) {
+    if (registration.rule.itemType === itemType) return registration
+  }
+  return undefined
 }
 
 export function getOwnerKindByTypeDescriptionBase(baseType: string): string | undefined {
@@ -254,6 +268,7 @@ export function clearDataPathResolverRegistryForTests(): void {
   tableColumnResolvers.length = 0
   traversalTransitionResolvers.length = 0
   registerRecordsItemResolvers.length = 0
+  clearStandardMembersForTests()
 }
 
 export function snapshotDataPathResolverRegistryForTests(): DataPathResolverRegistrySnapshot {
@@ -269,6 +284,7 @@ export function snapshotDataPathResolverRegistryForTests(): DataPathResolverRegi
     tableColumnResolvers: [...tableColumnResolvers],
     traversalTransitionResolvers: [...traversalTransitionResolvers],
     registerRecordsItemResolvers: [...registerRecordsItemResolvers],
+    standardMembers: snapshotStandardMembersForTests(),
   }
 }
 
@@ -285,4 +301,26 @@ export function restoreDataPathResolverRegistryForTests(snapshot: DataPathResolv
   tableColumnResolvers.push(...snapshot.tableColumnResolvers)
   traversalTransitionResolvers.push(...snapshot.traversalTransitionResolvers)
   registerRecordsItemResolvers.push(...snapshot.registerRecordsItemResolvers)
+  restoreStandardMembersForTests(snapshot.standardMembers)
 }
+
+export {
+  getStandardMembers,
+  registerStandardMembers,
+  resolveIndexTimeStandardMember,
+  resolveStandardTableColumn,
+  resolveTraversalTimeStandardMember,
+  standardMemberInternalToYaml,
+  standardMemberInternalToYamlForOwnerKind,
+  standardMemberYamlToInternal,
+  standardMemberYamlToInternalForOwnerKind,
+} from "./standardMembers"
+export type {
+  PrimitiveKind,
+  StandardMemberDeclaration,
+  StandardMemberError,
+  StandardMemberKind,
+  StandardMemberNames,
+  StandardMemberPhase,
+  StandardMemberSourceScope,
+} from "./standardMembers"

--- a/packages/core/metadata/validation/dataPath/resolver.test.ts
+++ b/packages/core/metadata/validation/dataPath/resolver.test.ts
@@ -4,6 +4,7 @@ import type { ClientApplicationForm } from "../../forms/clientApplicationForm/ty
 import type { FormAttribute } from "../../forms/commonObjects/formAttribute/types"
 import { MetadataAccountingRegisterRules } from "../../appliedObjects/metadataAccountingRegister/rules"
 import { MetadataAccumulationRegisterRules } from "../../appliedObjects/metadataAccumulationRegister/rules"
+import { MetadataBusinessProcessRules } from "../../appliedObjects/metadataBusinessProcess/rules"
 import { MetadataCatalogRules } from "../../appliedObjects/metadataCatalog/rules"
 import { MetadataChartOfAccountsRules } from "../../appliedObjects/metadataChartOfAccounts/rules"
 import { MetadataChartOfCalculationTypesRules } from "../../appliedObjects/metadataChartOfCalculationTypes/rules"
@@ -1173,7 +1174,7 @@ describe("resolveDataPath", () => {
       target: {
         value: "Объект.ExtDimensionTypes",
         segments: ["Объект", "ExtDimensionTypes"],
-        source: { kind: "objectField", owner: { kind: "ПланСчетов", name: "Хозрасчетный" }, name: "ExtDimensionTypes" },
+        source: { kind: "objectField", owner: { kind: "ПланСчетов", name: "Хозрасчетный" }, name: "ВидыСубконто" },
         typeInfo: { kinds: ["tableSource"], table: { kind: "ValueTable" } },
       },
     })
@@ -1191,7 +1192,7 @@ describe("resolveDataPath", () => {
       status: "ok",
       diagnostics: [],
       target: {
-        source: { kind: "tableColumn", table: "ExtDimensionTypes", name: "ExtDimensionType" },
+        source: { kind: "tableColumn", table: "ВидыСубконто", name: "ExtDimensionType" },
         typeInfo: {
           kinds: ["object"],
           nextTypes: [{ kind: "ПланВидовХарактеристик", name: "ВидыСубконтоХозрасчетные" }],
@@ -1342,11 +1343,11 @@ describe("resolveDataPath", () => {
       status: "ok",
       diagnostics: [],
       target: {
-        source: { kind: "tableColumn", table: "BaseCalculationTypes", name: "CalculationType" },
+        source: { kind: "tableColumn", table: "БазовыеВидыРасчета", name: "CalculationType" },
         typeInfo: {
           kinds: ["object"],
           nextTypes: [{ kind: "ПланВидовРасчета", name: "Начисления" }],
-          sourceText: "ChartOfCalculationTypes.Начисления",
+          sourceText: "ПланВидовРасчета.BaseCalculationTypes.CalculationType",
         },
       },
     })
@@ -1684,6 +1685,14 @@ describe("resolveDataPath", () => {
           ],
         },
       }),
+      owner({
+        ref: { kind: "БизнесПроцесс", name: "Согласование" },
+        rule: MetadataBusinessProcessRules,
+        model: {
+          itemType: "MetadataBusinessProcess",
+          tasks: ["Task.ЗадачаИсполнителя"],
+        },
+      }),
     ])
 
     for (const [path, yamlName] of [
@@ -1854,7 +1863,7 @@ describe("resolveDataPath", () => {
         target: {
           value: path,
           source: { kind: "objectField", owner: { kind: "ПланОбмена", name: "Синхронизация" }, name: yamlName },
-          typeInfo: { kinds: ["scalar"], sourceText: "ПланОбмена.SentReceivedNo" },
+          typeInfo: { kinds: ["scalar"], sourceText: path.endsWith("SentNo") ? "ПланОбмена.SentNo" : "ПланОбмена.ReceivedNo" },
         },
       })
     }
@@ -2524,6 +2533,9 @@ function ownerCache(owners: OwnerMetadata[]): OwnerMetadataCache {
   const byKey = new Map(owners.map((item) => [ownerKey(item.ref), item]))
 
   return {
+    listRefs(kind) {
+      return owners.map((item) => item.ref).filter((ref) => ref.kind === kind)
+    },
     get(ref): OwnerMetadataResult {
       const found = byKey.get(ownerKey(ref))
       if (found !== undefined) return { status: "ok", owner: found }

--- a/packages/core/metadata/validation/dataPath/resolver.ts
+++ b/packages/core/metadata/validation/dataPath/resolver.ts
@@ -8,6 +8,7 @@ import {
   getMetadataLinkPrefixesByOwnerKind,
   resolveRegisteredTableColumn,
   resolveMovementItem as resolveRegisteredMovementItem,
+  resolveTraversalTimeStandardMember,
   resolveTraversalTransition,
   resolveVirtualOwnerField,
 } from "./registry"
@@ -200,6 +201,25 @@ export function resolveDataPath(params: ResolveDataPathParams): ResolveDataPathR
     }
 
     const field = resolveObjectFieldSegment({ index: ownerResult.owner.fieldIndex, segment: lookupSegment })
+    const standardMember = resolveTraversalTimeStandardMember({
+      owner: ownerResult.owner,
+      segment: lookupSegment,
+      ownerCache: params.ownerCache,
+    })
+    if (standardMember?.kind === "error") {
+      return error(params, `ПутьКДанным "${value}": ${standardMember.message}`)
+    }
+    if (standardMember !== undefined) {
+      state = {
+        typeInfo: standardMember.typeInfo,
+        source: { kind: "objectField", owner: ownerResult.owner.ref, name: standardMember.name },
+        ...(standardMember.tableSource !== undefined ? { tableSource: standardMember.tableSource } : {}),
+      }
+
+      if (isLast) return okTarget({ value, segments, state })
+      continue
+    }
+
     const virtualField = resolveVirtualOwnerField({
       owner: ownerResult.owner,
       segment: lookupSegment,

--- a/packages/core/metadata/validation/dataPath/standardMembers.coverage.test.ts
+++ b/packages/core/metadata/validation/dataPath/standardMembers.coverage.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { getStandardMembers } from "./standardMembers"
+
+describe("standardMembers declarations coverage", () => {
+  it.each([
+    ["Справочник", ["Ref", "Owner", "Code", "Description", "Parent", "IsFolder", "DeletionMark", "Predefined", "PredefinedDataName"]],
+    ["Документ", ["Ref", "Date", "Number", "Posted", "DeletionMark"]],
+    ["Перечисление", ["Ref", "Order"]],
+    ["ПланСчетов", ["Ref", "Code", "Description", "Parent", "Type", "OffBalance", "Order", "DeletionMark", "Predefined", "PredefinedDataName", "ExtDimensionTypes"]],
+    ["ПланВидовХарактеристик", ["Ref", "ValueType", "Code", "Description", "Parent", "IsFolder", "DeletionMark", "Predefined", "PredefinedDataName"]],
+    ["ПланВидовРасчета", ["Ref", "Code", "Description", "ActionPeriodIsBasic", "DeletionMark", "Predefined", "PredefinedDataName", "LeadingCalculationTypes", "DisplacingCalculationTypes", "BaseCalculationTypes"]],
+    ["ПланОбмена", ["Ref", "Code", "Description", "ThisNode", "ExchangeDate", "SentNo", "ReceivedNo", "DeletionMark"]],
+    ["ЖурналДокументов", ["Ref", "Type", "Date", "Number", "Posted", "DeletionMark"]],
+    ["БизнесПроцесс", ["Ref", "Date", "Number", "Started", "Completed", "HeadTask", "DeletionMark"]],
+    ["Задача", ["Ref", "Date", "Number", "Executed", "BusinessProcess", "RoutePoint", "Description", "DeletionMark"]],
+    ["РегистрСведений", ["Active", "LineNumber", "Recorder", "Period"]],
+    ["РегистрНакопления", ["RecordType", "Active", "LineNumber", "Recorder", "Period"]],
+    ["РегистрБухгалтерии", ["PeriodAdjustment", "Account", "Active", "LineNumber", "Recorder", "Period", "ExtDimension1", "ExtDimensionType1"]],
+    ["РегистрРасчета", ["RegistrationPeriod", "ReversingEntry", "Active", "BegOfActionPeriod", "EndOfActionPeriod", "ActionPeriod", "BegOfBasePeriod", "EndOfBasePeriod", "CalculationType", "LineNumber", "Recorder"]],
+  ])("%s has declared standard members", (ownerKind, expectedNames) => {
+    const actualNames = getStandardMembers(ownerKind).map((member) => member.names.internal)
+    for (const name of expectedNames) expect(actualNames).toContain(name)
+  })
+})

--- a/packages/core/metadata/validation/dataPath/standardMembers.ts
+++ b/packages/core/metadata/validation/dataPath/standardMembers.ts
@@ -1,0 +1,584 @@
+import type { MetadataItem, MetadataItemRule } from "../../orchestration/property/types"
+import type { OwnerMetadata, OwnerMetadataCache } from "./ownerCache"
+import {
+  getMetadataLinkPrefixesByOwnerKind,
+  getOwnerKindByMetadataLinkPrefix,
+} from "./registry"
+import type { DataPathTableInfo, DataPathTypeInfo, FormDataPathColumnSource, OwnerTypeRef } from "./types"
+
+export type StandardMemberKind = "standardAttribute" | "standardTabularSection" | "standardTabularSectionColumn"
+export type StandardMemberPhase = "index-time" | "traversal-time" | "deferred"
+export type StandardMemberSourceScope = "self" | "ownerModel" | "rules" | "projectIndex"
+export type PrimitiveKind = "boolean" | "string" | "dateTime" | "number"
+
+export interface StandardMemberNames {
+  internal: string
+  yaml: string
+}
+
+interface BaseStandardMemberDeclaration {
+  memberKind: StandardMemberKind
+  names: StandardMemberNames
+  phase: StandardMemberPhase
+  sourceScope: StandardMemberSourceScope
+}
+
+export interface PrimitiveStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "primitive"
+  kind: PrimitiveKind
+  terminal?: true
+  allowNestedProperties?: false
+}
+
+export interface SameOwnerObjectStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "sameOwnerObject"
+}
+
+export interface ObjectRefsFromPropertyStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "objectRefsFromProperty"
+  property: string
+  compositePolicy: "errorOnTraversal"
+}
+
+export interface MetadataPropertyScalarStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "codeByProperty" | "numberByProperty"
+  property: string
+}
+
+export interface ObjectRefFromPropertyStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "objectRefFromProperty"
+  property: string
+}
+
+export interface StandardEnumStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "standardEnum"
+  name: string
+}
+
+export interface TypeDescriptionStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "typeDescription"
+  allowNestedProperties: false
+}
+
+export interface OpaqueStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "opaque"
+  allowNestedProperties: false
+}
+
+export interface UnsupportedStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "unsupported"
+  reason: string
+}
+
+export interface ReverseLookupStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "reverseLookup"
+  phase: "traversal-time"
+  sourceScope: "projectIndex"
+  target: string
+  property: string
+  emptyPolicy: "error"
+  compositePolicy: "errorOnTraversal"
+}
+
+export interface ClosedReverseLookupStandardMemberDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardAttribute"
+  family: "closedReverseLookup"
+  phase: "traversal-time"
+  sourceScope: "projectIndex"
+  target?: string
+  result: string
+  source: string
+  property?: string
+  emptyPolicy: "error"
+  allowNestedProperties: false
+}
+
+export interface StandardTableDeclaration extends BaseStandardMemberDeclaration {
+  memberKind: "standardTabularSection"
+  family: "standardTable"
+  tableKind: "ValueTable"
+  columns: readonly StandardTableColumnDeclaration[]
+}
+
+export type StandardTableColumnDeclaration =
+  | PrimitiveStandardTableColumnDeclaration
+  | SameOwnerObjectStandardTableColumnDeclaration
+  | ObjectRefFromOwnerPropertyStandardTableColumnDeclaration
+
+export interface PrimitiveStandardTableColumnDeclaration {
+  memberKind: "standardTabularSectionColumn"
+  names: StandardMemberNames
+  family: "primitive"
+  kind: PrimitiveKind
+  discoveredFrom?: string
+}
+
+export interface SameOwnerObjectStandardTableColumnDeclaration {
+  memberKind: "standardTabularSectionColumn"
+  names: StandardMemberNames
+  family: "sameOwnerObject"
+}
+
+export interface ObjectRefFromOwnerPropertyStandardTableColumnDeclaration {
+  memberKind: "standardTabularSectionColumn"
+  names: StandardMemberNames
+  family: "objectRefFromOwnerProperty"
+  property: string
+}
+
+export type StandardMemberDeclaration =
+  | PrimitiveStandardMemberDeclaration
+  | SameOwnerObjectStandardMemberDeclaration
+  | ObjectRefsFromPropertyStandardMemberDeclaration
+  | MetadataPropertyScalarStandardMemberDeclaration
+  | ObjectRefFromPropertyStandardMemberDeclaration
+  | StandardEnumStandardMemberDeclaration
+  | TypeDescriptionStandardMemberDeclaration
+  | OpaqueStandardMemberDeclaration
+  | UnsupportedStandardMemberDeclaration
+  | ReverseLookupStandardMemberDeclaration
+  | ClosedReverseLookupStandardMemberDeclaration
+  | StandardTableDeclaration
+
+export interface ResolveIndexTimeStandardMemberParams {
+  owner: Pick<OwnerMetadata, "ref" | "model" | "rule">
+  internalName: string
+  yamlName: string
+  explicitTypeInfo?: DataPathTypeInfo
+}
+
+export interface ResolvedStandardMember {
+  name: string
+  targetName: string
+  typeInfo: DataPathTypeInfo
+}
+
+export interface ResolveTraversalTimeStandardMemberParams {
+  owner: OwnerMetadata
+  segment: string
+  ownerCache: OwnerMetadataCache
+}
+
+export interface ResolvedTraversalStandardMember {
+  name: string
+  typeInfo: DataPathTypeInfo
+  tableSource?: {
+    table: DataPathTableInfo
+    columns: Map<string, FormDataPathColumnSource>
+    hasColumns: boolean
+  }
+}
+
+export interface StandardMemberError {
+  kind: "error"
+  message: string
+}
+
+export interface ResolveStandardTableColumnParams {
+  owner: OwnerMetadata
+  table: DataPathTableInfo
+  segment: string
+}
+
+const membersByOwnerKind = new Map<string, StandardMemberDeclaration[]>()
+
+export function registerStandardMembers(ownerKind: string, members: readonly StandardMemberDeclaration[]): void {
+  const existing = membersByOwnerKind.get(ownerKind) ?? []
+  membersByOwnerKind.set(ownerKind, [...existing, ...members])
+}
+
+export function getStandardMembers(ownerKind: string): readonly StandardMemberDeclaration[] {
+  return membersByOwnerKind.get(ownerKind) ?? []
+}
+
+export function clearStandardMembersForTests(): void {
+  membersByOwnerKind.clear()
+}
+
+export function snapshotStandardMembersForTests(): Map<string, StandardMemberDeclaration[]> {
+  return new Map([...membersByOwnerKind].map(([kind, members]) => [kind, [...members]]))
+}
+
+export function restoreStandardMembersForTests(snapshot: Map<string, StandardMemberDeclaration[]>): void {
+  membersByOwnerKind.clear()
+  for (const [kind, members] of snapshot) membersByOwnerKind.set(kind, [...members])
+}
+
+export function resolveIndexTimeStandardMember(
+  params: ResolveIndexTimeStandardMemberParams
+): ResolvedStandardMember | undefined {
+  for (const member of getStandardMembers(params.owner.ref.kind)) {
+    if (member.phase !== "index-time") continue
+    if (member.memberKind !== "standardAttribute") continue
+    if (!matchesStandardMember(member, params.internalName, params.yamlName)) continue
+    if (params.explicitTypeInfo !== undefined) {
+      return { name: member.names.yaml, targetName: member.names.internal, typeInfo: params.explicitTypeInfo }
+    }
+
+    const typeInfo = indexTimeTypeInfo(member, params.owner)
+    if (typeInfo !== undefined) {
+      return { name: member.names.yaml, targetName: member.names.internal, typeInfo }
+    }
+  }
+  return undefined
+}
+
+export function resolveTraversalTimeStandardMember(
+  params: ResolveTraversalTimeStandardMemberParams
+): ResolvedTraversalStandardMember | StandardMemberError | undefined {
+  for (const member of getStandardMembers(params.owner.ref.kind)) {
+    if (member.phase !== "traversal-time") continue
+    if (!matchesSegment(member, params.segment)) continue
+
+    if (member.memberKind === "standardTabularSection" && member.family === "standardTable") {
+      const table = { kind: member.tableKind } satisfies DataPathTableInfo
+      return {
+        name: member.names.yaml,
+        typeInfo: {
+          kinds: ["tableSource"],
+          nextTypes: [],
+          table,
+          sourceText: `${params.owner.ref.kind}.${member.names.internal}`,
+        },
+        tableSource: {
+          table,
+          columns: columnsFromStandardTable({ owner: params.owner, table: member }),
+          hasColumns: true,
+        },
+      }
+    }
+
+    if (member.memberKind !== "standardAttribute") continue
+    if (member.family === "reverseLookup") return resolveReverseLookupMember({ ...params, member })
+    if (member.family === "closedReverseLookup") return resolveClosedReverseLookupMember({ ...params, member })
+
+    const typeInfo = indexTimeTypeInfo(member, params.owner)
+    if (typeInfo !== undefined) return { name: member.names.yaml, typeInfo }
+  }
+  return undefined
+}
+
+export function resolveStandardTableColumn(
+  params: ResolveStandardTableColumnParams
+): FormDataPathColumnSource | undefined {
+  for (const member of getStandardMembers(params.owner.ref.kind)) {
+    if (member.memberKind !== "standardTabularSection" || member.family !== "standardTable") continue
+    if (!sameTable(member, params.table)) continue
+    const columns = columnsFromStandardTable({ owner: params.owner, table: member })
+    return columns.get(params.segment)
+  }
+  return undefined
+}
+
+export function standardMemberInternalToYaml(internalName: string): string | undefined {
+  for (const members of membersByOwnerKind.values()) {
+    const member = members.find((item) => item.names.internal === internalName)
+    if (member !== undefined) return member.names.yaml
+  }
+  return undefined
+}
+
+export function standardMemberInternalToYamlForOwnerKind(
+  ownerKind: string,
+  internalName: string
+): string | undefined {
+  const member = getStandardMembers(ownerKind).find((item) => item.names.internal === internalName)
+  return member?.names.yaml
+}
+
+export function standardMemberYamlToInternal(yamlName: string): string | undefined {
+  for (const members of membersByOwnerKind.values()) {
+    const member = members.find((item) => item.names.yaml === yamlName)
+    if (member !== undefined) return member.names.internal
+  }
+  return undefined
+}
+
+export function standardMemberYamlToInternalForOwnerKind(ownerKind: string, yamlName: string): string | undefined {
+  const member = getStandardMembers(ownerKind).find((item) => item.names.yaml === yamlName)
+  return member?.names.internal
+}
+
+function indexTimeTypeInfo(
+  member: Exclude<StandardMemberDeclaration, StandardTableDeclaration>,
+  owner: Pick<OwnerMetadata, "ref" | "model" | "rule">
+): DataPathTypeInfo | undefined {
+  switch (member.family) {
+    case "primitive":
+      return primitiveTypeInfo(member.kind, `${owner.ref.kind}.${member.names.internal}`)
+    case "sameOwnerObject":
+      return {
+        kinds: ["object"],
+        nextTypes: [sameOwnerRef(owner.ref)],
+        sourceText: `${owner.ref.kind}.${member.names.internal}`,
+      }
+    case "objectRefsFromProperty":
+      return objectRefsFromProperty(owner, member.property)
+    case "objectRefFromProperty":
+      return objectRefFromProperty(owner, member.property)
+    case "codeByProperty":
+    case "numberByProperty":
+      return scalarFromMetadataProperty(owner, member.property, `${owner.ref.kind}.${member.names.internal}`)
+    case "standardEnum":
+      return { kinds: ["scalar"], nextTypes: [], sourceText: member.name }
+    case "typeDescription":
+      return { kinds: ["typeDescription"], nextTypes: [], sourceText: `${owner.ref.kind}.${member.names.internal}` }
+    case "opaque":
+      return { kinds: ["unsupportedIntermediate"], nextTypes: [], sourceText: `${owner.ref.kind}.${member.names.internal}` }
+    case "unsupported":
+      return { kinds: ["unsupportedIntermediate"], nextTypes: [], sourceText: member.reason }
+    case "reverseLookup":
+    case "closedReverseLookup":
+      return undefined
+  }
+}
+
+function resolveReverseLookupMember(params: {
+  owner: OwnerMetadata
+  ownerCache: OwnerMetadataCache
+  member: ReverseLookupStandardMemberDeclaration
+}): ResolvedTraversalStandardMember | StandardMemberError {
+  const candidates = reverseLookupCandidates({
+    owner: params.owner,
+    ownerCache: params.ownerCache,
+    target: params.member.target,
+    property: params.member.property,
+  })
+
+  if (candidates.length === 0) return missingLinkedObjects(params.member)
+  return {
+    name: params.member.names.yaml,
+    typeInfo: {
+      kinds: ["object"],
+      nextTypes: candidates,
+      ...(candidates.length > 1 ? { isComposite: true } : {}),
+      sourceText: candidates.map(formatOwnerRef).join(" | "),
+    },
+  }
+}
+
+function resolveClosedReverseLookupMember(params: {
+  owner: OwnerMetadata
+  ownerCache: OwnerMetadataCache
+  member: ClosedReverseLookupStandardMemberDeclaration
+}): ResolvedTraversalStandardMember | StandardMemberError {
+  if (params.member.property !== undefined) {
+    const candidates = reverseLookupCandidates({
+      owner: params.owner,
+      ownerCache: params.ownerCache,
+      target: params.member.target ?? params.member.result,
+      property: params.member.property,
+    })
+    if (candidates.length === 0) return missingLinkedObjects(params.member)
+  }
+
+  return {
+    name: params.member.names.yaml,
+    typeInfo: {
+      kinds: ["unsupportedIntermediate"],
+      nextTypes: [],
+      sourceText: params.member.result,
+    },
+  }
+}
+
+function missingLinkedObjects(
+  member: ReverseLookupStandardMemberDeclaration | ClosedReverseLookupStandardMemberDeclaration
+): StandardMemberError {
+  return {
+    kind: "error",
+    message: `для стандартного реквизита "${member.names.internal}" не найдены связанные объекты`,
+  }
+}
+
+function reverseLookupCandidates(params: {
+  owner: OwnerMetadata
+  ownerCache: OwnerMetadataCache
+  target: string
+  property: string
+}): OwnerTypeRef[] {
+  const currentLink = metadataLinkForOwnerRef(params.owner.ref)
+  if (currentLink === undefined) return []
+
+  const targetKind = ownerKindFromDeclarationTarget(params.target)
+  if (targetKind === undefined) return []
+
+  const result: OwnerTypeRef[] = []
+  for (const ref of params.ownerCache.listRefs(targetKind)) {
+    const ownerResult = params.ownerCache.get(ref)
+    if (ownerResult.status !== "ok") continue
+
+    const links = metadataRecord(ownerResult.owner.model)[params.property]
+    if (!Array.isArray(links)) continue
+    if (links.some((link) => link === currentLink)) result.push(ref)
+  }
+  return result
+}
+
+function columnsFromStandardTable(params: {
+  owner: OwnerMetadata
+  table: StandardTableDeclaration
+}): Map<string, FormDataPathColumnSource> {
+  const columns = new Map<string, FormDataPathColumnSource>()
+  for (const column of params.table.columns) {
+    if (column.discoveredFrom !== undefined) {
+      for (const name of discoveredColumnNames(params.owner.model, column.discoveredFrom)) {
+        columns.set(name, {
+          name,
+          typeInfo: primitiveTypeInfo(column.kind, `${params.owner.ref.kind}.${params.table.names.internal}.${name}`),
+        })
+      }
+      continue
+    }
+
+    const typeInfo = standardTableColumnTypeInfo({ owner: params.owner, table: params.table, column })
+    columns.set(column.names.internal, { name: column.names.internal, typeInfo })
+    if (column.names.yaml !== column.names.internal) columns.set(column.names.yaml, { name: column.names.yaml, typeInfo })
+  }
+  return columns
+}
+
+function standardTableColumnTypeInfo(params: {
+  owner: OwnerMetadata
+  table: StandardTableDeclaration
+  column: StandardTableColumnDeclaration
+}): DataPathTypeInfo {
+  switch (params.column.family) {
+    case "primitive":
+      return primitiveTypeInfo(
+        params.column.kind,
+        `${params.owner.ref.kind}.${params.table.names.internal}.${params.column.names.internal}`
+      )
+    case "sameOwnerObject":
+      return {
+        kinds: ["object"],
+        nextTypes: [sameOwnerRef(params.owner.ref)],
+        sourceText: `${params.owner.ref.kind}.${params.table.names.internal}.${params.column.names.internal}`,
+      }
+    case "objectRefFromOwnerProperty":
+      return (
+        objectRefFromProperty(params.owner, params.column.property) ?? {
+          kinds: ["unknown"],
+          nextTypes: [],
+          sourceText: `${params.owner.ref.kind}.${params.column.property}`,
+        }
+      )
+  }
+}
+
+function discoveredColumnNames(model: MetadataItem, property: string): string[] {
+  const values = metadataRecord(model)[property]
+  if (!Array.isArray(values)) return []
+  return values
+    .map((value) => metadataRecord(value).name)
+    .filter((name): name is string => typeof name === "string" && name.length > 0)
+}
+
+function sameTable(member: StandardTableDeclaration, table: DataPathTableInfo): boolean {
+  return table.kind === member.tableKind
+}
+
+function matchesStandardMember(
+  member: { names: StandardMemberNames },
+  internalName: string,
+  yamlName: string
+): boolean {
+  return member.names.internal === internalName || member.names.yaml === yamlName
+}
+
+function matchesSegment(member: { names: StandardMemberNames }, segment: string): boolean {
+  return member.names.internal === segment || member.names.yaml === segment
+}
+
+function primitiveTypeInfo(kind: PrimitiveKind, sourceText: string): DataPathTypeInfo {
+  const dataPathKind = kind === "string" || kind === "number" ? "scalar" : kind
+  return { kinds: [dataPathKind], nextTypes: [], sourceText }
+}
+
+function objectRefsFromProperty(owner: Pick<OwnerMetadata, "model">, property: string): DataPathTypeInfo | undefined {
+  const links = metadataRecord(owner.model)[property]
+  if (!Array.isArray(links)) return undefined
+  const nextTypes = links
+    .flatMap((link) => (typeof link === "string" ? [ownerTypeRefFromMetadataLink(link)] : []))
+    .filter((item): item is OwnerTypeRef => item !== undefined)
+  if (nextTypes.length === 0) return undefined
+  return {
+    kinds: ["object"],
+    nextTypes: uniqueOwnerRefs(nextTypes),
+    ...(nextTypes.length > 1 ? { isComposite: true } : {}),
+    sourceText: links.filter((link): link is string => typeof link === "string").join(" | "),
+  }
+}
+
+function objectRefFromProperty(owner: Pick<OwnerMetadata, "model">, property: string): DataPathTypeInfo | undefined {
+  const value = metadataRecord(owner.model)[property]
+  if (typeof value !== "string") return undefined
+  const ref = ownerTypeRefFromMetadataLink(value)
+  if (ref === undefined) return undefined
+  return { kinds: ["object"], nextTypes: [ref], sourceText: value }
+}
+
+function scalarFromMetadataProperty(
+  owner: Pick<OwnerMetadata, "model">,
+  property: string,
+  sourceText: string
+): DataPathTypeInfo | undefined {
+  return metadataRecord(owner.model)[property] === undefined
+    ? undefined
+    : { kinds: ["scalar"], nextTypes: [], sourceText }
+}
+
+function ownerTypeRefFromMetadataLink(link: string): OwnerTypeRef | undefined {
+  const [prefix, name] = splitMetadataLink(link)
+  const kind = getOwnerKindByMetadataLinkPrefix(prefix)
+  if (kind === undefined) return undefined
+  return { kind, ...(name !== undefined && name !== "" ? { name } : {}) }
+}
+
+function metadataLinkForOwnerRef(ref: OwnerTypeRef): string | undefined {
+  const prefix = getMetadataLinkPrefixesByOwnerKind(ref.kind)[0]
+  if (prefix === undefined || ref.name === undefined) return undefined
+  return `${prefix}.${ref.name}`
+}
+
+function ownerKindFromDeclarationTarget(target: string): string | undefined {
+  return getOwnerKindByMetadataLinkPrefix(target) ?? target
+}
+
+function splitMetadataLink(link: string): [prefix: string, name?: string] {
+  const dotIndex = link.indexOf(".")
+  if (dotIndex === -1) return [link]
+  return [link.substring(0, dotIndex), link.substring(dotIndex + 1)]
+}
+
+function sameOwnerRef(ref: OwnerTypeRef): OwnerTypeRef {
+  return { kind: ref.kind, ...(ref.name !== undefined ? { name: ref.name } : {}) }
+}
+
+function uniqueOwnerRefs(items: readonly OwnerTypeRef[]): OwnerTypeRef[] {
+  const result: OwnerTypeRef[] = []
+  for (const item of items) {
+    if (!result.some((existing) => existing.kind === item.kind && existing.name === item.name)) result.push(item)
+  }
+  return result
+}
+
+function metadataRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {}
+}
+
+function formatOwnerRef(ref: OwnerTypeRef): string {
+  return ref.name === undefined ? ref.kind : `${ref.kind}.${ref.name}`
+}
+
+export type { MetadataItemRule }

--- a/packages/core/metadata/validation/projectValidationObjectTable.ts
+++ b/packages/core/metadata/validation/projectValidationObjectTable.ts
@@ -10,6 +10,7 @@ export interface ValidationObjectTable {
   mergeRecords(records: readonly ValidationObjectRecord[]): void
   mergeReferenceIndexEntries(entries: ValidationReferenceIndexEntries): void
   getOwner(ref: OwnerTypeRef): ValidationObjectRecord | undefined
+  listOwners(kind: OwnerTypeRef["kind"]): readonly OwnerTypeRef[]
   hasFile(filePath: string): boolean
   snapshot(): ValidationObjectTableSnapshot
 }
@@ -51,6 +52,11 @@ export function createValidationObjectTable(
     },
     getOwner(ref) {
       return recordsByOwner.get(ownerKey(ref))
+    },
+    listOwners(kind) {
+      return [...recordsByOwner.values()]
+        .map((record) => record.ownerRef)
+        .filter((ref): ref is OwnerTypeRef => ref !== undefined && ref.kind === kind)
     },
     hasFile(filePath) {
       return filePaths.has(resolve(filePath))

--- a/packages/core/metadata/validation/sharedValidationBinaryOwners.test.ts
+++ b/packages/core/metadata/validation/sharedValidationBinaryOwners.test.ts
@@ -39,6 +39,25 @@ describe("SharedValidationBinaryOwners", () => {
     expect(binary.get({ kind: "Справочник", name: "НетТакого" })).toMatchObject({ status: "not-found" })
   })
 
+  it("lists owner refs by data path kind", () => {
+    const secondRecord = {
+      ...catalogRecord(),
+      filePath: "/project/Справочник/Контрагенты/Свойства.yaml",
+      projectPath: "Справочник/Контрагенты/Свойства.yaml",
+      owner: { dir: "Справочник", name: "Контрагенты" },
+      ownerRef: { kind: "Справочник", name: "Контрагенты" },
+    } satisfies ValidationObjectRecord
+    const table = createValidationObjectTable({
+      records: [catalogRecord(), secondRecord],
+      filePaths: ["/project/Справочник/Номенклатура/Свойства.yaml", secondRecord.filePath],
+    })
+    const snapshot = createBinarySharedOwnersSnapshot(table.snapshot())
+    const regular = createOwnerMetadataCacheFromValidationTable({ projectDir: "/project", table })
+    const binary = createOwnerMetadataCacheFromBinarySharedOwners({ projectDir: "/project", snapshot })
+
+    expect(sortRefs(binary.listRefs("Справочник"))).toEqual(sortRefs(regular.listRefs("Справочник")))
+  })
+
   it("restores owner model data used by data path resolvers", () => {
     const table = createValidationObjectTable({
       records: [
@@ -96,6 +115,12 @@ describe("SharedValidationBinaryOwners", () => {
     expect([...owner.owner.fieldIndex.fields.keys()]).toEqual(["Артикул", "Товары"])
   })
 })
+
+function sortRefs(refs: readonly { kind: string; name?: string }[]): Array<{ kind: string; name?: string }> {
+  return [...refs].sort((left, right) =>
+    `${left.kind}.${left.name ?? ""}`.localeCompare(`${right.kind}.${right.name ?? ""}`)
+  )
+}
 
 function catalogRecord(): ValidationObjectRecord {
   return {

--- a/packages/core/metadata/validation/sharedValidationBinaryOwners.ts
+++ b/packages/core/metadata/validation/sharedValidationBinaryOwners.ts
@@ -207,6 +207,14 @@ export function createOwnerMetadataCacheFromBinarySharedOwners(params: {
       results.set(key, result)
       return result
     },
+    listRefs(kind) {
+      const ownerKind = getDataPathOwnerKind(kind)
+      const tableKind = ownerKind?.projectDir ?? kind
+      return view.listOwners(tableKind).map((ref) => ({
+        kind,
+        ...(ref.name !== undefined ? { name: ref.name } : {}),
+      }))
+    },
   }
 }
 
@@ -240,6 +248,17 @@ function createBinaryOwnersView(snapshot: BinarySharedOwnersSnapshot) {
         else right = middle - 1
       }
       return undefined
+    },
+    listOwners(kind: OwnerTypeRef["kind"]): readonly OwnerTypeRef[] {
+      const result: OwnerTypeRef[] = []
+      for (let ownerId = 0; ownerId < ownerCount; ownerId += 1) {
+        const base = ownersOffset + ownerId * OWNER_INTS
+        const currentKind = strings.get(ints[base] ?? 0)
+        if (currentKind !== kind) continue
+        const name = strings.get(ints[base + 1] ?? 0)
+        result.push({ kind, ...(name.length > 0 ? { name } : {}) })
+      }
+      return result
     },
     owner(ownerId: number) {
       const base = ownersOffset + ownerId * OWNER_INTS


### PR DESCRIPTION
## Что изменилось
- Добавлен декларативный реестр стандартных реквизитов рядом с прикладными объектами.
- Подключено разрешение стандартных реквизитов в DataPath resolver и compiled validation path.
- Добавлено YAML-преобразование стандартных реквизитов для путей к данным и связей параметров выбора.
- Зафиксирована рабочая спека по стандартным реквизитам и табличным частям.

## Проверки
- env CI=true pnpm --filter '@nakidka/core' test
- env CI=true pnpm test
- validation-profile по /Users/nikita/git/nkdk-yaml