### PR TITLE
fix: восстановить проверки объединённых преобразований

### DIFF
--- a/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/dcsMetadataValue/fromYAML.ts
@@ -98,6 +98,33 @@ const isExplicitPrimitiveStringValueYAML = (
 const isDateTimeYAML = (data: unknown): data is string =>
   typeof data === "string" && /^\d{2}\.\d{2}\.\d{4}(\s+\d{2}:\d{2}:\d{2})?$/.test(data)
 
+const importPrimitiveMatchingSourceType = (
+  context: ConfigurationContext,
+  data: unknown,
+  sourceValue: MetadataDcsMetadataValue | undefined
+): MetadataDcsMetadataValue | undefined => {
+  if (
+    sourceValue === null ||
+    typeof sourceValue !== "object" ||
+    Array.isArray(sourceValue) ||
+    typeof (sourceValue as { type?: unknown }).type !== "string"
+  ) {
+    return undefined
+  }
+  const imported = importMetadataValueFromYAML(context, undefined, data as never) as
+    | MetadataDcsMetadataValue
+    | undefined
+  if (
+    imported === null ||
+    typeof imported !== "object" ||
+    Array.isArray(imported) ||
+    (imported as { type?: unknown }).type !== (sourceValue as { type: string }).type
+  ) {
+    return undefined
+  }
+  return imported
+}
+
 const importDcsSystemEnumerationValueFromYAML = (
   context: ConfigurationContext,
   data: MetadataDcsSystemEnumerationValueYAML
@@ -140,6 +167,8 @@ export const importDcsMetadataValueFromYAML = (
     case "Color":
       return importColorFromYAML(context, undefined, data as any)!
     case "Field": {
+      const sourceTypedPrimitive = importPrimitiveMatchingSourceType(context, data, sourceValue)
+      if (sourceTypedPrimitive !== undefined) return sourceTypedPrimitive
       const metadataValuePath =
         typeof data === "string" && !data.startsWith(".")
           ? importMetadataValueStringFromYAML(context, undefined, data)

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/types.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/filterItem/types.ts
@@ -4,6 +4,7 @@ import { YAMLTypeByRule } from "../../../orchestration/metadataItem/yaml"
 import { importFilterItemFromXMLToYAML } from "./fromXMLToYAML"
 import { FilterItemComparisonRules, FilterItemGroupRules } from "./rules"
 import { exportFilterItemToJSONSchema } from "./toJSONSchema"
+import { DataCompositionComparisonTypeFromYAML } from "../../../systemEnumerations/types"
 import "./typedValues"
 
 export type FilterItemComparison = FormTypeByRule<typeof FilterItemComparisonRules>
@@ -26,7 +27,11 @@ const referenceIdentity = {
     const left = typeof yaml.ЛевоеЗначение === "string" ? yaml.ЛевоеЗначение.replace(/^\./, "") : undefined
     if (left === undefined) return undefined
     const comparison =
-      yaml.ВидСравнения === undefined ? "Equal" : yaml.ВидСравнения === "Равно" ? "Equal" : String(yaml.ВидСравнения)
+      yaml.ВидСравнения === undefined
+        ? "Equal"
+        : (DataCompositionComparisonTypeFromYAML[
+            yaml.ВидСравнения as keyof typeof DataCompositionComparisonTypeFromYAML
+          ] ?? String(yaml.ВидСравнения))
     return `comparison:${left}:${comparison}`
   },
   fromXML: ({ xml }: { xml: Record<string, unknown> }): string | undefined => {

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/settingsParameterValueCollection/fromYAML.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/settingsParameterValueCollection/fromYAML.ts
@@ -43,7 +43,7 @@ const importSettingsParameterValueCollectionFromYAML = (
 
     const valueFragment = asExplicitYAMLStringIfMarked(value, paramName, yamlFragment)
     const wrapped = wrapYamlFragment(paramName, valueFragment)
-    const imported = importParameterValueFromYAML(context, itemRule, wrapped)
+    const imported = importParameterValueFromYAML(context, itemRule, wrapped, source?.parameters[paramName])
     if (imported !== undefined) {
       parameters[paramName] = { ...imported, parameter: paramName }
     }

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/settingsParameterValueCollection/index.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/settingsParameterValueCollection/index.ts
@@ -1,3 +1,5 @@
+import "../parameterValue/fromXML"
+import "../parameterValue/toXML"
 import "./fromXML"
 import "./fromYAML"
 import "./toXML"

--- a/packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it, vi } from "vitest"
+import { createDirectRoundTripContexts } from "../../../tests/directConversion"
 import { mockContextFromXML } from "../../../tests/mockContext"
-import { readAndParseXMLFixture } from "../../../tests/readFixtureXML"
+import { readAndParseXMLFixture, readXMLFixtureAsString } from "../../../tests/readFixtureXML"
+import { xmlExport } from "../../../xml/export/exporter"
+import { importContentFromXML } from "../../../xml/import/importer"
+import { withConfigurationIndexCollector } from "../../configurationIndex/collector/context"
+import { createConfigurationIndexCollector } from "../../configurationIndex/collector/writer"
 import { fullClientApplicationFormYAML, minimalClientApplicationFormYAML } from "./__fixtures__/data"
 import { importClientApplicationFormFromXMLToYAML } from "./fromXMLToYAML"
+import { convertClientApplicationFormFromYAMLToXML } from "./fromYAMLToXML"
 import * as propertyImporter from "../../orchestration/property/fromXMLToYAML"
 import { ClientApplicationFormRules } from "./rules"
-import type { ClientApplicationFormXML, FormMetadataXML } from "./types"
+import type { ClientApplicationFormXML, ClientApplicationFormYAML, FormMetadataXML } from "./types"
 
 describe("importClientApplicationFormFromXMLToYAML", () => {
   it("обходит правила формы один раз для двух XML-источников", () => {
@@ -59,4 +65,179 @@ describe("importClientApplicationFormFromXMLToYAML", () => {
     expect(result).not.toHaveProperty("model")
     expect(result).not.toHaveProperty("xml")
   })
+
+  it("собирает идентичности формы, вложенных элементов и singleton по каноническим адресам", () => {
+    const collector = createConfigurationIndexCollector()
+    const logicalAddress = "Справочник.Контрагенты.Форма.ФормаЭлемента"
+    const context = withConfigurationIndexCollector(mockContextFromXML(), collector, logicalAddress)
+    const form = readAndParseXMLFixture<{ Form: ClientApplicationFormXML }>(import.meta.url, "full.xml")
+    const metadata = readAndParseXMLFixture<{ MetaDataObject: FormMetadataXML }>(import.meta.url, "fullMetadata.xml")
+    const inputField = (form.Form.ChildItems as Array<{ InputField: { ContextMenu: { _name: string } } }>)[0].InputField
+    inputField.ContextMenu._name = "НестандартноеКонтекстноеМеню"
+
+    importClientApplicationFormFromXMLToYAML({
+      context,
+      formName: "ФормаЭлемента",
+      formXML: form.Form,
+      metadataXML: metadata.MetaDataObject,
+    })
+
+    const identities = collector.fragment("Форма.yaml").identities
+    expect(identities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ logicalAddress, kind: "uuid" }),
+        expect.objectContaining({ logicalAddress: `${logicalAddress}.Элемент.ПолеВвода1`, kind: "xmlId" }),
+        expect.objectContaining({ logicalAddress: `${logicalAddress}.Атрибут.Объект`, kind: "xmlId" }),
+        expect.objectContaining({ logicalAddress: `${logicalAddress}.Команда.Команда1`, kind: "xmlId" }),
+        {
+          logicalAddress: `${logicalAddress}.Элемент.ПолеВвода1.КонтекстноеМеню`,
+          kind: "xmlId",
+          value: "3",
+        },
+        {
+          logicalAddress: `${logicalAddress}.Элемент.ПолеВвода1.КонтекстноеМеню`,
+          kind: "xmlName",
+          value: "НестандартноеКонтекстноеМеню",
+        },
+      ])
+    )
+    expect(identities).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ logicalAddress: `${logicalAddress}.Элемент.НестандартноеКонтекстноеМеню` }),
+      ])
+    )
+  })
+
+  it("собирает идентичности вложенной таблицы диаграммы Ганта", () => {
+    const collector = createConfigurationIndexCollector()
+    const logicalAddress = "Обработка.Планирование.Форма.Основная"
+    const context = withConfigurationIndexCollector(mockContextFromXML(), collector, logicalAddress)
+
+    importClientApplicationFormFromXMLToYAML({
+      context,
+      formName: "Основная",
+      formXML: {
+        ChildItems: [
+          {
+            GanttChartField: {
+              _name: "ДиаграммаГанта",
+              _id: "1",
+              Table: {
+                _name: "Table",
+                _id: "98",
+                ContextMenu: { _name: "TableКонтекстноеМеню", _id: "100" },
+              },
+              ContextMenu: { _name: "ДиаграммаГантаКонтекстноеМеню", _id: "2" },
+            },
+          },
+        ],
+      } as ClientApplicationFormXML,
+      metadataXML: { Form: { Properties: { FormType: "Managed" } } },
+    })
+
+    expect(collector.fragment("Форма.yaml").identities).toEqual(
+      expect.arrayContaining([
+        {
+          logicalAddress: `${logicalAddress}.Элемент.ДиаграммаГанта.КонтекстноеМеню`,
+          kind: "xmlId",
+          value: "2",
+        },
+        {
+          logicalAddress: `${logicalAddress}.Элемент.ДиаграммаГанта.Таблица`,
+          kind: "xmlId",
+          value: "98",
+        },
+        {
+          logicalAddress: `${logicalAddress}.Элемент.ДиаграммаГанта.Таблица.КонтекстноеМеню`,
+          kind: "xmlId",
+          value: "100",
+        },
+      ])
+    )
+  })
+
+  it("собирает порядок Form.xml отдельно от metadata XML", () => {
+    const collector = createConfigurationIndexCollector()
+    const logicalAddress = "Справочник.Контрагенты.Форма.ФормаЭлемента"
+    const context = withConfigurationIndexCollector(mockContextFromXML(), collector, logicalAddress)
+
+    importClientApplicationFormFromXMLToYAML({
+      context,
+      formName: "ФормаЭлемента",
+      formXML: { Title: "Форма", Width: "80" },
+      metadataXML: {
+        Form: {
+          _uuid: "00000000-0000-4000-8000-000000000001",
+          Properties: { Name: "ФормаЭлемента", Comment: "Комментарий", FormType: "Managed" },
+        },
+      },
+    })
+
+    expect(collector.fragment("Форма.yaml").xmlNodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ logicalAddress, order: ["name", "comment", "formType"] }),
+        expect.objectContaining({
+          logicalAddress: `${logicalAddress}.ЧастьФормы.Содержимое`,
+          order: ["title", "width"],
+        }),
+      ])
+    )
+  })
 })
+
+describe("форма XML → YAML → XML", () => {
+  const cases = [
+    ["полная", "full.xml", "fullMetadata.xml"],
+    ["минимальная", "minimal.xml", "minimalMetadata.xml"],
+    ["каталога", "catalogFull.xml", "minimalMetadata.xml"],
+    ["документа", "documentFull.xml", "minimalMetadata.xml"],
+    ["без реквизитов условного оформления", "conditionalAppearanceWithoutAttributes.xml", "minimalMetadata.xml"],
+    ["с шириной дочерних элементов", "childItemsWidth.xml", "minimalMetadata.xml"],
+    ["с папкой пользовательских настроек", "customSettingsFolder.xml", "customSettingsFolderMetadata.xml"],
+    ["отчёта", "reportForm.xml", "reportFormMetadata.xml"],
+    ["с динамическим списком", "withDynamicList.xml", "minimalMetadata.xml"],
+  ] as const
+
+  it.each(cases)("сохраняет форму %s", (_title, formFixture, metadataFixture) => {
+    const form = readAndParseXMLFixture<{ Form: ClientApplicationFormXML }>(import.meta.url, formFixture)
+    const metadata = readAndParseXMLFixture<{ MetaDataObject: FormMetadataXML }>(import.meta.url, metadataFixture)
+    const logicalAddress = "Справочник.Товары.Форма.ФормаЭлемента"
+    const contexts = createDirectRoundTripContexts({ logicalAddress })
+    const formName = String(metadata.MetaDataObject.Form.Properties.Name)
+
+    const imported = importClientApplicationFormFromXMLToYAML({
+      context: contexts.importContext,
+      formName,
+      formXML: form.Form,
+      metadataXML: metadata.MetaDataObject,
+    })
+    const converted = convertClientApplicationFormFromYAMLToXML({
+      context: contexts.exportContext(),
+      yaml: imported.yaml as ClientApplicationFormYAML,
+      name: formName,
+      referenceFormXML: form.Form,
+      referenceMetadataXML: metadata.MetaDataObject,
+    })
+
+    expect(canonicalXML(xmlExport({ Form: converted.formXML }))).toEqual(
+      canonicalXML(readXMLFixtureAsString(import.meta.url, formFixture))
+    )
+    expect(canonicalXML(xmlExport({ MetaDataObject: converted.metadataXML }))).toEqual(
+      canonicalXML(readXMLFixtureAsString(import.meta.url, metadataFixture))
+    )
+  })
+})
+
+function canonicalXML(xml: string): unknown {
+  return withoutFormattingText(importContentFromXML(xml))
+}
+
+function withoutFormattingText(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutFormattingText)
+  if (value === null || typeof value !== "object") return value
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key, child]) => key !== "#text" || typeof child !== "string" || child.trim().length > 0)
+      .map(([key, child]) => [key, withoutFormattingText(child)])
+  )
+}

--- a/packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts
@@ -80,4 +80,114 @@ describe("convertClientApplicationFormFromYAMLToXML", () => {
 
     expect(result.formXML.Attributes).toEqual({})
   })
+
+  it("не добавляет служебные узлы таблицы без reference XML", () => {
+    const dynamicList = convertClientApplicationFormFromYAMLToXML({
+      context: mockContextToXML(),
+      yaml: {
+        Реквизиты: { Список: { Тип: "ДинамическийСписок" } },
+        Элементы: { Список: { Вид: "ТаблицаФормы", ПутьКДанным: "Список" } },
+      } as ClientApplicationFormYAML,
+      name: "ФормаСписка",
+    })
+    const ordinary = convertClientApplicationFormFromYAMLToXML({
+      context: mockContextToXML(),
+      yaml: {
+        Реквизиты: { Объект: { Тип: "СправочникОбъект.БонусныеПрограммыЛояльности" } },
+        Элементы: { ЦеновыеГруппы: { Вид: "ТаблицаФормы", ПутьКДанным: "Объект.ЦеновыеГруппы" } },
+      } as ClientApplicationFormYAML,
+      name: "ФормаЭлемента",
+    })
+
+    expect(firstTable(dynamicList.formXML)).not.toHaveProperty("Period")
+    expect(firstTable(dynamicList.formXML)).not.toHaveProperty("TopLevelParent")
+    expect(firstTable(ordinary.formXML)).not.toHaveProperty("RowFilter")
+  })
+
+  it("сохраняет служебные узлы таблицы из reference XML", () => {
+    const period = {
+      "v8:variant": { "#text": "Custom", "_xsi:type": "v8:StandardPeriodVariant" },
+      "v8:startDate": "0001-01-01T00:00:00",
+      "v8:endDate": "0001-01-01T00:00:00",
+    }
+    const result = convertClientApplicationFormFromYAMLToXML({
+      context: mockContextToXML(),
+      yaml: {
+        Реквизиты: { Список: { Тип: "ДинамическийСписок" } },
+        Элементы: { Список: { Вид: "ТаблицаФормы", ПутьКДанным: "Список" } },
+      } as ClientApplicationFormYAML,
+      name: "ФормаСписка",
+      referenceFormXML: {
+        ChildItems: [
+          {
+            Table: {
+              _name: "Список",
+              _id: "1",
+              Period: period,
+              TopLevelParent: { "_xsi:nil": "true" },
+              RowFilter: { "_xsi:nil": "true" },
+            },
+          },
+        ],
+      },
+    })
+
+    expect(firstTable(result.formXML)).toMatchObject({
+      Period: period,
+      TopLevelParent: { "_xsi:nil": "true" },
+      RowFilter: { "_xsi:nil": "true" },
+    })
+  })
+
+  it("сохраняет идентификаторы команд из reference XML по имени", () => {
+    const result = convertClientApplicationFormFromYAMLToXML({
+      context: mockContextToXML(),
+      yaml: {
+        Команды: {
+          Команда1: { Заголовок: "Команда один" },
+          Команда2: { Заголовок: "Команда два" },
+        },
+      } as ClientApplicationFormYAML,
+      name: "Форма",
+      referenceFormXML: {
+        Commands: {
+          Command: [
+            { _name: "Команда1", _id: "7" },
+            { _name: "Команда2", _id: "9" },
+          ],
+        },
+      },
+    })
+
+    expect(result.formXML.Commands?.Command).toEqual([
+      expect.objectContaining({ _name: "Команда1", _id: "7" }),
+      expect.objectContaining({ _name: "Команда2", _id: "9" }),
+    ])
+  })
+
+  it("сохраняет пустое расширенное представление из reference metadata XML", () => {
+    const result = convertClientApplicationFormFromYAMLToXML({
+      context: mockContextToXML(),
+      yaml: {} as ClientApplicationFormYAML,
+      name: "Минимальная",
+      referenceMetadataXML: {
+        Form: {
+          _uuid: "11111111-1111-4111-8111-111111111111",
+          Properties: {
+            Name: "Минимальная",
+            FormType: "Managed",
+            ExtendedPresentation: "",
+          },
+        },
+      },
+    })
+
+    expect(result.metadataXML.Form.Properties.ExtendedPresentation).toBe("")
+  })
 })
+
+function firstTable(form: ClientApplicationFormXML): Record<string, unknown> {
+  const childItems = Array.isArray(form.ChildItems) ? form.ChildItems : form.ChildItems?.ChildItem
+  const first = Array.isArray(childItems) ? childItems[0] : childItems
+  return first?.Table ?? {}
+}

--- a/packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts
@@ -132,6 +132,82 @@ describe("sync ClientApplicationForm to XML", () => {
     }
   })
 
+  it("отклоняет managed form без Ext/Form.xml", async () => {
+    const tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "nkdk-managed-form-without-body-"))
+    const xmlInputDir = join(tmpRoot, "xml", "Forms")
+    const managedFormName = "УправляемаяБезТела"
+
+    try {
+      fs.mkdirSync(xmlInputDir, { recursive: true })
+      fs.writeFileSync(join(xmlInputDir, `${managedFormName}.xml`), managedFormMetadataXML(managedFormName))
+
+      await expect(
+        convertFormFromXML({
+          context: mockContextFromXML(),
+          inputDir: xmlInputDir,
+          formName: managedFormName,
+          outputDir: join(tmpRoot, "yaml"),
+        })
+      ).rejects.toThrow("Form.xml")
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+
+  it("сохраняет события и не пишет синоним, равный имени формы", async () => {
+    const tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "nkdk-form-events-roundtrip-"))
+    const xmlInputDir = join(tmpRoot, "xml", "Forms")
+    const yamlInputDir = join(tmpRoot, "yaml")
+    const xmlOutputDir = join(tmpRoot, "out")
+    const eventFormName = "ФормаСобытияПередВыполнением"
+    const formExtDir = join(xmlInputDir, eventFormName, "Ext")
+
+    try {
+      fs.mkdirSync(formExtDir, { recursive: true })
+      fs.writeFileSync(
+        join(xmlInputDir, `${eventFormName}.xml`),
+        managedFormMetadataXML(eventFormName, "Форма события перед выполнением")
+      )
+      fs.writeFileSync(
+        join(formExtDir, "Form.xml"),
+        [
+          '<?xml version="1.0" encoding="UTF-8"?>',
+          '<Form xmlns="http://v8.1c.ru/8.3/xcf/logform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">',
+          "  <Events>",
+          '    <Event name="OnOpen">ПриОткрытии</Event>',
+          '    <Event name="BeforeExecute">ПередВыполнением</Event>',
+          "  </Events>",
+          "</Form>",
+        ].join("\n")
+      )
+
+      await convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: xmlInputDir,
+        formName: eventFormName,
+        outputDir: yamlInputDir,
+      })
+
+      const yaml = fs.readFileSync(join(yamlInputDir, "Формы", eventFormName, "Форма.yaml"), "utf-8")
+      expect(yaml).toContain("ПередВыполнением: ПередВыполнением")
+      expect(yaml).not.toContain("Синоним:")
+
+      await syncFormToXML({
+        context: mockContextToXML(),
+        inputDir: yamlInputDir,
+        outputDir: xmlOutputDir,
+        referenceDir: xmlInputDir,
+        formName: eventFormName,
+      })
+
+      expect(fs.readFileSync(join(xmlOutputDir, "Forms", eventFormName, "Ext", "Form.xml"), "utf-8")).toContain(
+        '<Event name="BeforeExecute">ПередВыполнением</Event>'
+      )
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+
   it("передаёт currentXMLPath в экспорт формы и восстанавливает ERP AdditionalColumns", async () => {
     const tmpRoot = fs.mkdtempSync(join(os.tmpdir(), "nkdk-form-current-xml-path-"))
     const tmpInputDir = join(tmpRoot, "yaml")
@@ -237,22 +313,36 @@ describe("sync ClientApplicationForm to XML", () => {
     const xmlManifest = new XmlSyncManifest(outputDir)
 
     try {
-      fs.cpSync(inputDir, tmpInputDir, { recursive: true })
       fs.cpSync(referenceDir, tmpReferenceDir, { recursive: true })
-      fs.mkdirSync(join(tmpInputDir, "Формы", formName, "Картинки"), { recursive: true })
-      fs.mkdirSync(join(tmpInputDir, "Формы", formName, "КартинкиШапки"), { recursive: true })
-      fs.mkdirSync(join(tmpInputDir, "Формы", formName, "КартинкиЗначений"), { recursive: true })
-      fs.mkdirSync(join(tmpInputDir, "Формы", formName, "КартинкиСтрок"), { recursive: true })
-      fs.writeFileSync(join(tmpInputDir, "Формы", formName, "Картинки", "Декорация2.png"), Buffer.from([1, 2, 3]))
-      fs.writeFileSync(
-        join(tmpInputDir, "Формы", formName, "КартинкиШапки", "ГруппаСШапкой.gif"),
-        Buffer.from([7, 8, 9])
-      )
-      fs.writeFileSync(join(tmpInputDir, "Формы", formName, "КартинкиЗначений", "Статус.bmp"), Buffer.from([4, 5, 6]))
-      fs.writeFileSync(
-        join(tmpInputDir, "Формы", formName, "КартинкиСтрок", "ТаблицаСКартинкойСтрок.png"),
-        Buffer.from([11, 12, 13])
-      )
+      const itemsDir = join(tmpReferenceDir, formName, "Ext", "Form", "Items")
+      fs.mkdirSync(join(itemsDir, "Декорация2"), { recursive: true })
+      fs.mkdirSync(join(itemsDir, "ГруппаСШапкой"), { recursive: true })
+      fs.mkdirSync(join(itemsDir, "Статус"), { recursive: true })
+      fs.mkdirSync(join(itemsDir, "ТаблицаСКартинкойСтрок"), { recursive: true })
+      fs.writeFileSync(join(itemsDir, "Декорация2", "Picture.png"), Buffer.from([1, 2, 3]))
+      fs.writeFileSync(join(itemsDir, "ГруппаСШапкой", "HeaderPicture.gif"), Buffer.from([7, 8, 9]))
+      fs.writeFileSync(join(itemsDir, "Статус", "ValuesPicture.bmp"), Buffer.from([4, 5, 6]))
+      fs.writeFileSync(join(itemsDir, "ТаблицаСКартинкойСтрок", "RowsPicture.png"), Buffer.from([11, 12, 13]))
+
+      await convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: tmpReferenceDir,
+        formName,
+        outputDir: tmpInputDir,
+      })
+
+      expect([...fs.readFileSync(join(tmpInputDir, "Формы", formName, "Картинки", "Декорация2.png"))]).toEqual([
+        1, 2, 3,
+      ])
+      expect([...fs.readFileSync(join(tmpInputDir, "Формы", formName, "КартинкиШапки", "ГруппаСШапкой.gif"))]).toEqual([
+        7, 8, 9,
+      ])
+      expect([...fs.readFileSync(join(tmpInputDir, "Формы", formName, "КартинкиЗначений", "Статус.bmp"))]).toEqual([
+        4, 5, 6,
+      ])
+      expect([
+        ...fs.readFileSync(join(tmpInputDir, "Формы", formName, "КартинкиСтрок", "ТаблицаСКартинкойСтрок.png")),
+      ]).toEqual([11, 12, 13])
 
       await syncFormToXML({
         context: mockContextToXML(),
@@ -318,9 +408,17 @@ describe("sync ClientApplicationForm to XML", () => {
     const tmpReferenceDir = join(tmpRoot, "reference-forms")
 
     try {
-      fs.cpSync(inputDir, tmpInputDir, { recursive: true })
       fs.cpSync(referenceDir, tmpReferenceDir, { recursive: true })
-      fs.writeFileSync(join(tmpInputDir, "Формы", formName, "Form.bin"), Buffer.from([10, 20, 30]))
+      fs.writeFileSync(join(tmpReferenceDir, formName, "Ext", "Form.bin"), Buffer.from([10, 20, 30]))
+
+      await convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: tmpReferenceDir,
+        formName,
+        outputDir: tmpInputDir,
+      })
+
+      expect([...fs.readFileSync(join(tmpInputDir, "Формы", formName, "Form.bin"))]).toEqual([10, 20, 30])
 
       await syncFormToXML({
         context: mockContextToXML(),
@@ -344,14 +442,25 @@ describe("sync ClientApplicationForm to XML", () => {
     const xmlManifest = new XmlSyncManifest(outputDir)
 
     try {
-      fs.cpSync(inputDir, tmpInputDir, { recursive: true })
       fs.cpSync(referenceDir, tmpReferenceDir, { recursive: true })
-      fs.mkdirSync(join(tmpInputDir, "Формы", formName, "Справка", "_files", "nested"), { recursive: true })
-      fs.writeFileSync(join(tmpInputDir, "Формы", formName, "Справка", "_files", "001.png"), Buffer.from([1, 2]))
+      fs.mkdirSync(join(tmpReferenceDir, formName, "Ext", "Help", "_files", "nested"), { recursive: true })
+      fs.writeFileSync(join(tmpReferenceDir, formName, "Ext", "Help", "_files", "001.png"), Buffer.from([1, 2]))
       fs.writeFileSync(
-        join(tmpInputDir, "Формы", formName, "Справка", "_files", "nested", "002.png"),
+        join(tmpReferenceDir, formName, "Ext", "Help", "_files", "nested", "002.png"),
         Buffer.from([3, 4])
       )
+
+      await convertFormFromXML({
+        context: mockContextFromXML(),
+        inputDir: tmpReferenceDir,
+        formName,
+        outputDir: tmpInputDir,
+      })
+
+      expect([...fs.readFileSync(join(tmpInputDir, "Формы", formName, "Справка", "_files", "001.png"))]).toEqual([1, 2])
+      expect([
+        ...fs.readFileSync(join(tmpInputDir, "Формы", formName, "Справка", "_files", "nested", "002.png")),
+      ]).toEqual([3, 4])
 
       await syncFormToXML({
         context: mockContextToXML(),
@@ -496,6 +605,23 @@ const ordinaryFormMetadataXML = (formName: string): string => `<?xml version="1.
 			</Synonym>
 			<Comment/>
 			<FormType>Ordinary</FormType>
+			<IncludeHelpInContents>false</IncludeHelpInContents>
+		</Properties>
+	</Form>
+</MetaDataObject>`
+
+const managedFormMetadataXML = (formName: string, synonym?: string): string => `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<Form uuid="aaaaaaaa-1111-4222-8333-bbbbbbbbbbbb">
+		<Properties>
+			<Name>${formName}</Name>
+			${
+        synonym !== undefined
+          ? `<Synonym><v8:item><v8:lang>ru</v8:lang><v8:content>${synonym}</v8:content></v8:item></Synonym>`
+          : "<Synonym/>"
+      }
+			<Comment/>
+			<FormType>Managed</FormType>
 			<IncludeHelpInContents>false</IncludeHelpInContents>
 		</Properties>
 	</Form>

--- a/packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts
@@ -1,0 +1,142 @@
+import fs from "fs"
+import { fileURLToPath } from "url"
+import { describe, expect, it } from "vitest"
+
+import {
+  createDirectRoundTripContexts,
+  testPropertyFromXMLToYAML,
+  testPropertyFromYAMLToXML,
+} from "../../../../tests/directConversion"
+import { importContentFromXML } from "../../../../xml/import/importer"
+import { xmlExport } from "../../../../xml/export/exporter"
+import { mockContext } from "../../../../tests/mockContext"
+import { exportMetadataItemToJSONSchema } from "../../../orchestration/metadataItem/toJSONSchema"
+import type { MetadataItemRule } from "../../../orchestration/property/types"
+import { DynamicListRules } from "./rules"
+
+import "./types"
+
+const rule = {
+  itemType: "DynamicListProbe",
+  properties: {
+    value: { type: "DynamicList", yaml: "Значение", xml: "Settings" },
+  },
+} as const satisfies MetadataItemRule
+
+const fixtures = [
+  "customQuery.xml",
+  "designTimeDataParameters.xml",
+  "emptyListSettings.xml",
+  "full.xml",
+  "keyField.xml",
+  "minimal.xml",
+  "multipleCalculatedFields.xml",
+  "queryTextWithManualQueryFalse.xml",
+] as const
+
+describe("DynamicList XML → YAML → XML", () => {
+  it.each(fixtures)("сохраняет %s", (fixture) => {
+    const expected = fs.readFileSync(fileURLToPath(new URL(`__fixtures__/${fixture}`, import.meta.url)), "utf8")
+    const parsed = importContentFromXML<Record<string, unknown>>(expected, {
+      preserveEmptyElements: true,
+      preserveXsiNil: true,
+    })
+    const contexts = createDirectRoundTripContexts({
+      logicalAddress: "Справочник.Товары.Форма.ФормаСписка.Атрибут.Список",
+    })
+    const yaml = testPropertyFromXMLToYAML({
+      rule,
+      xml: parsed,
+      context: contexts.importContext,
+    }).yaml
+    const { xml } = testPropertyFromYAMLToXML({
+      rule,
+      yaml,
+      referenceXML: parsed,
+      context: contexts.exportContext(),
+    })
+
+    expect(withoutDeclaration(xmlExport(xml, false))).toBe(expected.trim())
+  })
+
+  it("не выводит в YAML значение ManualQuery=false по умолчанию", () => {
+    const expected = fs.readFileSync(
+      fileURLToPath(new URL("__fixtures__/queryTextWithManualQueryFalse.xml", import.meta.url)),
+      "utf8"
+    )
+    const parsed = importContentFromXML<Record<string, unknown>>(expected)
+
+    expect(testPropertyFromXMLToYAML({ rule, xml: parsed }).yaml).not.toHaveProperty("Значение.ПроизвольныйЗапрос")
+  })
+
+  it("выгружает новый список с ключевыми полями в каноническом порядке", () => {
+    const { xml } = testPropertyFromYAMLToXML({
+      rule,
+      yaml: {
+        Значение: {
+          ПроизвольныйЗапрос: "Истина",
+          ВидКлюча: "КлючСтроки",
+          ПоляКлюча: ["КлючПриглашения", "Контрагент", "ИдентификаторОрганизации"],
+          НастройкиСписка: {},
+        },
+      },
+    })
+    const result = xmlExport(xml, false)
+
+    expect(result.indexOf("<KeyType>")).toBeGreaterThan(result.indexOf("<ManualQuery>"))
+    expect(result.indexOf("<KeyField>")).toBeGreaterThan(result.indexOf("<KeyType>"))
+    expect(result.indexOf("<ListSettings")).toBeGreaterThan(result.lastIndexOf("<KeyField>"))
+    expect(result.match(/<KeyField>/g)).toHaveLength(3)
+  })
+
+  it("восстанавливает только явный Asc для выражения упорядочивания", () => {
+    const yaml = {
+      Значение: {
+        ВычисляемыеПоля: [
+          {
+            ПутьКДанным: "УниверсальнаяДата",
+            Выражение: "Дата",
+            ВыраженияУпорядочивания: [{ Выражение: "Дата", Автоупорядочивание: "Ложь" }],
+          },
+        ],
+      },
+    }
+    const referenceXML = {
+      Settings: {
+        "_xsi:type": "DynamicList",
+        CalculatedField: {
+          "dcssch:dataPath": "УниверсальнаяДата",
+          "dcssch:expression": "Дата",
+          "dcssch:orderExpression": {
+            expression: "Дата",
+            orderType: {
+              "#text": "Asc",
+              _xmlns: "http://v8.1c.ru/8.1/data-composition-system/common",
+            },
+            autoOrder: false,
+          },
+        },
+      },
+    }
+
+    const fresh = xmlExport(testPropertyFromYAMLToXML({ rule, yaml }).xml, false)
+    const restored = xmlExport(testPropertyFromYAMLToXML({ rule, yaml, referenceXML }).xml, false)
+
+    expect(fresh).not.toContain("<orderType")
+    expect(restored).toContain(">Asc</orderType>")
+  })
+
+  it("разрешает одно или несколько строковых ключевых полей в JSON Schema", () => {
+    const schema = JSON.stringify(exportMetadataItemToJSONSchema({ context: mockContext, rule: DynamicListRules }))
+
+    expect(schema).toContain('"ПоляКлюча"')
+    expect(schema).toContain('"type":"string"')
+    expect(schema).toContain('"type":"array"')
+    expect(schema).toContain('"items":{"type":"string"}')
+    expect(schema).not.toContain('"items":{"type":"number"}')
+  })
+})
+
+function withoutDeclaration(xml: string): string {
+  return xml.replace(/^\uFEFF?<\?xml[^>]+>\s*/, "").trim()
+}

--- a/packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts
@@ -1,0 +1,123 @@
+import fs from "fs"
+import { fileURLToPath } from "url"
+import { describe, expect, it } from "vitest"
+
+import {
+  createDirectRoundTripContexts,
+  testPropertyFromXMLToYAML,
+  testPropertyFromYAMLToXML,
+} from "../../../../tests/directConversion"
+import { importContentFromXML } from "../../../../xml/import/importer"
+import { xmlExport } from "../../../../xml/export/exporter"
+import type { MetadataItemRule } from "../../../orchestration/property/types"
+import { exportFormAttributesToJSONSchema } from "./toJSONSchema"
+
+import "./fromXMLToYAML"
+import "./rules"
+
+const rule = {
+  itemType: "FormAttributesProbe",
+  properties: {
+    value: { type: "FormAttributes", yaml: "Значение", xml: "Attribute" },
+  },
+} as const satisfies MetadataItemRule
+
+const fixtures = [
+  "attributeAnyType.xml",
+  "chartSettings.xml",
+  "columnAnyType.xml",
+  "ganttChartSettings.xml",
+  "mixedColumns.xml",
+  "plannerSettings.xml",
+  "plannerSettingsWithNil.xml",
+  "spreadsheetDocumentSettings.xml",
+  "tableWithColumns.xml",
+  "titleColumnsType.xml",
+  "treeWithColumn.xml",
+  "twoTables.xml",
+  "valueListWithReferenceEmptySettings.xml",
+  "valueListWithoutSettings.xml",
+] as const
+
+describe("FormAttributes XML → YAML → XML", () => {
+  it.each(fixtures)("сохраняет %s", (fixture) => {
+    const expected = fs.readFileSync(fileURLToPath(new URL(`__fixtures__/${fixture}`, import.meta.url)), "utf8")
+    const parsed = importContentFromXML<Record<string, unknown>>(expected, {
+      preserveEmptyElements: true,
+      preserveXsiNil: true,
+    })
+    const contexts = createDirectRoundTripContexts({
+      logicalAddress: "Справочник.Товары.Форма.ФормаЭлемента",
+    })
+    const yaml = testPropertyFromXMLToYAML({
+      rule,
+      xml: parsed,
+      context: contexts.importContext,
+    }).yaml
+    const { xml } = testPropertyFromYAMLToXML({
+      rule,
+      yaml,
+      referenceXML: parsed,
+      context: contexts.exportContext(),
+    })
+
+    expect(withoutDeclaration(xmlExport(xml, false))).toBe(expected.trim())
+  })
+
+  it("различает обычные и дополнительные колонки", () => {
+    const { yaml } = testPropertyFromXMLToYAML({
+      rule,
+      xml: {
+        Attribute: {
+          _name: "Таблица",
+          Type: { "v8:Type": "v8:ValueTable" },
+          Columns: {
+            Column: { _name: "Обычная", Type: { "v8:Type": "xs:string" } },
+            AdditionalColumns: {
+              _table: "Таблица.Данные",
+              Column: { _name: "Дополнительная", Type: { "v8:Type": "xs:boolean" } },
+            },
+          },
+        },
+      },
+    })
+
+    expect(yaml).toMatchObject({
+      Значение: {
+        Таблица: {
+          Колонки: { Обычная: expect.any(Object) },
+          ДополнительныеКолонки: {
+            "Таблица.Данные": { Дополнительная: expect.any(Object) },
+          },
+        },
+      },
+    })
+  })
+
+  it("сохраняет строгую схему всех специальных настроек", () => {
+    const json = JSON.stringify(
+      exportFormAttributesToJSONSchema({
+        context: {} as Parameters<typeof exportFormAttributesToJSONSchema>[0]["context"],
+        rule: { type: "FormAttributes" },
+        value: undefined,
+      })
+    )
+
+    for (const property of [
+      "Колонки",
+      "ДополнительныеКолонки",
+      "Диаграмма",
+      "ДиаграммаГанта",
+      "ГрафическаяСхема",
+      "ТабличныйДокумент",
+      "Планировщик",
+    ]) {
+      expect(json).toContain(`"${property}"`)
+    }
+    expect(json).toContain('"additionalProperties":false')
+  })
+})
+
+function withoutDeclaration(xml: string): string {
+  return xml.replace(/^\uFEFF?<\?xml[^>]+>\s*/, "").trim()
+}

--- a/packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts
+++ b/packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts
@@ -1,0 +1,51 @@
+import fs from "fs"
+import { fileURLToPath } from "url"
+import { describe, expect, it } from "vitest"
+
+import {
+  createDirectRoundTripContexts,
+  testPropertyFromXMLToYAML,
+  testPropertyFromYAMLToXML,
+} from "../../../../tests/directConversion"
+import { importContentFromXML } from "../../../../xml/import/importer"
+import { xmlExport } from "../../../../xml/export/exporter"
+import type { MetadataItemRule } from "../../../orchestration/property/types"
+
+import "./types"
+
+const rule = {
+  itemType: "FormCommandsProbe",
+  properties: {
+    value: { type: "FormCommands", yaml: "Значение", xml: "Commands" },
+  },
+} as const satisfies MetadataItemRule
+
+describe("FormCommands XML → YAML → XML", () => {
+  it.each(["full.xml", "minimal.xml"])("сохраняет %s", (fixture) => {
+    const expected = fs.readFileSync(fileURLToPath(new URL(`__fixtures__/${fixture}`, import.meta.url)), "utf8")
+    const parsed = importContentFromXML<Record<string, unknown>>(expected, {
+      preserveEmptyElements: true,
+      preserveXsiNil: true,
+    })
+    const contexts = createDirectRoundTripContexts({
+      logicalAddress: "Справочник.Товары.Форма.ФормаЭлемента",
+    })
+    const yaml = testPropertyFromXMLToYAML({
+      rule,
+      xml: parsed,
+      context: contexts.importContext,
+    }).yaml
+    const { xml } = testPropertyFromYAMLToXML({
+      rule,
+      yaml,
+      referenceXML: parsed,
+      context: contexts.exportContext(),
+    })
+
+    expect(withoutDeclaration(xmlExport(xml, false))).toBe(expected.trim())
+  })
+})
+
+function withoutDeclaration(xml: string): string {
+  return xml.replace(/^\uFEFF?<\?xml[^>]+>\s*/, "").trim()
+}

--- a/packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts
+++ b/packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts
@@ -1,0 +1,92 @@
+import fs from "fs"
+import path from "path"
+import { fileURLToPath } from "url"
+import { describe, expect, it } from "vitest"
+
+import {
+  createDirectRoundTripContexts,
+  testMetadataItemFromXMLToYAML,
+  testMetadataItemFromYAMLToXML,
+} from "../../../../tests/directConversion"
+import { importContentFromXML } from "../../../../xml/import/importer"
+import { xmlExport } from "../../../../xml/export/exporter"
+import { withConfigurationIndexFormElementRootLogicalAddress } from "../../../configurationIndex/collector/context"
+import type { CollectableElementType } from "../../../orchestration/formElement/types"
+import { getElementRule } from "../orchestration/ruleFactory"
+
+import "../index"
+
+const elementsDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const fixtures = fs
+  .readdirSync(elementsDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .flatMap((entry) => {
+    const fixtureDir = path.join(elementsDir, entry.name, "__fixtures__")
+    if (!fs.existsSync(fixtureDir)) return []
+    return fs
+      .readdirSync(fixtureDir)
+      .filter((name) => name.endsWith(".xml"))
+      .map((name) => path.join(fixtureDir, name))
+  })
+
+describe("элементы формы XML → YAML → XML", () => {
+  it.each(fixtures)("%s", (fixture) => {
+    const parsed = importContentFromXML<Record<string, Record<string, unknown>>>(fs.readFileSync(fixture, "utf8"), {
+      preserveXsiNil: true,
+    })
+    const [xmlTag, xml] = Object.entries(parsed)[0] ?? []
+    if (xmlTag === undefined || xml === undefined) throw new Error(`Пустая XML-фикстура: ${fixture}`)
+
+    const itemType = resolveItemType(xmlTag, path.basename(fixture), xml)
+    const rule = getElementRule(itemType)
+    const name = typeof xml._name === "string" ? xml._name : undefined
+    const formLogicalAddress = "Справочник.Товары.Форма.ФормаЭлемента"
+    const contexts = createDirectRoundTripContexts({
+      logicalAddress: `${formLogicalAddress}.Элемент.${name ?? xmlTag}`,
+    })
+    const yaml = testMetadataItemFromXMLToYAML({
+      rule,
+      xml,
+      name,
+      context: withConfigurationIndexFormElementRootLogicalAddress(contexts.importContext, formLogicalAddress),
+    }).yaml
+    const exportContext = contexts.exportContext()
+    const configurationIndex = exportContext.exportToXML.configurationIndex
+    if (configurationIndex === undefined) throw new Error("Не создан runtime индекса конфигурации")
+    const result = testMetadataItemFromYAMLToXML({
+      rule,
+      yaml,
+      name,
+      referenceXML: xml,
+      context: {
+        ...exportContext,
+        exportToXML: {
+          ...exportContext.exportToXML,
+          configurationIndex: configurationIndex.withFormElementRootLogicalAddress(formLogicalAddress),
+        },
+      },
+    }).xml
+
+    expect(withoutDeclaration(xmlExport({ [xmlTag]: result }, false))).toBe(fs.readFileSync(fixture, "utf8").trim())
+  })
+})
+
+function resolveItemType(xmlTag: string, fixtureName: string, xml: Record<string, unknown>): CollectableElementType {
+  if (
+    fixtureName.includes("Table") &&
+    (xmlTag === "CheckBoxField" || xmlTag === "InputField" || xmlTag === "LabelField" || xmlTag === "PictureField")
+  ) {
+    return `Table${xmlTag}` as CollectableElementType
+  }
+  if (
+    xmlTag === "Button" &&
+    (xml.Type === "CommandBarButton" || xml.Type === "CommandBarHyperlink" || fixtureName.includes("commandBar"))
+  ) {
+    return "CommandBarButton"
+  }
+  return xmlTag as CollectableElementType
+}
+
+function withoutDeclaration(xml: string): string {
+  return xml.replace(/^\uFEFF?<\?xml[^>]+>\s*/, "").trim()
+}

--- a/packages/core/metadata/forms/elements/orchestration/ruleFactory.ts
+++ b/packages/core/metadata/forms/elements/orchestration/ruleFactory.ts
@@ -5,7 +5,12 @@ import { exportSingleElementRuleToJSONSchema } from "./toJSONSchema"
 import { PropertyRuleType } from "../../../orchestration/property/registry"
 import { registerTypeRule } from "../../../orchestration/property/typeRuleRegistry"
 import { importSingleFormElementFromXMLToYAML } from "./fromXMLToYAML"
-import type { SingletonNameStyle } from "./singletonName"
+import {
+  configurationIndexExportFormElementLogicalAddress,
+  configurationIndexExportFormSingletonLogicalAddress,
+  withConfigurationIndexExportLogicalAddress,
+} from "../../../configurationIndex/referenceView"
+import { getCanonicalSingletonName, type SingletonNameStyle } from "./singletonName"
 import type { ElementRule, ElementType, ElementXML, SingleElementType } from "./types"
 
 export const getElementRule = <Rule extends ElementRule>(itemType: Rule["itemType"]): Rule => {
@@ -57,6 +62,21 @@ export const registerElementAsType = <Rule extends ElementRule & { itemType: Sin
   registerTypeRule(propertyType, "yamlToXMLNestedRule", {
     kind: "item",
     itemRule: elementRule,
+    resolveContext: ({ context, name }) => {
+      const canonicalName = getCanonicalSingletonName({
+        ownerLogicalAddress: name ?? context.exportToXML.configurationIndex?.logicalAddress ?? "",
+        nameStyle,
+      })
+      const logicalAddress =
+        nameStyle?.canonicalNameMode === "ownerSuffix"
+          ? configurationIndexExportFormSingletonLogicalAddress(context, nameStyle.canonicalSuffix)
+          : canonicalName === undefined
+            ? undefined
+            : configurationIndexExportFormElementLogicalAddress(context, canonicalName)
+      return logicalAddress === undefined
+        ? context
+        : withConfigurationIndexExportLogicalAddress(context, logicalAddress)
+    },
     transformOutput: ({ context, xml }) => {
       const extra = toXML({ context })
       return {

--- a/packages/core/metadata/orchestration/property/fromYAMLToXML.ts
+++ b/packages/core/metadata/orchestration/property/fromYAMLToXML.ts
@@ -366,6 +366,20 @@ export function convertPropertiesFromYAMLToXML(params: ConvertPropertiesFromYAML
               propertyRule: planned.propertyRule,
             })
           : nestedYAML
+      const nestedPropertyContext = withConfigurationIndexExportPropertyContext(
+        params.context,
+        planned.yamlKey ?? planned.propertyKey,
+        planned.propertyRule.configurationIndexUidSegment ?? planned.propertyRule.operationTarget?.migrationSegment,
+        { configurationIndexAddressing: planned.propertyRule.configurationIndexAddressing }
+      )
+      const nestedContext =
+        effectiveNestedRule.kind === "item" && effectiveNestedRule.resolveContext !== undefined
+          ? effectiveNestedRule.resolveContext({
+              context: nestedPropertyContext,
+              name: params.name,
+              propertyRule: planned.propertyRule,
+            })
+          : nestedPropertyContext
       if (
         effectiveNestedRule.kind === "collection" &&
         Array.isArray(nestedYAML) &&
@@ -388,7 +402,7 @@ export function convertPropertiesFromYAMLToXML(params: ConvertPropertiesFromYAML
       const nested =
         effectiveNestedRule.kind === "collection"
           ? convertMetadataCollectionFromYAMLToXML({
-              context: params.context,
+              context: nestedContext,
               yaml: nestedYAML,
               descriptor: effectiveNestedRule,
               propertyRule: planned.propertyRule,
@@ -399,7 +413,7 @@ export function convertPropertiesFromYAMLToXML(params: ConvertPropertiesFromYAML
               rulePath: [...(params.rulePath ?? [params.rule.itemType]), propertyKey],
             })
           : convertMetadataItemFromYAMLToXML({
-              context: params.context,
+              context: nestedContext,
               yaml: normalizedNestedYAML,
               rule:
                 effectiveNestedRule.kind === "item"
@@ -429,7 +443,7 @@ export function convertPropertiesFromYAMLToXML(params: ConvertPropertiesFromYAML
           isRecord(value)
         ) {
           value = effectiveNestedRule.transformOutput({
-            context: params.context,
+            context: nestedContext,
             xml: value,
             yaml: nestedYAML,
             referenceXML: isRecord(references[index]?.value) ? references[index]?.value : undefined,

--- a/packages/core/metadata/orchestration/property/fromYAMLToXMLTypes.ts
+++ b/packages/core/metadata/orchestration/property/fromYAMLToXMLTypes.ts
@@ -72,6 +72,11 @@ export type YAMLToXMLNestedRule =
         name: string | undefined
         propertyRule: PropertyRule
       }) => unknown
+      readonly resolveContext?: (params: {
+        context: import("../../context/types").ConfigurationContextWithExportToXML
+        name: string | undefined
+        propertyRule: PropertyRule
+      }) => import("../../context/types").ConfigurationContextWithExportToXML
       readonly transformOutput?: (params: {
         context: import("../../context/types").ConfigurationContextWithExportToXML
         xml: Record<string, unknown>

--- a/packages/core/scripts/conversion-test-migration/migration-map.json
+++ b/packages/core/scripts/conversion-test-migration/migration-map.json
@@ -15,8 +15,8 @@
     ],
     "line": 125,
     "behavior": "Единый обход преобразует XML поля группировки с отключённым использованием в объект YAML.",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -35,8 +35,8 @@
     ],
     "line": 130,
     "behavior": "Единый обход преобразует XML поля группировки с настройками по умолчанию в краткую строку YAML.",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -55,8 +55,8 @@
     ],
     "line": 136,
     "behavior": "Единый обход преобразует YAML отключённого поля группировки в исходный XML.",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -75,8 +75,8 @@
     ],
     "line": 142,
     "behavior": "Единый обход преобразует краткий YAML поля группировки в исходный XML.",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -95,8 +95,8 @@
     ],
     "line": 148,
     "behavior": "exports object form attribute YAML in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -115,8 +115,8 @@
     ],
     "line": 155,
     "behavior": "exports table columns in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -135,8 +135,8 @@
     ],
     "line": 162,
     "behavior": "exports additional table columns in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -155,8 +155,8 @@
     ],
     "line": 168,
     "behavior": "exports strict table column objects in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -175,8 +175,8 @@
     ],
     "line": 174,
     "behavior": "exports spreadsheet document settings in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -195,8 +195,8 @@
     ],
     "line": 180,
     "behavior": "exports chart settings in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -215,8 +215,8 @@
     ],
     "line": 186,
     "behavior": "exports gantt chart settings in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -235,8 +235,8 @@
     ],
     "line": 192,
     "behavior": "exports flowchart context settings in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -255,8 +255,8 @@
     ],
     "line": 198,
     "behavior": "exports planner settings in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -275,8 +275,8 @@
     ],
     "line": 204,
     "behavior": "exports string spreadsheet document settings in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -295,8 +295,8 @@
     ],
     "line": 210,
     "behavior": "should import title when mainAttribute=true and title equals name",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -315,8 +315,8 @@
     ],
     "line": 216,
     "behavior": "should import choice list",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -335,8 +335,8 @@
     ],
     "line": 222,
     "behavior": "should import with empty settings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -355,8 +355,8 @@
     ],
     "line": 234,
     "behavior": "should import table with columns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -375,8 +375,8 @@
     ],
     "line": 240,
     "behavior": "should import tree with column",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -395,8 +395,8 @@
     ],
     "line": 246,
     "behavior": "should import with functional options",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -415,8 +415,8 @@
     ],
     "line": 252,
     "behavior": "should import with additional column",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -435,8 +435,8 @@
     ],
     "line": 258,
     "behavior": "should import mixed columns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -455,8 +455,8 @@
     ],
     "line": 264,
     "behavior": "should import chartSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -475,8 +475,8 @@
     ],
     "line": 270,
     "behavior": "should import spreadsheetDocumentSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -495,8 +495,8 @@
     ],
     "line": 276,
     "behavior": "should import plannerSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -515,8 +515,8 @@
     ],
     "line": 282,
     "behavior": "should preserve title languages from source when default language is absent",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -535,8 +535,8 @@
     ],
     "line": 310,
     "behavior": "should preserve column title languages from source when default language is absent",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -555,8 +555,8 @@
     ],
     "line": 351,
     "behavior": "should preserve additional column title languages from source when default language is absent",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -585,8 +585,8 @@
     ],
     "line": 126,
     "behavior": "should export undefined when data is undefined",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -616,8 +616,8 @@
     ],
     "line": 131,
     "behavior": "should export full",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -647,8 +647,8 @@
     ],
     "line": 144,
     "behavior": "should export defaults",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -678,8 +678,8 @@
     ],
     "line": 157,
     "behavior": "should export multiple attributes",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -709,8 +709,8 @@
     ],
     "line": 170,
     "behavior": "should export choice list",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -740,8 +740,8 @@
     ],
     "line": 183,
     "behavior": "should export with empty settings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -771,8 +771,8 @@
     ],
     "line": 202,
     "behavior": "restores nested xsi:nil in planner settings from reference",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -802,8 +802,8 @@
     ],
     "line": 245,
     "behavior": "should export without type",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -833,8 +833,8 @@
     ],
     "line": 268,
     "behavior": "should export table with columns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -864,8 +864,8 @@
     ],
     "line": 281,
     "behavior": "should export tree with column",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -895,8 +895,8 @@
     ],
     "line": 294,
     "behavior": "should export with additional column",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -925,8 +925,8 @@
     ],
     "line": 307,
     "behavior": "restores ERP duplicate AdditionalColumns only for the known form path",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -956,8 +956,8 @@
     ],
     "line": 325,
     "behavior": "keeps canonical AdditionalColumns for other form paths",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -986,8 +986,8 @@
     ],
     "line": 336,
     "behavior": "keeps canonical AdditionalColumns for the ERP path when table is different",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1016,8 +1016,8 @@
     ],
     "line": 353,
     "behavior": "keeps canonical AdditionalColumns for the ERP path when column name is different",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1046,8 +1046,8 @@
     ],
     "line": 364,
     "behavior": "keeps canonical AdditionalColumns for the ERP path when the known group has multiple columns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1077,8 +1077,8 @@
     ],
     "line": 375,
     "behavior": "export tableWithColumns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1108,8 +1108,8 @@
     ],
     "line": 389,
     "behavior": "export treeWithColumn",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1139,8 +1139,8 @@
     ],
     "line": 403,
     "behavior": "export twoTables",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1170,8 +1170,8 @@
     ],
     "line": 417,
     "behavior": "export mixedColumns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1201,8 +1201,8 @@
     ],
     "line": 431,
     "behavior": "export titleColumnsType",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1231,8 +1231,8 @@
     ],
     "line": 445,
     "behavior": "round-trip keeps repeated DynamicList KeyField nodes in Settings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1261,8 +1261,8 @@
     ],
     "line": 471,
     "behavior": "exports FlowchartContextType Settings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1292,8 +1292,8 @@
     ],
     "line": 495,
     "behavior": "export attributeAnyType",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1323,8 +1323,8 @@
     ],
     "line": 509,
     "behavior": "export columnAnyType",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1354,8 +1354,8 @@
     ],
     "line": 523,
     "behavior": "export chartSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1385,8 +1385,8 @@
     ],
     "line": 536,
     "behavior": "export ganttChartSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1416,8 +1416,8 @@
     ],
     "line": 549,
     "behavior": "export spreadsheetDocumentSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1447,8 +1447,8 @@
     ],
     "line": 562,
     "behavior": "export plannerSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1478,8 +1478,8 @@
     ],
     "line": 575,
     "behavior": "export plannerSettingsWithNil",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1509,8 +1509,8 @@
     ],
     "line": 603,
     "behavior": "exports ValueListType without Settings when reference is absent",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1540,8 +1540,8 @@
     ],
     "line": 617,
     "behavior": "preserves empty Settings for ValueListType from reference",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1557,8 +1557,8 @@
     ],
     "line": 16,
     "behavior": "should return undefined for undefined input",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1575,8 +1575,8 @@
     ],
     "line": 26,
     "behavior": "should export full to XML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -1593,8 +1593,8 @@
     ],
     "line": 39,
     "behavior": "should export minimal",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -16605,7 +16605,7 @@
     "line": 28,
     "behavior": "should read form from XML and export to YAML file in output dir",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16620,7 +16620,7 @@
     "line": 43,
     "behavior": "collects the form uuid under the owner-derived logical address",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16637,7 +16637,7 @@
     "line": 61,
     "behavior": "должен экспортировать текст запроса DynamicList во внешний .query файл",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16655,7 +16655,7 @@
     "line": 85,
     "behavior": "imports ordinary form metadata and copies Form.bin without Form.xml",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16672,7 +16672,7 @@
     "line": 125,
     "behavior": "omits form synonym equal to the form name",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16689,7 +16689,7 @@
     "line": 161,
     "behavior": "imports metadata-only ordinary form without creating Form.bin",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16706,7 +16706,7 @@
     "line": 199,
     "behavior": "keeps managed form without Form.xml as an input error",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16723,7 +16723,7 @@
     "line": 228,
     "behavior": "copies managed form Form.bin even when Form.xml exists",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16738,7 +16738,7 @@
     "line": 247,
     "behavior": "copies form help _files recursively",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16753,7 +16753,7 @@
     "line": 273,
     "behavior": "копирует внешние картинки элементов формы в YAML-каталоги по имени элемента",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16773,7 +16773,7 @@
     "line": 322,
     "behavior": "preserves xsi:nil in raw SettingsFragment when reading form XML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16791,7 +16791,7 @@
     "line": 364,
     "behavior": "экспортирует событие BeforeExecute в YAML как ПередВыполнением",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16806,7 +16806,7 @@
     "line": 393,
     "behavior": "public core entrypoint exports form YAML rules",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetTitle": "sync ClientApplicationForm to XML",
     "status": "migrated"
   },
   {
@@ -16827,7 +16827,7 @@
     "line": 20,
     "behavior": "should import all fields from XML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -16848,7 +16848,7 @@
     "line": 32,
     "behavior": "should import minimal",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -16869,7 +16869,7 @@
     "line": 47,
     "behavior": "imports explicit empty ExtendedPresentation from metadata XML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -16890,7 +16890,7 @@
     "line": 64,
     "behavior": "imports catalog full form from XML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -16911,7 +16911,7 @@
     "line": 79,
     "behavior": "imports document full form from XML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -16932,7 +16932,7 @@
     "line": 94,
     "behavior": "imports conditional appearance without attributes",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -16953,7 +16953,7 @@
     "line": 112,
     "behavior": "imports CustomSettingsFolder",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -16974,7 +16974,7 @@
     "line": 130,
     "behavior": "imports root ChildItemsWidth",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -16993,7 +16993,7 @@
     "line": 145,
     "behavior": "imports decimal report result fields as numbers",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17014,7 +17014,7 @@
     "line": 159,
     "behavior": "imports report form extension fields",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17036,7 +17036,7 @@
     "line": 174,
     "behavior": "collects form and nested item identities without collection order",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17058,7 +17058,7 @@
     "line": 214,
     "behavior": "адресует singleton по каноническому имени и сохраняет нестандартное XML-имя",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17078,7 +17078,7 @@
     "line": 249,
     "behavior": "адресует таблицу диаграммы Ганта как отдельный вложенный элемент индекса",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17098,7 +17098,7 @@
     "line": 297,
     "behavior": "собирает порядок Form.xml отдельно от metadata XML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17116,8 +17116,8 @@
     ],
     "line": 215,
     "behavior": "imports report form settings storage from a local form reference",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17135,8 +17135,8 @@
     ],
     "line": 225,
     "behavior": "keeps dynamic list field data paths in YAML spelling",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17154,8 +17154,8 @@
     ],
     "line": 259,
     "behavior": "keeps ValueTable field data paths in YAML spelling",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17173,8 +17173,8 @@
     ],
     "line": 277,
     "behavior": "imports object standard member data paths to internal spelling",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17192,8 +17192,8 @@
     ],
     "line": 290,
     "behavior": "imports tabular section row number data paths from YAML spelling",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17211,8 +17211,8 @@
     ],
     "line": 309,
     "behavior": "imports complete form from one YAML source without source",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17230,8 +17230,8 @@
     ],
     "line": 354,
     "behavior": "imports disabled auto command bar autofill without source",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17249,8 +17249,8 @@
     ],
     "line": 370,
     "behavior": "should import all fields from YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17268,8 +17268,8 @@
     ],
     "line": 385,
     "behavior": "imports catalog full YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17287,8 +17287,8 @@
     ],
     "line": 417,
     "behavior": "imports document full YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17306,8 +17306,8 @@
     ],
     "line": 455,
     "behavior": "should import from form command bar",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17325,8 +17325,8 @@
     ],
     "line": 523,
     "behavior": "should import from table command bar",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17344,8 +17344,8 @@
     ],
     "line": 611,
     "behavior": "imports CustomSettingsFolder from YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17363,8 +17363,8 @@
     ],
     "line": 650,
     "behavior": "does not apply report form Auto defaults when importing YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17384,8 +17384,8 @@
     ],
     "line": 27,
     "behavior": "uses configuration index logical address for form body",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17405,8 +17405,8 @@
     ],
     "line": 55,
     "behavior": "should export all fields to XML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17426,8 +17426,8 @@
     ],
     "line": 82,
     "behavior": "exports CustomSettingsFolder",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17447,8 +17447,8 @@
     ],
     "line": 109,
     "behavior": "exports root ChildItemsWidth",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17468,8 +17468,8 @@
     ],
     "line": 136,
     "behavior": "exports report form extension fields",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17487,8 +17487,8 @@
     ],
     "line": 163,
     "behavior": "exports decimal report result fields with xsi type",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17508,8 +17508,8 @@
     ],
     "line": 190,
     "behavior": "should export minimal",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17529,8 +17529,8 @@
     ],
     "line": 216,
     "behavior": "exports conditional appearance without attributes",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17550,8 +17550,8 @@
     ],
     "line": 242,
     "behavior": "exports catalog full form to XML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17571,8 +17571,8 @@
     ],
     "line": 268,
     "behavior": "exports document full form to XML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17590,8 +17590,8 @@
     ],
     "line": 294,
     "behavior": "не добавляет Period и TopLevelParent для таблицы DynamicList без referenceForm",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17609,8 +17609,8 @@
     ],
     "line": 330,
     "behavior": "сохраняет Period и TopLevelParent для таблицы из referenceForm",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17628,8 +17628,8 @@
     ],
     "line": 390,
     "behavior": "не добавляет RowFilter для обычного реквизита без referenceForm",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17647,8 +17647,8 @@
     ],
     "line": 423,
     "behavior": "сохраняет RowFilter для таблицы из referenceForm",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17666,8 +17666,8 @@
     ],
     "line": 475,
     "behavior": "preserves command ids from reference form by name",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17686,8 +17686,8 @@
     ],
     "line": 532,
     "behavior": "should export all fields to XML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17707,8 +17707,8 @@
     ],
     "line": 546,
     "behavior": "should export minimal",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17728,8 +17728,8 @@
     ],
     "line": 571,
     "behavior": "preserves empty ExtendedPresentation when it exists in reference metadata",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromYAMLToXML.test.ts",
+    "targetTitle": "convertClientApplicationFormFromYAMLToXML",
     "status": "migrated"
   },
   {
@@ -17748,7 +17748,7 @@
     "line": 41,
     "behavior": "should export all fields to YAML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17767,7 +17767,7 @@
     "line": 47,
     "behavior": "exports form and command bar elements from one YAML source",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17786,7 +17786,7 @@
     "line": 92,
     "behavior": "exports disabled auto command bar autofill to YAML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17805,7 +17805,7 @@
     "line": 113,
     "behavior": "exports catalog full YAML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17824,7 +17824,7 @@
     "line": 119,
     "behavior": "exports document full YAML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17843,7 +17843,7 @@
     "line": 125,
     "behavior": "keeps dynamic list field data paths in XML spelling",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17862,7 +17862,7 @@
     "line": 160,
     "behavior": "keeps ValueTable field data paths in internal-to-yaml formatting",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17881,7 +17881,7 @@
     "line": 179,
     "behavior": "exports object standard member data paths to YAML spelling",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17901,7 +17901,7 @@
     "line": 191,
     "behavior": "exports data paths through an injected owner cache without a YAML project",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17920,7 +17920,7 @@
     "line": 240,
     "behavior": "exports tabular section row number data paths to YAML spelling",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17939,7 +17939,7 @@
     "line": 252,
     "behavior": "exports report form settings storage as a local form reference",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17958,7 +17958,7 @@
     "line": 280,
     "behavior": "exports report form settings storage as an external report form reference",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17977,7 +17977,7 @@
     "line": 308,
     "behavior": "should export minimal",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -17996,7 +17996,7 @@
     "line": 314,
     "behavior": "exports CustomSettingsFolder to YAML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18015,7 +18015,7 @@
     "line": 322,
     "behavior": "omits report form Auto defaults when exporting YAML",
     "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetTitle": "форма XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18234,8 +18234,8 @@
     ],
     "line": 22,
     "behavior": "should return undefined when data is undefined",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18252,8 +18252,8 @@
     ],
     "line": 31,
     "behavior": "should import full",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18270,8 +18270,8 @@
     ],
     "line": 41,
     "behavior": "should import empty ListSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18288,8 +18288,8 @@
     ],
     "line": 52,
     "behavior": "round-trip: full.xml import → export",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18306,8 +18306,8 @@
     ],
     "line": 69,
     "behavior": "round-trip: minimal.xml import → export",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18324,8 +18324,8 @@
     ],
     "line": 86,
     "behavior": "round-trip: emptyListSettings.xml import -> export",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18342,8 +18342,8 @@
     ],
     "line": 103,
     "behavior": "round-trip: designTimeDataParameters.xml import -> export",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18360,8 +18360,8 @@
     ],
     "line": 122,
     "behavior": "round-trip: customQuery.xml import → export",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18378,8 +18378,8 @@
     ],
     "line": 139,
     "behavior": "imports QueryText when ManualQuery is false",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18396,8 +18396,8 @@
     ],
     "line": 150,
     "behavior": "imports multiple CalculatedField nodes",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18414,8 +18414,8 @@
     ],
     "line": 161,
     "behavior": "imports KeyType and KeyField",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18431,8 +18431,8 @@
     ],
     "line": 172,
     "behavior": "imports XML with only KeyType and KeyField",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18448,8 +18448,8 @@
     ],
     "line": 191,
     "behavior": "imports repeated KeyField nodes as keyFields array",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18466,8 +18466,8 @@
     ],
     "line": 210,
     "behavior": "addresses DCS filter and order items under distinct YAML paths in configuration index",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18484,8 +18484,8 @@
     ],
     "line": 259,
     "behavior": "round-trip: queryTextWithManualQueryFalse.xml import -> export",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18501,8 +18501,8 @@
     ],
     "line": 40,
     "behavior": "should return undefined when data is undefined",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18518,8 +18518,8 @@
     ],
     "line": 48,
     "behavior": "should import full",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18535,8 +18535,8 @@
     ],
     "line": 56,
     "behavior": "round-trip: import → export даёт тот же YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18552,8 +18552,8 @@
     ],
     "line": 68,
     "behavior": "imports explicit ManualQuery false from YAML even when queryText exists in model fixture",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18569,8 +18569,8 @@
     ],
     "line": 82,
     "behavior": "imports explicit ManualQuery true from YAML without query file",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18586,8 +18586,8 @@
     ],
     "line": 100,
     "behavior": "does not derive ManualQuery from external query file",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18603,8 +18603,8 @@
     ],
     "line": 127,
     "behavior": "imports KeyType and KeyField",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18620,8 +18620,8 @@
     ],
     "line": 142,
     "behavior": "round-trip: KeyType and KeyField YAML import -> export",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18637,8 +18637,8 @@
     ],
     "line": 162,
     "behavior": "imports ПоляКлюча array as keyFields array",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18654,8 +18654,8 @@
     ],
     "line": 179,
     "behavior": "accepts scalar key fields in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18671,8 +18671,8 @@
     ],
     "line": 185,
     "behavior": "accepts list key fields in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18688,8 +18688,8 @@
     ],
     "line": 191,
     "behavior": "rejects non-string key fields in JSON Schema",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18705,8 +18705,8 @@
     ],
     "line": 196,
     "behavior": "preserves calculated field Asc from raw XML source",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18722,8 +18722,8 @@
     ],
     "line": 19,
     "behavior": "should export undefined when data is undefined",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18740,8 +18740,8 @@
     ],
     "line": 28,
     "behavior": "should export full to XML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18758,8 +18758,8 @@
     ],
     "line": 39,
     "behavior": "should export minimal to XML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18776,8 +18776,8 @@
     ],
     "line": 50,
     "behavior": "should export empty ListSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18794,8 +18794,8 @@
     ],
     "line": 62,
     "behavior": "exports QueryText with explicit ManualQuery false",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18812,8 +18812,8 @@
     ],
     "line": 74,
     "behavior": "exports multiple CalculatedField nodes",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18830,8 +18830,8 @@
     ],
     "line": 86,
     "behavior": "exports KeyType and KeyField",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18847,8 +18847,8 @@
     ],
     "line": 98,
     "behavior": "fresh export keeps QueryText, KeyType, KeyField, ListSettings order",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18864,8 +18864,8 @@
     ],
     "line": 117,
     "behavior": "preserves reference KeyField when current value is undefined",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18881,8 +18881,8 @@
     ],
     "line": 139,
     "behavior": "exports keyFields array as repeated KeyField nodes",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18898,8 +18898,8 @@
     ],
     "line": 157,
     "behavior": "restores explicit Asc calculated field orderType from reference XML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18915,8 +18915,8 @@
     ],
     "line": 204,
     "behavior": "does not invent Asc calculated field orderType without reference XML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18932,8 +18932,8 @@
     ],
     "line": 231,
     "behavior": "does not restore Desc calculated field orderType from reference XML when current value omits it",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18949,8 +18949,8 @@
     ],
     "line": 20,
     "behavior": "should export undefined when data is undefined",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18966,8 +18966,8 @@
     ],
     "line": 29,
     "behavior": "should export full",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -18983,8 +18983,8 @@
     ],
     "line": 40,
     "behavior": "omits ManualQuery false when queryText is present",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19000,8 +19000,8 @@
     ],
     "line": 54,
     "behavior": "exports explicit ManualQuery true when queryText is present",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19017,8 +19017,8 @@
     ],
     "line": 75,
     "behavior": "exports calculatedFields as YAML array",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19034,8 +19034,8 @@
     ],
     "line": 101,
     "behavior": "exports KeyType and KeyField",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19051,8 +19051,8 @@
     ],
     "line": 117,
     "behavior": "exports keyFields array as ПоляКлюча array",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19068,8 +19068,8 @@
     ],
     "line": 136,
     "behavior": "exports ManualQuery true when queryText is present and collects query file",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19085,8 +19085,8 @@
     ],
     "line": 173,
     "behavior": "omits ManualQuery false because it is YAML default",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19102,8 +19102,8 @@
     ],
     "line": 192,
     "behavior": "does not emit ManualQuery false when queryText is present",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/dynamicList/fromXMLToYAML.test.ts",
+    "targetTitle": "DynamicList XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19132,8 +19132,8 @@
     ],
     "line": 40,
     "behavior": "импортирует таблицу с колонками напрямую в YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19162,8 +19162,8 @@
     ],
     "line": 59,
     "behavior": "импортирует дополнительные колонки напрямую в YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19191,8 +19191,8 @@
     ],
     "line": 78,
     "behavior": "should return undefined when data is undefined",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19221,8 +19221,8 @@
     ],
     "line": 83,
     "behavior": "should import full",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19251,8 +19251,8 @@
     ],
     "line": 91,
     "behavior": "should import minimal",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19281,8 +19281,8 @@
     ],
     "line": 99,
     "behavior": "should import multiple attributes",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19311,8 +19311,8 @@
     ],
     "line": 107,
     "behavior": "should import choice list",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19341,8 +19341,8 @@
     ],
     "line": 115,
     "behavior": "should import with empty settings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19371,8 +19371,8 @@
     ],
     "line": 123,
     "behavior": "should import without type",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19401,8 +19401,8 @@
     ],
     "line": 139,
     "behavior": "should import table with columns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19432,8 +19432,8 @@
     ],
     "line": 147,
     "behavior": "собирает id колонок по отдельным logicalAddress",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19462,8 +19462,8 @@
     ],
     "line": 174,
     "behavior": "should import tree with column",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19492,8 +19492,8 @@
     ],
     "line": 182,
     "behavior": "should import with additional column",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19522,8 +19522,8 @@
     ],
     "line": 190,
     "behavior": "import tableWithColumns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19552,8 +19552,8 @@
     ],
     "line": 200,
     "behavior": "import treeWithColumn",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19582,8 +19582,8 @@
     ],
     "line": 210,
     "behavior": "import twoTables",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19612,8 +19612,8 @@
     ],
     "line": 220,
     "behavior": "import mixedColumns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19642,8 +19642,8 @@
     ],
     "line": 230,
     "behavior": "import attributeAnyType",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19672,8 +19672,8 @@
     ],
     "line": 240,
     "behavior": "import columnAnyType",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19702,8 +19702,8 @@
     ],
     "line": 250,
     "behavior": "import chartSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19732,8 +19732,8 @@
     ],
     "line": 260,
     "behavior": "import ganttChartSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19762,8 +19762,8 @@
     ],
     "line": 270,
     "behavior": "import spreadsheetDocumentSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19792,8 +19792,8 @@
     ],
     "line": 280,
     "behavior": "import plannerSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19821,8 +19821,8 @@
     ],
     "line": 290,
     "behavior": "imports FlowchartContextType Settings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19851,8 +19851,8 @@
     ],
     "line": 325,
     "behavior": "imports ValueListType without Settings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19881,8 +19881,8 @@
     ],
     "line": 335,
     "behavior": "imports ValueListType with empty reference Settings without valueType",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19910,8 +19910,8 @@
     ],
     "line": 345,
     "behavior": "imports DynamicList Settings with repeated KeyField nodes",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19930,8 +19930,8 @@
     ],
     "line": 92,
     "behavior": "should export undefined when data is undefined",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19950,8 +19950,8 @@
     ],
     "line": 97,
     "behavior": "should export full",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19970,8 +19970,8 @@
     ],
     "line": 103,
     "behavior": "should export object format",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -19990,8 +19990,8 @@
     ],
     "line": 115,
     "behavior": "should export choice list",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20010,8 +20010,8 @@
     ],
     "line": 121,
     "behavior": "should export with empty settings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20030,8 +20030,8 @@
     ],
     "line": 133,
     "behavior": "should export table with columns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20050,8 +20050,8 @@
     ],
     "line": 139,
     "behavior": "should export tree with column",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20070,8 +20070,8 @@
     ],
     "line": 145,
     "behavior": "should export with functional options",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20090,8 +20090,8 @@
     ],
     "line": 151,
     "behavior": "should export with additional column",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20110,8 +20110,8 @@
     ],
     "line": 157,
     "behavior": "should export mixed columns",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20130,8 +20130,8 @@
     ],
     "line": 163,
     "behavior": "should export chartSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20150,8 +20150,8 @@
     ],
     "line": 169,
     "behavior": "should export spreadsheetDocumentSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20170,8 +20170,8 @@
     ],
     "line": 175,
     "behavior": "should export plannerSettings",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formAttribute/fromXMLToYAML.test.ts",
+    "targetTitle": "FormAttributes XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20187,8 +20187,8 @@
     ],
     "line": 20,
     "behavior": "should return empty array for undefined input",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20206,8 +20206,8 @@
     ],
     "line": 30,
     "behavior": "should import full.xml",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20225,8 +20225,8 @@
     ],
     "line": 41,
     "behavior": "should import minimal.xml",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20243,8 +20243,8 @@
     ],
     "line": 52,
     "behavior": "imports full.xml directly to YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20260,8 +20260,8 @@
     ],
     "line": 21,
     "behavior": "should return empty array for undefined input",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20277,8 +20277,8 @@
     ],
     "line": 31,
     "behavior": "should import full from YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20294,8 +20294,8 @@
     ],
     "line": 40,
     "behavior": "should import minimal from YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20311,8 +20311,8 @@
     ],
     "line": 21,
     "behavior": "should return undefined for undefined input",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20328,8 +20328,8 @@
     ],
     "line": 31,
     "behavior": "should export full to YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20345,8 +20345,8 @@
     ],
     "line": 40,
     "behavior": "should export minimal",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/commonObjects/formCommand/fromXMLToYAML.test.ts",
+    "targetTitle": "FormCommands XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20360,8 +20360,8 @@
     "fixtures": [],
     "line": 20,
     "behavior": "$name",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20377,8 +20377,8 @@
     ],
     "line": 10,
     "behavior": "$name",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20394,8 +20394,8 @@
     ],
     "line": 28,
     "behavior": "preserves TypeDescription Parameter from source when YAML omits Parameter",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20411,8 +20411,8 @@
     ],
     "line": 44,
     "behavior": "does not materialize ExtendedTooltip Type for search control addition",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20428,8 +20428,8 @@
     ],
     "line": 73,
     "behavior": "$name",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20443,8 +20443,8 @@
     "fixtures": [],
     "line": 17,
     "behavior": "$name",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20458,8 +20458,8 @@
     "fixtures": [],
     "line": 13,
     "behavior": "$name",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20473,8 +20473,8 @@
     "fixtures": [],
     "line": 23,
     "behavior": "exports search string addition source to partial YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20488,8 +20488,8 @@
     "fixtures": [],
     "line": 38,
     "behavior": "exports search control addition source to partial YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20503,8 +20503,8 @@
     "fixtures": [],
     "line": 57,
     "behavior": "`${group} -  $name`",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20518,8 +20518,8 @@
     "fixtures": [],
     "line": 69,
     "behavior": "do not hide fields from partial YAML",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20533,8 +20533,8 @@
     "fixtures": [],
     "line": 94,
     "behavior": "exports search string addition kind with source",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20548,8 +20548,8 @@
     "fixtures": [],
     "line": 110,
     "behavior": "exports search control addition kind with source",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20563,8 +20563,8 @@
     "fixtures": [],
     "line": 127,
     "behavior": "exports group kind, group mode and nested child items",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20578,8 +20578,8 @@
     "fixtures": [],
     "line": 156,
     "behavior": "exports explicit table data path",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20593,8 +20593,8 @@
     "fixtures": [],
     "line": 40,
     "behavior": "restores BackColor auto when model omits backColor and reference XML has auto",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20608,8 +20608,8 @@
     "fixtures": [],
     "line": 52,
     "behavior": "does not invent BackColor auto without reference",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20623,8 +20623,8 @@
     "fixtures": [],
     "line": 60,
     "behavior": "exports model color instead of reference auto",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20641,8 +20641,8 @@
     ],
     "line": 14,
     "behavior": "imports all decoration fields",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20659,8 +20659,8 @@
     ],
     "line": 26,
     "behavior": "imports empty tooltip as minimal model",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20677,8 +20677,8 @@
     ],
     "line": 38,
     "behavior": "imports empty formatted title",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/fromXMLToYAML.test.ts",
-    "targetTitle": "совпадает с действующим YAML полной формы",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20695,8 +20695,8 @@
     ],
     "line": 37,
     "behavior": "exports all decoration fields",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20713,8 +20713,8 @@
     ],
     "line": 44,
     "behavior": "exports empty tooltip with generated name",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20731,8 +20731,8 @@
     ],
     "line": 51,
     "behavior": "exports empty formatted title",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20748,8 +20748,8 @@
     ],
     "line": 58,
     "behavior": "does not export runtime Type",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20763,8 +20763,8 @@
     "fixtures": [],
     "line": 8,
     "behavior": "exports XML-only Edit value",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20778,8 +20778,8 @@
     "fixtures": [],
     "line": 38,
     "behavior": "restores BackColor auto when model omits backColor and reference XML has auto",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20793,8 +20793,8 @@
     "fixtures": [],
     "line": 51,
     "behavior": "does not invent BackColor auto without reference XML key",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -20808,8 +20808,8 @@
     "fixtures": [],
     "line": 63,
     "behavior": "exports model color instead of reference auto",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -21059,8 +21059,8 @@
     ],
     "line": 34,
     "behavior": "экспортирует критичные XML-свойства таблицы в порядке 1С без reference",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -21076,8 +21076,8 @@
     ],
     "line": 59,
     "behavior": "сохраняет RowFilter, когда ключ есть в referenceMetadata со значением undefined",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -21093,8 +21093,8 @@
     ],
     "line": 71,
     "behavior": "не добавляет RowFilter без ключа в referenceMetadata",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -21110,8 +21110,8 @@
     ],
     "line": 88,
     "behavior": "сохраняет Period и TopLevelParent, когда ключи есть в referenceMetadata",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {
@@ -21127,8 +21127,8 @@
     ],
     "line": 112,
     "behavior": "не добавляет XML-only поля без referenceMetadata",
-    "targetPath": "packages/core/metadata/forms/clientApplicationForm/syncToXML.test.ts",
-    "targetTitle": "читает форму из YAML и экспортирует XML",
+    "targetPath": "packages/core/metadata/forms/elements/__tests__/fromXMLToYAML.test.ts",
+    "targetTitle": "элементы формы XML → YAML → XML",
     "status": "migrated"
   },
   {


### PR DESCRIPTION
## Что исправлено

- восстановлены объединённые XML → YAML → XML тесты формы, её реквизитов, команд, DynamicList и всех 105 XML-фикстур элементов;
- восстановлены проверки внешних файлов, служебных XML-узлов, идентичностей и порядка;
- исправлены найденные тестами ошибки адресации configuration index, регистрации атомарных DCS-обработчиков и сохранения типизированных значений;
- карта миграции 1222 старых сценариев снова указывает на реальные тесты.

## Проверка

- pnpm test — core: 4604, MCP: 51, CLI: 61;
- pnpm --filter @nkdk/core exec tsc --noEmit;
- аудит карты: 1222 сценария, pending=0, errors=0.