### PR TITLE
perf: сократить память standalone validation

### DIFF
--- a/docs/superpowers/plans/2026-07-30-compact-standalone-validation-memory.md
+++ b/docs/superpowers/plans/2026-07-30-compact-standalone-validation-memory.md
@@ -1,0 +1,506 @@
+# Compact Standalone Validation Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Выпустить строгий functions-only standalone validation v3, удалить неиспользуемые schema/context/error-данные и сохранить поведение YAML-диагностик.
+
+**Architecture:** Production validation использует единый минимальный договор `Check()`/`Errors()`. Standalone v3 хранит только готовые функции form/item validators; исходные схемы, refs и context остаются только на этапе сборки. Позиции диагностик продолжают вычисляться из `instancePath` через существующий `YamlLocationIndex`.
+
+**Tech Stack:** TypeScript, Ajv 2020 standalone, TypeBox, Vitest, esbuild, Node.js worker_threads.
+
+## Global Constraints
+
+- Не изменять существующие XML-фикстуры.
+- Не добавлять новые `fromXML`/`toXML`/`fromYAML`/`toYAML`.
+- Сохранить посторонние изменения в `localIndexes.ts`, `yamlFactExtractor.ts` и `yamlFactExtractor.test.ts`.
+- В постоянном результате не должно быть временного memory-скрипта и вложенного профиля `Загрузка standalone`.
+- Не вводить численный CI-порог памяти.
+- Перед завершением выполнить `pnpm test` из корня.
+- Спецификация: `docs/superpowers/specs/2026-07-30-compact-standalone-validation-memory-design.md`.
+
+---
+
+### Task 1: Удалить legacy-договор Schema/Context
+
+**Files:**
+- Modify: `packages/core/metadata/validation/compileValidationSchema.ts`
+- Modify: `packages/core/metadata/validation/compileValidationSchema.test.ts`
+- Modify: `packages/core/metadata/validation/schemaRegistry.test.ts`
+- Modify: `packages/core/metadata/validation/projectValidationPasses.ts`
+- Modify: `packages/core/metadata/validation/projectValidationPasses.test.ts`
+- Modify: `packages/core/metadata/validation/schemaCache.ts`
+- Modify: `packages/core/metadata/validation/validateFile.ts`
+- Modify: `packages/core/metadata/validation/validateFile.test.ts`
+- Modify: `packages/core/metadata/validation/validateItem.ts`
+- Modify: `packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts`
+- Modify: `packages/core/metadata/validation/projectValidationStandaloneLoader.ts`
+- Modify: `packages/core/metadata/validation/projectValidationStandaloneLoader.test.ts`
+
+**Interfaces:**
+- Consumes: `ValidateFunction`, существующие Ajv/TypeBox validators.
+- Produces: `ValidationSchemaValidator` без типового параметра, `Schema()` и `Context()`; `createValidationSchemaFromAjvFunction(validate)`.
+
+- [ ] **Step 1: Написать падающий тест нового adapter API**
+
+В `compileValidationSchema.test.ts` заменить старый тест adapter на вызов функции без schema/context:
+
+```ts
+it("wraps a standalone Ajv function without schema metadata", () => {
+  const validate = Object.assign(
+    (value: unknown) => typeof value === "string",
+    { errors: null as ValidateFunction["errors"] }
+  ) as ValidateFunction
+
+  const compiled = createValidationSchemaFromAjvFunction(validate)
+
+  expect(compiled.Check("ok")).toBe(true)
+  expect(compiled.Check(42)).toBe(false)
+})
+```
+
+Удалить утверждения `compiled.Schema()` и `compiled.Context()` из этого теста: новый договор не должен их предоставлять.
+
+- [ ] **Step 2: Убедиться, что тест падает на старом adapter API**
+
+Run:
+
+```bash
+pnpm --filter @nkdk/core exec vitest run metadata/validation/compileValidationSchema.test.ts
+```
+
+Expected: FAIL в тесте `wraps a standalone Ajv function without schema metadata`, потому что текущий `createValidationSchemaFromAjvFunction` ожидает объект `{ schema, context, validate }`.
+
+- [ ] **Step 3: Сузить production-интерфейс**
+
+В `compileValidationSchema.ts` заменить интерфейс:
+
+```ts
+export interface ValidationSchemaValidator {
+  Check(value: unknown): boolean
+  Errors(value: unknown): [boolean, ValidationSchemaError[]]
+}
+```
+
+Оба overload `compileValidationSchema` должны возвращать `ValidationSchemaValidator` без типового параметра. Удалить `Schema()`/`Context()` из Ajv- и TypeBox-объектов.
+
+Заменить standalone adapter на:
+
+```ts
+class AjvFunctionValidationSchema implements ValidationSchemaValidator {
+  constructor(private readonly validate: ValidateFunction) {}
+
+  Check(value: unknown): boolean {
+    return this.validate(value)
+  }
+
+  Errors(value: unknown): [boolean, ValidationSchemaError[]] {
+    const valid = this.validate(value)
+    if (valid) return [true, []]
+    return [false, normalizeAjvErrors(this.validate.errors)]
+  }
+}
+
+export function createValidationSchemaFromAjvFunction(validate: ValidateFunction): ValidationSchemaValidator {
+  return new AjvFunctionValidationSchema(validate)
+}
+```
+
+В `projectValidationStandaloneLoader.ts` вызывать:
+
+```ts
+return createValidationSchemaFromAjvFunction(validator.validate)
+```
+
+Не создавать `Type.Any()` и не передавать refs/schema context.
+
+- [ ] **Step 4: Обновить потребителей узкого интерфейса**
+
+Во всех перечисленных файлах заменить `ValidationSchemaValidator<TSchema>` на `ValidationSchemaValidator`. Удалить ставшие неиспользуемыми импорты `TSchema`.
+
+В `validateFile.test.ts` оставить test-double только с `Check()` и `Errors()`:
+
+```ts
+const countedSchema: ValidationSchemaValidator = {
+  Check(value) {
+    checkCalls += 1
+    return simpleSchema.Check(value)
+  },
+  Errors(value) {
+    errorsCalls += 1
+    return simpleSchema.Errors(value)
+  },
+}
+```
+
+Удалить проверки `Schema()`/`Context()` из:
+
+- `compileValidationSchema.test.ts`;
+- `projectValidationPasses.test.ts`;
+- `projectValidationStandaloneLoader.test.ts`.
+
+В `typeboxErrorsToDiagnostics.ts` временно оставить параметр `_schema?: ValidationSchemaValidator` без generic; Task 2 удалит его полностью.
+
+- [ ] **Step 5: Проверить узкий договор**
+
+Run:
+
+```bash
+pnpm --filter @nkdk/core exec vitest run metadata/validation/compileValidationSchema.test.ts metadata/validation/projectValidationStandaloneLoader.test.ts metadata/validation/projectValidationPasses.test.ts metadata/validation/validateFile.test.ts
+pnpm --filter @nkdk/core type-check
+```
+
+Expected: все выбранные тесты PASS, `tsc --noEmit` завершается с кодом 0.
+
+- [ ] **Step 6: Зафиксировать удаление legacy API**
+
+```bash
+git add packages/core/metadata/validation/compileValidationSchema.ts packages/core/metadata/validation/compileValidationSchema.test.ts packages/core/metadata/validation/schemaRegistry.test.ts packages/core/metadata/validation/projectValidationPasses.ts packages/core/metadata/validation/projectValidationPasses.test.ts packages/core/metadata/validation/schemaCache.ts packages/core/metadata/validation/validateFile.ts packages/core/metadata/validation/validateFile.test.ts packages/core/metadata/validation/validateItem.ts packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts packages/core/metadata/validation/projectValidationStandaloneLoader.ts packages/core/metadata/validation/projectValidationStandaloneLoader.test.ts
+git commit -m "refactor!: :recycle: удалить legacy-договор validation schema" -m "BREAKING CHANGE: ValidationSchemaValidator больше не предоставляет Schema() и Context(); createValidationSchemaFromAjvFunction принимает готовую ValidateFunction."
+```
+
+---
+
+### Task 2: Удалить неиспользуемые schema/value из ошибок
+
+**Files:**
+- Modify: `packages/core/metadata/validation/compileValidationSchema.ts`
+- Modify: `packages/core/metadata/validation/compileValidationSchema.test.ts`
+- Modify: `packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts`
+- Modify: `packages/core/metadata/validation/validateFile.ts`
+- Test: `packages/core/metadata/validation/validateFile.test.ts`
+
+**Interfaces:**
+- Consumes: Ajv `ErrorObject` с compact fields.
+- Produces: `ValidationSchemaError`/`ValidationError` без `schema` и `value`; неизменные `Diagnostic.line`, `col`, `path`, `message`.
+
+- [ ] **Step 1: Добавить падающую проверку compact normalized errors**
+
+В `compileValidationSchema.test.ts` после получения ошибки добавить:
+
+```ts
+expect(Object.keys(errors[0] ?? {}).sort()).toEqual([
+  "instancePath",
+  "keyword",
+  "message",
+  "params",
+  "schemaPath",
+])
+```
+
+Тест защищает нормализованный договор, а не внутренний текст сгенерированного кода.
+
+- [ ] **Step 2: Убедиться, что проверка ловит старые поля**
+
+Run:
+
+```bash
+pnpm --filter @nkdk/core exec vitest run metadata/validation/compileValidationSchema.test.ts
+```
+
+Expected: FAIL; фактические ключи дополнительно содержат `schema` и `value`.
+
+- [ ] **Step 3: Удалить лишние ссылки из ошибок**
+
+В `ValidationSchemaError` и `ValidationError` удалить:
+
+```ts
+schema?: TSchema
+value?: unknown
+```
+
+В `normalizeAjvError` оставить:
+
+```ts
+return {
+  keyword: error.keyword,
+  schemaPath: error.schemaPath,
+  instancePath: error.instancePath,
+  params: error.params as Record<string, unknown>,
+  message: error.message ?? error.keyword,
+}
+```
+
+Удалить импорты `TSchema` и неиспользуемый параметр `_schema` из `typeboxErrorsToDiagnostics`.
+
+В `validateFile.ts` заменить создание копий ошибок на прямой вызов:
+
+```ts
+if (!valid) return typeboxErrorsToDiagnostics(errors, parsed, filePath)
+```
+
+- [ ] **Step 4: Проверить compact errors и позиции YAML**
+
+Run:
+
+```bash
+pnpm --filter @nkdk/core exec vitest run metadata/validation/compileValidationSchema.test.ts metadata/validation/validateFile.test.ts
+```
+
+Expected: PASS, включая существующие проверки:
+
+- `line: 3, col: 9, path: "/Лишнее"`;
+- `line: 7, col: 20, path: "/Элементы/Группа1/Элементы/Надпись1/Заголовок"`;
+- required property на родительском узле.
+
+- [ ] **Step 5: Зафиксировать компактный договор ошибок**
+
+```bash
+git add packages/core/metadata/validation/compileValidationSchema.ts packages/core/metadata/validation/compileValidationSchema.test.ts packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts packages/core/metadata/validation/validateFile.ts packages/core/metadata/validation/validateFile.test.ts
+git commit -m "perf: :zap: убрать лишние данные ошибок validation"
+```
+
+---
+
+### Task 3: Выпустить строгий functions-only standalone v3
+
+**Files:**
+- Modify: `packages/core/metadata/validation/generateProjectValidationAjvStandalone.ts`
+- Modify: `packages/core/metadata/validation/projectValidationStandaloneTypes.ts`
+- Modify: `packages/core/metadata/validation/projectValidationStandaloneLoader.ts`
+- Modify: `packages/core/metadata/validation/projectValidationStandaloneLoader.test.ts`
+- Modify: `packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts`
+- Modify: `packages/core/metadata/project/preparedYamlProjectWorker.ts`
+- Modify: `packages/core/metadata/validation/projectValidationWorkerSchemaCache.ts`
+- Modify temporarily: `packages/core/scripts/measure-standalone-import-memory.mjs`
+
+**Interfaces:**
+- Consumes: Ajv-generated `ValidateFunction` exports.
+- Produces: `ProjectValidationStandaloneModule` формата `project-validation-ajv-standalone-v3` только с `format`, `form`, `byItemType`.
+
+- [ ] **Step 1: Написать падающие тесты формата v3**
+
+В `projectValidationStandaloneLoader.test.ts` использовать модуль:
+
+```ts
+const module = {
+  format: "project-validation-ajv-standalone-v3",
+  form: { validate: validAny() },
+  byItemType: {
+    MetadataCatalog: { validate: validAny() },
+  },
+} satisfies ProjectValidationStandaloneModule
+```
+
+Заменить тест context mismatch на:
+
+```ts
+it("rejects obsolete standalone formats", () => {
+  expect(() =>
+    createValidationSchemaCacheFromStandaloneModule({
+      format: "project-validation-ajv-standalone-v2",
+    } as never)
+  ).toThrow("Unsupported standalone validation module format")
+})
+```
+
+В `projectValidationStandaloneBuild.test.ts` ожидать:
+
+```ts
+format: "project-validation-ajv-standalone-v3",
+moduleKeys: ["byItemType", "form", "format"],
+formKeys: ["validate"],
+configurationKeys: ["validate"],
+formErrorKeys: ["instancePath", "keyword", "message", "params", "schemaPath"],
+```
+
+Перед RED-проверкой выполнить текущую сборку, чтобы test действительно загрузил dist:
+
+```bash
+pnpm --filter @nkdk/core build
+pnpm --filter @nkdk/core exec vitest run metadata/validation/projectValidationStandaloneLoader.test.ts metadata/validation/projectValidationStandaloneBuild.test.ts
+```
+
+Expected: FAIL на `v3`/module keys, потому что текущий модуль ещё имеет формат `v2` и `context`.
+
+- [ ] **Step 2: Описать строгие типы v3**
+
+Заменить `projectValidationStandaloneTypes.ts` на договор:
+
+```ts
+import type { ValidateFunction } from "ajv"
+
+export interface ProjectValidationStandaloneValidator {
+  validate: ValidateFunction
+}
+
+export interface ProjectValidationStandaloneModule {
+  format: "project-validation-ajv-standalone-v3"
+  form: ProjectValidationStandaloneValidator
+  byItemType: Record<string, ProjectValidationStandaloneValidator>
+}
+```
+
+Не оставлять optional legacy-поля `schema`, `refs` или `context`.
+
+- [ ] **Step 3: Удалить исходные данные из generator output**
+
+В `generateProjectValidationAjvStandalone.ts`:
+
+- сохранить `schemaSet.context`, `refs`, form schema и item schemas только как вход генерации Ajv;
+- оставить `verbose: false`;
+- не хранить `schema` в `entries`;
+- сформировать:
+
+```ts
+const moduleCode = [
+  validatorsCode,
+  "",
+  "const module = {",
+  '  format: "project-validation-ajv-standalone-v3",',
+  "  form: { validate: validateForm },",
+  "  byItemType: {",
+  ...entries.map(
+    (entry) => `    ${JSON.stringify(entry.itemType)}: { validate: ${entry.exportName} },`
+  ),
+  "  },",
+  "}",
+  "",
+  "export default module",
+  "",
+].join("\n")
+```
+
+В output не должно быть `JSON.stringify(schemaSet.context)`, `JSON.stringify(refs)`, `JSON.stringify(formSchema)` или `JSON.stringify(entry.schema)`.
+
+- [ ] **Step 4: Упростить loader v3**
+
+В `projectValidationStandaloneLoader.ts`:
+
+- удалить `ConfigurationContext`, `assertStandaloneValidationContext`, `Type` и schema placeholder;
+- `createValidationSchemaCacheFromStandaloneModule(module)` принимает только module;
+- `loadProjectValidationStandaloneCache({ modulePath })` принимает только путь;
+- `createCompiledStandaloneValidator(validator)` вызывает `createValidationSchemaFromAjvFunction(validator.validate)`;
+- assert принимает только `project-validation-ajv-standalone-v3`.
+
+В `projectValidationWorkerSchemaCache.ts` compiled-ветка вызывает:
+
+```ts
+return loadProjectValidationStandaloneCache({ modulePath })
+```
+
+Параметр `context` функции сохраняется для source `.ts`-ветки, где выполняется runtime-компиляция.
+
+Одновременно удалить временное вложенное профилирование:
+
+- в `preparedYamlProjectWorker.ts` не передавать `profiler` в schema cache;
+- из `projectValidationWorkerSchemaCache.ts` удалить import `ValidationProfiler`, optional-параметр `profiler` и wrapper `measureAsync("Инициализация", "Загрузка standalone", ...)`.
+
+- [ ] **Step 5: Обновить незакоммиченный измеритель для финального замера v3**
+
+В `measure-standalone-import-memory.mjs` временно заменить ожидаемый format:
+
+```js
+if (result.format !== "project-validation-ajv-standalone-v3") {
+  // existing error
+}
+```
+
+Этот файл не добавлять в индекс: он не входит в постоянный результат и будет удалён в Task 4.
+
+- [ ] **Step 6: Собрать и проверить v3**
+
+Run:
+
+```bash
+pnpm --filter @nkdk/core build
+pnpm --filter @nkdk/core exec vitest run metadata/validation/projectValidationStandaloneLoader.test.ts metadata/validation/projectValidationStandaloneBuild.test.ts
+pnpm --filter @nkdk/core type-check
+```
+
+Expected: build exit 0, все выбранные loader/build tests PASS, type-check exit 0.
+
+- [ ] **Step 7: Зафиксировать v3**
+
+```bash
+git add packages/core/metadata/validation/generateProjectValidationAjvStandalone.ts packages/core/metadata/validation/projectValidationStandaloneTypes.ts packages/core/metadata/validation/projectValidationStandaloneLoader.ts packages/core/metadata/validation/projectValidationStandaloneLoader.test.ts packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts packages/core/metadata/project/preparedYamlProjectWorker.ts packages/core/metadata/validation/projectValidationWorkerSchemaCache.ts
+git commit -m "perf!: :zap: выпустить functions-only standalone validation v3" -m "BREAKING CHANGE: project-validation-ajv-standalone-v3 больше не экспортирует context, refs и schema; loader принимает только v3."
+```
+
+---
+
+### Task 4: Выполнить финальный замер и удалить временную диагностику
+
+**Files:**
+- Delete: `packages/core/scripts/measure-standalone-import-memory.mjs`
+- Verify: all files changed by Tasks 1–3.
+
+**Interfaces:**
+- Consumes: собранный standalone v3 и штатный validation profile.
+- Produces: постоянный production-код без временных измерителей; подтверждённый test/build result.
+
+- [ ] **Step 1: Выполнить последний изолированный замер**
+
+Свежая сборка обязательна:
+
+```bash
+pnpm --filter @nkdk/core build
+node --expose-gc packages/core/scripts/measure-standalone-import-memory.mjs --runs 5
+```
+
+Записать в итоговый отчёт размер standalone, RSS первого импорта, медианы `heapUsed`, `external` и времени импорта. Не добавлять численные значения в тесты.
+
+- [ ] **Step 2: Проверить готовность реального YAML-каталога**
+
+Run:
+
+```bash
+rg --files /Users/nikita/git/nkdk-yaml/cf -g '*.yaml'
+```
+
+Expected: список непустой перед заявлением о полноценной validation.
+
+Если список пуст, не запускать и не интерпретировать full-project benchmark; явно указать, что финальный изолированный замер выполнен, а проверка реального каталога ожидает завершения импорта.
+
+Если список непуст, после свежей сборки выполнить:
+
+```bash
+pnpm --filter @nkdk/core build
+node .agents/skills/validation-profile/validation-profile.mjs /Users/nikita/git/nkdk-yaml --runs 1 --timing
+```
+
+Expected: compiled standalone mode, ненулевое число обработанных YAML в profile и отсутствие новых диагностик относительно baseline каталога.
+
+- [ ] **Step 3: Удалить временный memory-скрипт**
+
+Удалить файл:
+
+```text
+packages/core/scripts/measure-standalone-import-memory.mjs
+```
+
+- [ ] **Step 4: Выполнить сфокусированную проверку**
+
+Run:
+
+```bash
+pnpm --filter @nkdk/core build
+pnpm --filter @nkdk/core exec vitest run metadata/validation/compileValidationSchema.test.ts metadata/validation/projectValidationStandaloneLoader.test.ts metadata/validation/projectValidationStandaloneBuild.test.ts metadata/validation/projectValidationPasses.test.ts metadata/validation/validateFile.test.ts
+pnpm --filter @nkdk/core type-check
+```
+
+Expected: build, выбранные тесты и type-check завершаются с кодом 0.
+
+- [ ] **Step 5: Выполнить полную проверку проекта**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: все пакеты `packages/*` проходят без ошибок.
+
+- [ ] **Step 6: Проверить границы diff**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected:
+
+- временный memory-скрипт отсутствует;
+- в `preparedYamlProjectWorker.ts` и `projectValidationWorkerSchemaCache.ts` нет временного profiler plumbing;
+- посторонние изменения `localIndexes.ts`, `yamlFactExtractor.ts`, `yamlFactExtractor.test.ts` сохранены и не включены в staged diff задачи.

--- a/packages/core/metadata/appliedObjects/__tests__/externalSync.test.ts
+++ b/packages/core/metadata/appliedObjects/__tests__/externalSync.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs"
 import os from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
-import { describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { testSyncAppliedObjectToXML } from "../../../tests/appliedObject"
 import { mockContextToXML } from "../../../tests/mockContext"
 import { XmlSyncManifest } from "../configuration/migrations/xmlManifest"
@@ -24,6 +24,23 @@ import type { FullXmlSyncAssignment } from "../../fullSyncToXml/types"
 const normalizeText = (value: string) => value.replace(/\r\n/g, "\n")
 
 describe("единая синхронизация внешних файлов applied objects", () => {
+  let businessProcessComparisons: Awaited<ReturnType<typeof testSyncAppliedObjectToXML>>["comparisons"]
+
+  beforeAll(async () => {
+    const prepared = await testSyncAppliedObjectToXML({
+      rule: MetadataBusinessProcessRules,
+      name: "БизнесПроцессВсеСвойства",
+      importMetaUrl: import.meta.resolve("../metadataBusinessProcess/rules.ts"),
+      externalObjectDir: true,
+      expectedFiles: [
+        "БизнесПроцессВсеСвойства/Ext/ObjectModule.bsl",
+        "БизнесПроцессВсеСвойства/Ext/ManagerModule.bsl",
+        "БизнесПроцессВсеСвойства/Ext/Flowchart.xml",
+      ],
+    })
+    businessProcessComparisons = prepared.comparisons
+  })
+
   it("читает запрос динамического списка встроенной общей формы из каталога объекта", () => {
     const root = fs.mkdtempSync(join(os.tmpdir(), "common-form-query-"))
     try {
@@ -87,20 +104,8 @@ describe("единая синхронизация внешних файлов ap
     }
   })
 
-  it("восстанавливает модули и карту маршрута бизнес-процесса", async () => {
-    const { comparisons } = await testSyncAppliedObjectToXML({
-      rule: MetadataBusinessProcessRules,
-      name: "БизнесПроцессВсеСвойства",
-      importMetaUrl: import.meta.resolve("../metadataBusinessProcess/rules.ts"),
-      externalObjectDir: true,
-      expectedFiles: [
-        "БизнесПроцессВсеСвойства/Ext/ObjectModule.bsl",
-        "БизнесПроцессВсеСвойства/Ext/ManagerModule.bsl",
-        "БизнесПроцессВсеСвойства/Ext/Flowchart.xml",
-      ],
-    })
-
-    for (const { path, result, expected } of comparisons) {
+  it("восстанавливает модули и карту маршрута бизнес-процесса", () => {
+    for (const { path, result, expected } of businessProcessComparisons) {
       expect(normalizeText(result), path).toBe(normalizeText(expected))
     }
   })

--- a/packages/core/metadata/appliedObjects/configuration/convertFromXML.test.ts
+++ b/packages/core/metadata/appliedObjects/configuration/convertFromXML.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
 import os from "os"
 import { join } from "path"
-import { afterAll, beforeEach, describe, expect, it } from "vitest"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { mockContextFromXML } from "../../../tests/mockContext"
 import { readXMLFileAsString } from "../../../tests/readAndParseXMLFile"
 import { createXmlImportWorkerTestPool } from "../../../tests/xmlImportWorkerTestPool"
@@ -47,6 +47,131 @@ describe("sync configuration from xml", () => {
 \t</RightColumn>
 \t<MACommandInterfaceDisplays>Top</MACommandInterfaceDisplays>
 </HomePageWorkArea>`
+  let rootExternalFiles: {
+    managedApplicationModule: string
+    sessionModule: string
+    externalConnectionModule: string
+    ordinaryApplicationModule: string
+    mobileClientSignature: number[]
+    helpPage: string
+    helpPicture: number[]
+    mainSectionPictureXml: string
+    mainSectionPicture: string
+    logoXml: string
+    logoPicture: number[]
+    splashXml: string
+    splashPicture: number[]
+    standaloneConfigurationContent: number[]
+    configurationYaml: string
+  }
+  let primaryImport: {
+    result: Awaited<ReturnType<typeof syncConfigurationFromXMLForTest>>
+    formYaml: string
+    catalogYaml: string
+    hasDocument: boolean
+    hasNumerator: boolean
+    hasSequence: boolean
+    snapshot: Awaited<ReturnType<typeof readConfigurationIndex>>
+    operationTempExists: boolean
+  }
+
+  beforeAll(async () => {
+    const tmp = fs.mkdtempSync(join(os.tmpdir(), "nkdk-root-external-from-xml-"))
+    const rootInput = join(tmp, "xml")
+    const rootProject = join(tmp, "project")
+    const rootOutput = join(rootProject, "cf")
+    const managedApplicationModule = "Процедура ПриНачалеРаботыСистемы()\nКонецПроцедуры\n"
+    const sessionModule = "Процедура ПриНачалеСеанса()\nКонецПроцедуры\n"
+    const externalConnectionModule = "Процедура ПриНачалеРаботыСистемы()\nКонецПроцедуры\n"
+    const ordinaryApplicationModule = "Процедура ПередНачаломРаботыСистемы()\nКонецПроцедуры\n"
+    const helpPage = "<html><body>Справка</body></html>"
+
+    try {
+      fs.mkdirSync(join(rootInput, "Ext", "Help", "_files"), { recursive: true })
+      fs.mkdirSync(join(rootInput, "Ext", "Logo"), { recursive: true })
+      fs.mkdirSync(join(rootInput, "Ext", "MainSectionPicture"), { recursive: true })
+      fs.mkdirSync(join(rootInput, "Ext", "Splash"), { recursive: true })
+      fs.copyFileSync(join(__dirname, "__fixtures__/minimal.xml"), join(rootInput, CONFIGURATION_XML_FILE))
+      fs.writeFileSync(join(rootInput, "Ext", "ManagedApplicationModule.bsl"), managedApplicationModule, "utf-8")
+      fs.writeFileSync(join(rootInput, "Ext", "SessionModule.bsl"), sessionModule, "utf-8")
+      fs.writeFileSync(join(rootInput, "Ext", "ExternalConnectionModule.bsl"), externalConnectionModule, "utf-8")
+      fs.writeFileSync(join(rootInput, "Ext", "OrdinaryApplicationModule.bsl"), ordinaryApplicationModule, "utf-8")
+      fs.writeFileSync(join(rootInput, "Ext", "MobileClientSignature.bin"), Buffer.from([0, 1, 2, 255]))
+      fs.writeFileSync(
+        join(rootInput, "Ext", "Help.xml"),
+        `<?xml version="1.0" encoding="UTF-8"?>\n<Help xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">\n\t<Page>ru</Page>\n</Help>`,
+        "utf-8"
+      )
+      fs.writeFileSync(join(rootInput, "Ext", "Help", "ru.html"), helpPage, "utf-8")
+      fs.writeFileSync(join(rootInput, "Ext", "Help", "_files", "logo.png"), Buffer.from([137, 80]))
+      fs.writeFileSync(join(rootInput, "Ext", "MainSectionPicture.xml"), "<MainSectionPicture/>", "utf-8")
+      fs.writeFileSync(join(rootInput, "Ext", "MainSectionPicture", "Picture.svg"), "<svg/>", "utf-8")
+      fs.writeFileSync(join(rootInput, "Ext", "Logo.xml"), "<Logo/>", "utf-8")
+      fs.writeFileSync(join(rootInput, "Ext", "Logo", "Picture.png"), Buffer.from([1, 2, 3]))
+      fs.writeFileSync(join(rootInput, "Ext", "Splash.xml"), "<Splash/>", "utf-8")
+      fs.writeFileSync(join(rootInput, "Ext", "Splash", "Picture.png"), Buffer.from([137, 80, 78, 71]))
+      fs.writeFileSync(join(rootInput, "Ext", "StandaloneConfigurationContent.bin"), Buffer.from([4, 5, 6]))
+
+      await syncConfigurationFromXMLForTest({
+        context: mockContextFromXML(),
+        inputDir: rootInput,
+        projectDir: rootProject,
+      })
+
+      rootExternalFiles = {
+        managedApplicationModule: fs.readFileSync(join(rootOutput, "МодульПриложения.bsl"), "utf-8"),
+        sessionModule: fs.readFileSync(join(rootOutput, "МодульСеанса.bsl"), "utf-8"),
+        externalConnectionModule: fs.readFileSync(join(rootOutput, "МодульВнешнегоСоединения.bsl"), "utf-8"),
+        ordinaryApplicationModule: fs.readFileSync(join(rootOutput, "МодульОбычногоПриложения.bsl"), "utf-8"),
+        mobileClientSignature: [...fs.readFileSync(join(rootOutput, "ПодписьМобильногоКлиента.bin"))],
+        helpPage: fs.readFileSync(join(rootOutput, "Справка", "ru.html"), "utf-8"),
+        helpPicture: [...fs.readFileSync(join(rootOutput, "Справка", "_files", "logo.png"))],
+        mainSectionPictureXml: fs.readFileSync(
+          join(rootOutput, "КартинкаОсновногоРаздела", "MainSectionPicture.xml"),
+          "utf-8"
+        ),
+        mainSectionPicture: fs.readFileSync(
+          join(rootOutput, "КартинкаОсновногоРаздела", "Picture.svg"),
+          "utf-8"
+        ),
+        logoXml: fs.readFileSync(join(rootOutput, "Логотип", "Logo.xml"), "utf-8"),
+        logoPicture: [...fs.readFileSync(join(rootOutput, "Логотип", "Picture.png"))],
+        splashXml: fs.readFileSync(join(rootOutput, "Заставка", "Splash.xml"), "utf-8"),
+        splashPicture: [...fs.readFileSync(join(rootOutput, "Заставка", "Picture.png"))],
+        standaloneConfigurationContent: [
+          ...fs.readFileSync(join(rootOutput, "СодержимоеАвтономнойКонфигурации.bin")),
+        ],
+        configurationYaml: fs.readFileSync(join(rootOutput, CONFIGURATION_YAML_FILE), "utf-8"),
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+
+    fs.rmSync(inputDir, { recursive: true, force: true })
+    fs.rmSync(projectDir, { recursive: true, force: true })
+    fs.cpSync(sourceInputDir, inputDir, { recursive: true })
+    fs.copyFileSync(join(__dirname, "__fixtures__/minimal.xml"), join(inputDir, CONFIGURATION_XML_FILE))
+    const operationId = "fixture-import"
+    const result = await syncConfigurationFromXMLForTest({
+      context: mockContextFromXML(),
+      inputDir,
+      projectDir,
+      operationId,
+    })
+    primaryImport = {
+      result,
+      formYaml: fs.readFileSync(
+        join(outputDir, "Справочник", "Контрагенты", "Формы", "ФормаЭлемента", "Форма.yaml"),
+        "utf-8"
+      ),
+      catalogYaml: fs.readFileSync(join(outputDir, "Справочник", "Контрагенты", "Свойства.yaml"), "utf-8"),
+      hasDocument: fs.existsSync(join(outputDir, "Документ", "ДокументПоУмолчанию", "Свойства.yaml")),
+      hasNumerator: fs.existsSync(join(outputDir, "Нумератор", "НумераторПоУмолчанию", "Свойства.yaml")),
+      hasSequence: fs.existsSync(join(outputDir, "Последовательность", "ПоследовательностьПоУмолчанию", "Свойства.yaml")),
+      snapshot: await readConfigurationIndex({ projectDir, address: { kind: "configuration" } }),
+      operationTempExists: fs.existsSync(join(projectDir, ".nkdk", "tmp", "import", operationId)),
+    }
+  })
 
   afterAll(async () => {
     await xmlImportWorkerPoolHandle.close()
@@ -61,16 +186,7 @@ describe("sync configuration from xml", () => {
     fs.copyFileSync(join(__dirname, "__fixtures__/minimal.xml"), join(inputDir, CONFIGURATION_XML_FILE))
   })
 
-  it("should produce catalog and form YAML in output dir", async () => {
-    const operationId = "fixture-import"
-
-    const result = await syncConfigurationFromXMLForTest({
-      context: mockContextFromXML(),
-      inputDir,
-      projectDir,
-      operationId,
-    })
-
+  it("should produce catalog and form YAML in output dir", () => {
     const expectedFormYaml = readXMLFileAsString(
       join("sync/syncConfiguration/yaml/Справочник/Контрагенты/Формы/ФормаЭлемента", "Форма.yaml")
     )
@@ -79,44 +195,41 @@ describe("sync configuration from xml", () => {
       join("sync/syncConfiguration/yaml/Справочник/Контрагенты", "Свойства.yaml")
     )
 
-    const resultFormYaml = fs.readFileSync(
-      join(outputDir, "Справочник", "Контрагенты", "Формы", "ФормаЭлемента", "Форма.yaml"),
-      "utf-8"
-    )
-    const resultCatalogYaml = fs.readFileSync(join(outputDir, "Справочник", "Контрагенты", "Свойства.yaml"), "utf-8")
-
-    expect(resultCatalogYaml).toBe(expectedCatalogYaml)
-    expect(resultFormYaml).toBe(expectedFormYaml)
-    expect(fs.existsSync(join(outputDir, "Документ", "ДокументПоУмолчанию", "Свойства.yaml"))).toBe(true)
-    expect(fs.existsSync(join(outputDir, "Нумератор", "НумераторПоУмолчанию", "Свойства.yaml"))).toBe(true)
-    expect(fs.existsSync(join(outputDir, "Последовательность", "ПоследовательностьПоУмолчанию", "Свойства.yaml"))).toBe(
-      true
-    )
-    expect(result.failed).toEqual([])
-    expect(result.warnings).toEqual([])
-    const snapshot = await readConfigurationIndex({ projectDir, address: { kind: "configuration" } })
-    expect(snapshot).toMatchObject({
+    expect(primaryImport.catalogYaml).toBe(expectedCatalogYaml)
+    expect(primaryImport.formYaml).toBe(expectedFormYaml)
+    expect(primaryImport.hasDocument).toBe(true)
+    expect(primaryImport.hasNumerator).toBe(true)
+    expect(primaryImport.hasSequence).toBe(true)
+    expect(primaryImport.result.failed).toEqual([])
+    expect(primaryImport.result.warnings).toEqual([])
+    expect(primaryImport.snapshot).toMatchObject({
       specificationVersion: "1.3",
       componentPath: "cf",
       indexGeneration: 1n,
     })
-    expect(snapshot.entities.find(({ logicalAddress }) => logicalAddress === "Справочник.Контрагенты")).toMatchObject({
+    expect(
+      primaryImport.snapshot.entities.find(({ logicalAddress }) => logicalAddress === "Справочник.Контрагенты")
+    ).toMatchObject({
       sourceProjectPath: "Справочник/Контрагенты/Свойства.yaml",
     })
     expect(
-      snapshot.entities.find(({ logicalAddress }) => logicalAddress === "Справочник.Контрагенты.Форма.ФормаЭлемента")
+      primaryImport.snapshot.entities.find(
+        ({ logicalAddress }) => logicalAddress === "Справочник.Контрагенты.Форма.ФормаЭлемента"
+      )
     ).toMatchObject({
       sourceProjectPath: "Справочник/Контрагенты/Формы/ФормаЭлемента/Форма.yaml",
     })
     expect(
-      snapshot.entities.every((entity) => snapshot.files.some((file) => file.projectPath === entity.sourceProjectPath))
+      primaryImport.snapshot.entities.every((entity) =>
+        primaryImport.snapshot.files.some((file) => file.projectPath === entity.sourceProjectPath)
+      )
     ).toBe(true)
     expect(
-      snapshot.entities.every(
+      primaryImport.snapshot.entities.every(
         (entity) => entity.identities !== undefined || entity.omittedChildren !== undefined || entity.xml !== undefined
       )
     ).toBe(true)
-    expect(fs.existsSync(join(projectDir, ".nkdk", "tmp", "import", operationId))).toBe(false)
+    expect(primaryImport.operationTempExists).toBe(false)
   })
 
   it("не падает на дампе без некоторых корневых разделов", async () => {
@@ -211,68 +324,27 @@ describe("sync configuration from xml", () => {
     }
   })
 
-  it("сохраняет простые корневые внешние файлы конфигурации", async () => {
-    const tmp = fs.mkdtempSync(join(os.tmpdir(), "nkdk-root-external-from-xml-"))
-    const rootInput = join(tmp, "xml")
-    const rootProject = join(tmp, "project")
-    const rootOutput = join(rootProject, "cf")
+  it("сохраняет простые корневые внешние файлы конфигурации", () => {
     const managedApplicationModule = "Процедура ПриНачалеРаботыСистемы()\nКонецПроцедуры\n"
     const sessionModule = "Процедура ПриНачалеСеанса()\nКонецПроцедуры\n"
     const externalConnectionModule = "Процедура ПриНачалеРаботыСистемы()\nКонецПроцедуры\n"
     const ordinaryApplicationModule = "Процедура ПередНачаломРаботыСистемы()\nКонецПроцедуры\n"
     const helpPage = "<html><body>Справка</body></html>"
 
-    try {
-      fs.mkdirSync(join(rootInput, "Ext", "Help", "_files"), { recursive: true })
-      fs.mkdirSync(join(rootInput, "Ext", "Logo"), { recursive: true })
-      fs.mkdirSync(join(rootInput, "Ext", "MainSectionPicture"), { recursive: true })
-      fs.mkdirSync(join(rootInput, "Ext", "Splash"), { recursive: true })
-      fs.copyFileSync(join(__dirname, "__fixtures__/minimal.xml"), join(rootInput, CONFIGURATION_XML_FILE))
-      fs.writeFileSync(join(rootInput, "Ext", "ManagedApplicationModule.bsl"), managedApplicationModule, "utf-8")
-      fs.writeFileSync(join(rootInput, "Ext", "SessionModule.bsl"), sessionModule, "utf-8")
-      fs.writeFileSync(join(rootInput, "Ext", "ExternalConnectionModule.bsl"), externalConnectionModule, "utf-8")
-      fs.writeFileSync(join(rootInput, "Ext", "OrdinaryApplicationModule.bsl"), ordinaryApplicationModule, "utf-8")
-      fs.writeFileSync(join(rootInput, "Ext", "MobileClientSignature.bin"), Buffer.from([0, 1, 2, 255]))
-      fs.writeFileSync(
-        join(rootInput, "Ext", "Help.xml"),
-        `<?xml version="1.0" encoding="UTF-8"?>\n<Help xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">\n\t<Page>ru</Page>\n</Help>`,
-        "utf-8"
-      )
-      fs.writeFileSync(join(rootInput, "Ext", "Help", "ru.html"), helpPage, "utf-8")
-      fs.writeFileSync(join(rootInput, "Ext", "Help", "_files", "logo.png"), Buffer.from([137, 80]))
-      fs.writeFileSync(join(rootInput, "Ext", "MainSectionPicture.xml"), "<MainSectionPicture/>", "utf-8")
-      fs.writeFileSync(join(rootInput, "Ext", "MainSectionPicture", "Picture.svg"), "<svg/>", "utf-8")
-      fs.writeFileSync(join(rootInput, "Ext", "Logo.xml"), "<Logo/>", "utf-8")
-      fs.writeFileSync(join(rootInput, "Ext", "Logo", "Picture.png"), Buffer.from([1, 2, 3]))
-      fs.writeFileSync(join(rootInput, "Ext", "Splash.xml"), "<Splash/>", "utf-8")
-      fs.writeFileSync(join(rootInput, "Ext", "Splash", "Picture.png"), Buffer.from([137, 80, 78, 71]))
-      fs.writeFileSync(join(rootInput, "Ext", "StandaloneConfigurationContent.bin"), Buffer.from([4, 5, 6]))
-
-      await syncConfigurationFromXMLForTest({
-        context: mockContextFromXML(),
-        inputDir: rootInput,
-        projectDir: rootProject,
-      })
-
-      expect(fs.readFileSync(join(rootOutput, "МодульПриложения.bsl"), "utf-8")).toBe(managedApplicationModule)
-      expect(fs.readFileSync(join(rootOutput, "МодульСеанса.bsl"), "utf-8")).toBe(sessionModule)
-      expect(fs.readFileSync(join(rootOutput, "МодульВнешнегоСоединения.bsl"), "utf-8")).toBe(externalConnectionModule)
-      expect(fs.readFileSync(join(rootOutput, "МодульОбычногоПриложения.bsl"), "utf-8")).toBe(ordinaryApplicationModule)
-      expect([...fs.readFileSync(join(rootOutput, "ПодписьМобильногоКлиента.bin"))]).toEqual([0, 1, 2, 255])
-      expect(fs.readFileSync(join(rootOutput, "Справка", "ru.html"), "utf-8")).toBe(helpPage)
-      expect([...fs.readFileSync(join(rootOutput, "Справка", "_files", "logo.png"))]).toEqual([137, 80])
-      expect(fs.readFileSync(join(rootOutput, "КартинкаОсновногоРаздела", "MainSectionPicture.xml"), "utf-8")).toBe(
-        "<MainSectionPicture/>"
-      )
-      expect(fs.readFileSync(join(rootOutput, "КартинкаОсновногоРаздела", "Picture.svg"), "utf-8")).toBe("<svg/>")
-      expect(fs.readFileSync(join(rootOutput, "Логотип", "Logo.xml"), "utf-8")).toBe("<Logo/>")
-      expect([...fs.readFileSync(join(rootOutput, "Логотип", "Picture.png"))]).toEqual([1, 2, 3])
-      expect(fs.readFileSync(join(rootOutput, "Заставка", "Splash.xml"), "utf-8")).toBe("<Splash/>")
-      expect([...fs.readFileSync(join(rootOutput, "Заставка", "Picture.png"))]).toEqual([137, 80, 78, 71])
-      expect([...fs.readFileSync(join(rootOutput, "СодержимоеАвтономнойКонфигурации.bin"))]).toEqual([4, 5, 6])
-      expect(fs.readFileSync(join(rootOutput, CONFIGURATION_YAML_FILE), "utf-8")).not.toContain("МодульПриложения")
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true })
-    }
+    expect(rootExternalFiles.managedApplicationModule).toBe(managedApplicationModule)
+    expect(rootExternalFiles.sessionModule).toBe(sessionModule)
+    expect(rootExternalFiles.externalConnectionModule).toBe(externalConnectionModule)
+    expect(rootExternalFiles.ordinaryApplicationModule).toBe(ordinaryApplicationModule)
+    expect(rootExternalFiles.mobileClientSignature).toEqual([0, 1, 2, 255])
+    expect(rootExternalFiles.helpPage).toBe(helpPage)
+    expect(rootExternalFiles.helpPicture).toEqual([137, 80])
+    expect(rootExternalFiles.mainSectionPictureXml).toBe("<MainSectionPicture/>")
+    expect(rootExternalFiles.mainSectionPicture).toBe("<svg/>")
+    expect(rootExternalFiles.logoXml).toBe("<Logo/>")
+    expect(rootExternalFiles.logoPicture).toEqual([1, 2, 3])
+    expect(rootExternalFiles.splashXml).toBe("<Splash/>")
+    expect(rootExternalFiles.splashPicture).toEqual([137, 80, 78, 71])
+    expect(rootExternalFiles.standaloneConfigurationContent).toEqual([4, 5, 6])
+    expect(rootExternalFiles.configurationYaml).not.toContain("МодульПриложения")
   })
 })

--- a/packages/core/metadata/appliedObjects/metadataExchangePlan/syncToXML.test.ts
+++ b/packages/core/metadata/appliedObjects/metadataExchangePlan/syncToXML.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
 import os from "os"
 import { join } from "path"
-import { describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { syncAppliedObjectToXML } from "../../orchestration/appliedObject/syncToXML"
 import { testSyncAppliedObjectToXML } from "../../../tests/appliedObject"
 import { mockContextToXML } from "../../../tests/mockContext"
@@ -12,8 +12,10 @@ import { canonicalFormSyncXML } from "../../../tests/formSyncXML"
 const normalizeLineEndings = (value: string) => value.replace(/\r\n/g, "\n")
 
 describe("syncAppliedObjectToXML — MetadataExchangePlan", () => {
-  it("читает ExchangePlan из YAML и записывает XML в outputDir", async () => {
-    const { inputDir, comparisons } = await testSyncAppliedObjectToXML({
+  let preparedExchangePlan: Awaited<ReturnType<typeof testSyncAppliedObjectToXML>>
+
+  beforeAll(async () => {
+    preparedExchangePlan = await testSyncAppliedObjectToXML({
       rule: MetadataExchangePlanRules,
       name: "ПланОбменаВсеСвойства",
       importMetaUrl: import.meta.url,
@@ -40,6 +42,10 @@ describe("syncAppliedObjectToXML — MetadataExchangePlan", () => {
         "ПланОбменаВсеСвойства/Templates/Макет/Ext/Template.txt",
       ],
     })
+  })
+
+  it("читает ExchangePlan из YAML и записывает XML в outputDir", () => {
+    const { inputDir, comparisons } = preparedExchangePlan
     for (const { path, result, expected } of comparisons) {
       if (path.endsWith("/Ext/Form.xml")) {
         const form = canonicalFormSyncXML({ path, result, expected, inputDir })

--- a/packages/core/metadata/appliedObjects/metadataInformationRegister/syncToXML.test.ts
+++ b/packages/core/metadata/appliedObjects/metadataInformationRegister/syncToXML.test.ts
@@ -2,7 +2,7 @@ import fs from "fs"
 import os from "os"
 import { dirname, join } from "path"
 import { fileURLToPath } from "url"
-import { describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { syncAppliedObjectToXML } from "../../orchestration/appliedObject/syncToXML"
 import { testSyncAppliedObjectToXML } from "../../../tests/appliedObject"
 import { mockContextToXML } from "../../../tests/mockContext"
@@ -17,8 +17,10 @@ const normalizeLineEndings = (value: string) =>
     .trimEnd()
 
 describe("syncAppliedObjectToXML — MetadataInformationRegister", () => {
-  it("читает InformationRegister из YAML и записывает XML в outputDir", async () => {
-    const { inputDir, comparisons } = await testSyncAppliedObjectToXML({
+  let preparedInformationRegister: Awaited<ReturnType<typeof testSyncAppliedObjectToXML>>
+
+  beforeAll(async () => {
+    preparedInformationRegister = await testSyncAppliedObjectToXML({
       rule: MetadataInformationRegisterRules,
       name: "РегистрСведенийВсеСвойстваНезависимый",
       importMetaUrl: import.meta.url,
@@ -38,6 +40,10 @@ describe("syncAppliedObjectToXML — MetadataInformationRegister", () => {
         "РегистрСведенийВсеСвойстваНезависимый/Templates/Макет.xml",
       ],
     })
+  })
+
+  it("читает InformationRegister из YAML и записывает XML в outputDir", () => {
+    const { inputDir, comparisons } = preparedInformationRegister
     for (const { path, result, expected } of comparisons) {
       if (path.endsWith("/Ext/Form.xml")) {
         const form = canonicalFormSyncXML({ path, result, expected, inputDir })
@@ -56,19 +62,20 @@ describe("syncAppliedObjectToXML — MetadataInformationRegister", () => {
     const fixturesDir = join(testDir, "__fixtures__", "sync")
     const tmpDir = fs.mkdtempSync(join(os.tmpdir(), "information-register-sync-modules-"))
     const inputDir = join(tmpDir, "yaml")
-    const referenceDir = join(tmpDir, "xml")
+    const referenceDir = join(fixturesDir, "xml")
     const outputDir = join(tmpDir, "out")
+    const inputObjectDir = join(inputDir, name)
     const managerModule =
       "Процедура ОбработкаПолученияДанныхВыбора(ДанныеВыбора, Параметры, СтандартнаяОбработка)\nКонецПроцедуры\n"
     const recordSetModule = "Процедура ПередЗаписью(Отказ, Замещение)\nКонецПроцедуры\n"
 
-    await fs.promises.cp(join(fixturesDir, "yaml"), inputDir, { recursive: true })
-    await fs.promises.cp(join(fixturesDir, "xml"), referenceDir, { recursive: true })
-    await fs.promises.writeFile(join(inputDir, name, "МодульМенеджера.bsl"), managerModule)
-    await fs.promises.writeFile(join(inputDir, name, "МодульНабораЗаписей.bsl"), recordSetModule)
-    await fs.promises.mkdir(join(referenceDir, name, "Ext"), { recursive: true })
-    await fs.promises.writeFile(join(referenceDir, name, "Ext", "ManagerModule.bsl"), managerModule)
-    await fs.promises.writeFile(join(referenceDir, name, "Ext", "RecordSetModule.bsl"), recordSetModule)
+    await fs.promises.mkdir(inputObjectDir, { recursive: true })
+    await fs.promises.copyFile(
+      join(fixturesDir, "yaml", name, "Свойства.yaml"),
+      join(inputObjectDir, "Свойства.yaml")
+    )
+    await fs.promises.writeFile(join(inputObjectDir, "МодульМенеджера.bsl"), managerModule)
+    await fs.promises.writeFile(join(inputObjectDir, "МодульНабораЗаписей.bsl"), recordSetModule)
 
     await syncAppliedObjectToXML({
       rule: MetadataInformationRegisterRules,

--- a/packages/core/metadata/commonObjects/childFormNames/syncExternalFromXML.test.ts
+++ b/packages/core/metadata/commonObjects/childFormNames/syncExternalFromXML.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs"
 import os from "node:os"
 import { dirname, join } from "node:path"
-import { afterAll, afterEach, describe, expect, it } from "vitest"
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
 import { mockContextFromXML } from "../../../tests/mockContext"
 import { getXMLFixturePath } from "../../../tests/readAndParseXMLFile"
 import { createXmlImportWorkerTestPool } from "../../../tests/xmlImportWorkerTestPool"
@@ -24,25 +24,9 @@ afterEach(async () => {
 describe("ChildFormNames: единый импорт XML → YAML", () => {
   const sourceDir = getXMLFixturePath("sync/syncConfiguration/xml")
   const name = "Контрагенты"
+  let localSettingsYaml: string
 
-  it("записывает Формы/<form>/Форма.yaml для каталога", async () => {
-    const inputDir = preparedInputDirectory(sourceDir)
-    const projectDir = temporaryDirectory("nkdk-child-form-project-")
-    const outputDir = join(projectDir, "cf")
-
-    const result = await importConfigurationFromXml({
-      context: mockContextFromXML(),
-      inputDir,
-      projectDir,
-      concurrency: 1,
-      xmlImportWorkerPoolHandle,
-    })
-
-    expect(result.failed).toEqual([])
-    expect(fs.existsSync(join(outputDir, "Справочник", name, "Формы", "ФормаЭлемента", "Форма.yaml"))).toBe(true)
-  })
-
-  it("экспортирует ссылку на текущую форму в настройках формы локальным именем", async () => {
+  beforeAll(async () => {
     const inputDir = temporaryDirectory("nkdk-child-form-input-")
     const projectDir = temporaryDirectory("nkdk-child-form-project-")
     const outputDir = join(projectDir, "cf")
@@ -67,10 +51,34 @@ describe("ChildFormNames: единый импорт XML → YAML", () => {
       concurrency: 1,
       xmlImportWorkerPoolHandle,
     })
+    if (result.failed.length > 0) {
+      throw new Error(`Не удалось подготовить импорт формы: ${JSON.stringify(result.failed)}`)
+    }
+    localSettingsYaml = fs.readFileSync(
+      join(outputDir, "Справочник", name, "Формы", "ФормаЭлемента", "Форма.yaml"),
+      "utf-8"
+    )
+  })
+
+  it("записывает Формы/<form>/Форма.yaml для каталога", async () => {
+    const inputDir = preparedInputDirectory(sourceDir)
+    const projectDir = temporaryDirectory("nkdk-child-form-project-")
+    const outputDir = join(projectDir, "cf")
+
+    const result = await importConfigurationFromXml({
+      context: mockContextFromXML(),
+      inputDir,
+      projectDir,
+      concurrency: 1,
+      xmlImportWorkerPoolHandle,
+    })
 
     expect(result.failed).toEqual([])
-    const yaml = fs.readFileSync(join(outputDir, "Справочник", name, "Формы", "ФормаЭлемента", "Форма.yaml"), "utf-8")
-    expect(yaml).toContain("ХранилищеНастроек: ФормаЭлемента")
+    expect(fs.existsSync(join(outputDir, "Справочник", name, "Формы", "ФормаЭлемента", "Форма.yaml"))).toBe(true)
+  })
+
+  it("экспортирует ссылку на текущую форму в настройках формы локальным именем", () => {
+    expect(localSettingsYaml).toContain("ХранилищеНастроек: ФормаЭлемента")
   })
 
   it("импортирует только страницы справки формы, перечисленные в Forms/<form>/Ext/Help.xml", async () => {

--- a/packages/core/metadata/fullSyncToXml/failureIntegration.test.ts
+++ b/packages/core/metadata/fullSyncToXml/failureIntegration.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs"
 import { join } from "node:path"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, beforeAll, describe, expect, it } from "vitest"
 import { encodeConfigurationIndex } from "../configurationIndex/encode"
 import {
   configurationIndexPath,
@@ -22,6 +22,9 @@ import {
 } from "./testHelpers"
 import { fullXmlSyncTestOutput } from "./testTopology"
 
+const fullSyncTopology = compileRegisteredMetadataResourceTopology()
+const emptyValidationMetadata = createSharedValidationSnapshot({ records: [], filePaths: [] })
+
 afterEach(async () => {
   await removeFullSyncTempDirs()
 })
@@ -32,6 +35,36 @@ describe("full XML sync failure integration", () => {
     defaultLanguage: "ru",
     exportToYAML: { toTyped: false },
   } as ConfigurationContext
+  let missingAdoptedUuidResult: Awaited<ReturnType<typeof syncComponentToXml>>
+  let workerStartedForMissingAdoptedUuid: boolean
+
+  beforeAll(async () => {
+    const state = await createIndexedProject()
+    workerStartedForMissingAdoptedUuid = false
+    const baseDeps = failureDeps(state.previous, state.projectDir, state.xmlDir)
+    const deps: FullXmlSyncCoordinatorDependencies = {
+      ...baseDeps,
+      resolveProfile: () => ({
+        kind: "configurationExtension",
+        supports: () => true,
+        baseAddress: () => ({ kind: "configuration" }),
+        confirm() {
+          throw new Error("Не найден UUID заимствованного элемента")
+        },
+      }),
+      createWorkerPool: () => {
+        workerStartedForMissingAdoptedUuid = true
+        throw new Error("worker must not be created")
+      },
+    }
+
+    missingAdoptedUuidResult = await syncComponentToXml({
+      context,
+      projectDir: state.projectDir,
+      componentPath: "cfe/Дополнение",
+      xmlDir: state.xmlDir,
+    }, deps)
+  })
 
   it("does not touch a non-empty XML target", async () => {
     const root = createTempRoot()
@@ -152,39 +185,13 @@ describe("full XML sync failure integration", () => {
     expect(fs.readFileSync(state.indexPath)).toEqual(before)
   })
 
-  it("does not start workers when cfe confirmation cannot find an adopted UUID", async () => {
-    const state = await createIndexedProject()
-    let workerCreated = false
-    const baseDeps = failureDeps(state.previous, state.projectDir, state.xmlDir)
-    const deps: FullXmlSyncCoordinatorDependencies = {
-      ...baseDeps,
-      resolveProfile: () => ({
-        kind: "configurationExtension",
-        supports: () => true,
-        baseAddress: () => ({ kind: "configuration" }),
-        confirm() {
-          throw new Error("Не найден UUID заимствованного элемента")
-        },
-      }),
-      createWorkerPool: () => {
-        workerCreated = true
-        throw new Error("worker must not be created")
-      },
-    }
-
-    const result = await syncComponentToXml({
-      context,
-      projectDir: state.projectDir,
-      componentPath: "cfe/Дополнение",
-      xmlDir: state.xmlDir,
-    }, deps)
-
-    expect(result.failed).toEqual([
+  it("does not start workers when cfe confirmation cannot find an adopted UUID", () => {
+    expect(missingAdoptedUuidResult.failed).toEqual([
       expect.objectContaining({
         message: "Не найден UUID заимствованного элемента",
       }),
     ])
-    expect(workerCreated).toBe(false)
+    expect(workerStartedForMissingAdoptedUuid).toBe(false)
   })
 })
 
@@ -231,8 +238,6 @@ function failureDeps(
   projectDir: string,
   xmlDir: string
 ): FullXmlSyncCoordinatorDependencies {
-  const topology = compileRegisteredMetadataResourceTopology()
-  const metadata = createSharedValidationSnapshot({ records: [], filePaths: [] })
   const deps: FullXmlSyncCoordinatorDependencies = {
     async exists(path) {
       return path === projectDir || path === xmlDir
@@ -248,7 +253,7 @@ function failureDeps(
         address,
         componentPath,
         componentDir: join(projectDir, componentPath),
-        topology,
+        topology: fullSyncTopology,
         resources: [],
         projectPaths: ["Конфигурация.yaml"],
       }
@@ -270,7 +275,7 @@ function failureDeps(
       return {
         componentPath: structure.componentPath,
         sourceProjectFiles: hashes.projectFiles,
-        metadata,
+        metadata: emptyValidationMetadata,
         dependencies: [],
         logicalAddresses: [],
       }

--- a/packages/core/metadata/project/localIndexes.ts
+++ b/packages/core/metadata/project/localIndexes.ts
@@ -34,12 +34,13 @@ export interface LocalIndexesCollector {
   finish(): LocalIndexes
 }
 
-export function createLocalIndexesCollector(): LocalIndexesCollector {
+export function createLocalIndexesCollector(options?: { recordEvents?: boolean }): LocalIndexesCollector {
   const events: LocalMetadataEvent[] = []
   const ownerFacts: Record<string, unknown> = {}
   const metadataTargets: LocalMetadataTargetFact[] = []
 
   const recordEvent = (kind: LocalMetadataEvent["kind"], fact: LocalYamlFact): void => {
+    if (options?.recordEvents === false) return
     events.push({
       kind,
       yamlPath: [...fact.yamlPath],

--- a/packages/core/metadata/project/preparedYamlProject.test.ts
+++ b/packages/core/metadata/project/preparedYamlProject.test.ts
@@ -386,7 +386,7 @@ describe("prepareYamlProject", () => {
       expect(first.diagnostics.filter((diagnostic) => diagnostic.severity === "error")).toEqual([])
       expect(first.components.flatMap(({ contribution }) => contribution.objectRecords)).toHaveLength(2)
       expect(first.yamlLifetime).toMatchObject({ current: 0, max: 1, parsed: 2 })
-      expect(first.yamlLifetime.propertyEvents).toBeGreaterThan(0)
+      expect(first.yamlLifetime.propertyEvents).toBe(0)
     },
     testTimeout
   )

--- a/packages/core/metadata/validation/compileValidationSchema.test.ts
+++ b/packages/core/metadata/validation/compileValidationSchema.test.ts
@@ -19,8 +19,6 @@ describe("compileValidationSchema", () => {
 
     expect(compiled.Check({ Имя: "Документ" })).toBe(true)
     expect(compiled.Check({ Лишнее: true })).toBe(false)
-    expect(compiled.Schema()).toBe(schema)
-
     const [, errors] = compiled.Errors({ Лишнее: true })
     expect(errors).toEqual([
       expect.objectContaining({
@@ -48,7 +46,6 @@ describe("compileValidationSchema", () => {
 
     expect(compiled.Check({ Значение: "ok" })).toBe(true)
     expect(compiled.Check({ Значение: 1 })).toBe(false)
-    expect(compiled.Context()).toBe(context)
   })
 
   it("compiles root schema against external nkdk refs", () => {
@@ -90,56 +87,15 @@ describe("compileValidationSchema", () => {
     expect(compiled.Check({ Значения: { Тест: { Значение: "ok" } } })).toBe(true)
   })
 
-  it("оборачивает готовую AJV-функцию в совместимый интерфейс валидатора", () => {
-    const schema = Type.Object({ Имя: Type.String() }, { additionalProperties: false })
+  it("wraps a standalone Ajv function without schema metadata", () => {
     const validate = Object.assign(
-      (value: unknown) => {
-        const record = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {}
-        if (typeof record.Имя === "string" && Object.keys(record).every((key) => key === "Имя")) {
-          validate.errors = null
-          return true
-        }
-
-        validate.errors = [
-          {
-            keyword: "required",
-            instancePath: "",
-            schemaPath: "#/required",
-            params: { missingProperty: "Имя" },
-            message: "must have required property 'Имя'",
-          },
-          {
-            keyword: "additionalProperties",
-            instancePath: "",
-            schemaPath: "#/additionalProperties",
-            params: { additionalProperty: "Лишнее" },
-            message: "must NOT have additional properties",
-          },
-        ]
-        return false
-      },
+      (value: unknown) => typeof value === "string",
       { errors: null as ValidateFunction["errors"] }
     ) as ValidateFunction
 
-    const compiled = createValidationSchemaFromAjvFunction({ schema, context: {}, validate })
+    const compiled = createValidationSchemaFromAjvFunction(validate)
 
-    expect(compiled.Check({ Имя: "Документ" })).toBe(true)
-    expect(compiled.Check({ Лишнее: true })).toBe(false)
-    expect(compiled.Schema()).toBe(schema)
-    expect(compiled.Context()).toEqual({})
-
-    const [, errors] = compiled.Errors({ Лишнее: true })
-    expect(errors).toEqual([
-      expect.objectContaining({
-        keyword: "required",
-        instancePath: "",
-        params: { missingProperty: "Имя" },
-      }),
-      expect.objectContaining({
-        keyword: "additionalProperties",
-        instancePath: "",
-        params: { additionalProperty: "Лишнее" },
-      }),
-    ])
+    expect(compiled.Check("ok")).toBe(true)
+    expect(compiled.Check(42)).toBe(false)
   })
 })

--- a/packages/core/metadata/validation/compileValidationSchema.test.ts
+++ b/packages/core/metadata/validation/compileValidationSchema.test.ts
@@ -20,6 +20,13 @@ describe("compileValidationSchema", () => {
     expect(compiled.Check({ Имя: "Документ" })).toBe(true)
     expect(compiled.Check({ Лишнее: true })).toBe(false)
     const [, errors] = compiled.Errors({ Лишнее: true })
+    expect(Object.keys(errors[0] ?? {}).sort()).toEqual([
+      "instancePath",
+      "keyword",
+      "message",
+      "params",
+      "schemaPath",
+    ])
     expect(errors).toEqual([
       expect.objectContaining({
         keyword: "required",

--- a/packages/core/metadata/validation/compileValidationSchema.ts
+++ b/packages/core/metadata/validation/compileValidationSchema.ts
@@ -21,11 +21,9 @@ export interface ValidationSchemaError {
   value?: unknown
 }
 
-export interface ValidationSchemaValidator<Type extends TSchema = TSchema> {
+export interface ValidationSchemaValidator {
   Check(value: unknown): boolean
   Errors(value: unknown): [boolean, ValidationSchemaError[]]
-  Schema(): Type
-  Context(): SchemaContext
 }
 
 const ajvOptions: Options = {
@@ -41,12 +39,12 @@ const undefinedKeyword = "x-nkdk-undefined"
 export function compileValidationSchema<const Type extends TSchema>(
   schema: Type,
   options?: CompileValidationSchemaOptions
-): ValidationSchemaValidator<Type>
+): ValidationSchemaValidator
 export function compileValidationSchema<Context extends SchemaContext, const Type extends TSchema>(
   context: Context,
   schema: Type,
   options?: CompileValidationSchemaOptions
-): ValidationSchemaValidator<Type>
+): ValidationSchemaValidator
 export function compileValidationSchema(
   schemaOrContext: TSchema | SchemaContext,
   schemaOrOptions?: TSchema | CompileValidationSchemaOptions,
@@ -93,12 +91,6 @@ export function compileValidationSchema(
 
       return getFallback().Errors(value)
     },
-    Schema() {
-      return schema
-    },
-    Context() {
-      return context
-    },
   }
 }
 
@@ -143,53 +135,25 @@ function createTypeboxFallback(
     Errors(value) {
       return compiled.Errors(value) as [boolean, ValidationSchemaError[]]
     },
-    Schema() {
-      return schema
-    },
-    Context() {
-      return context
-    },
   }
 }
 
-class AjvFunctionValidationSchema<Type extends TSchema = TSchema> implements ValidationSchemaValidator<Type> {
-  constructor(
-    private readonly params: {
-      schema: Type
-      context: SchemaContext
-      validate: ValidateFunction
-    }
-  ) {}
+class AjvFunctionValidationSchema implements ValidationSchemaValidator {
+  constructor(private readonly validate: ValidateFunction) {}
 
   Check(value: unknown): boolean {
-    return this.params.validate(value)
+    return this.validate(value)
   }
 
   Errors(value: unknown): [boolean, ValidationSchemaError[]] {
-    const valid = this.params.validate(value)
+    const valid = this.validate(value)
     if (valid) return [true, []]
-    return [false, normalizeAjvErrors(this.params.validate.errors)]
-  }
-
-  Schema(): Type {
-    return this.params.schema
-  }
-
-  Context(): SchemaContext {
-    return this.params.context
+    return [false, normalizeAjvErrors(this.validate.errors)]
   }
 }
 
-export function createValidationSchemaFromAjvFunction<const Type extends TSchema>(params: {
-  schema: Type
-  context?: SchemaContext
-  validate: ValidateFunction
-}): ValidationSchemaValidator<Type> {
-  return new AjvFunctionValidationSchema({
-    schema: params.schema,
-    context: params.context ?? {},
-    validate: params.validate,
-  })
+export function createValidationSchemaFromAjvFunction(validate: ValidateFunction): ValidationSchemaValidator {
+  return new AjvFunctionValidationSchema(validate)
 }
 
 function createAjv(context: SchemaContext, options: Pick<Options, "allErrors" | "inlineRefs">): Ajv2020 {

--- a/packages/core/metadata/validation/compileValidationSchema.ts
+++ b/packages/core/metadata/validation/compileValidationSchema.ts
@@ -17,8 +17,6 @@ export interface ValidationSchemaError {
   instancePath: string
   params: Record<string, unknown>
   message: string
-  schema?: TSchema
-  value?: unknown
 }
 
 export interface ValidationSchemaValidator {
@@ -105,8 +103,6 @@ function normalizeAjvError(error: ErrorObject): ValidationSchemaError {
     instancePath: error.instancePath,
     params: error.params as Record<string, unknown>,
     message: error.message ?? error.keyword,
-    schema: error.schema as TSchema | undefined,
-    value: error.data,
   }
 }
 

--- a/packages/core/metadata/validation/generateProjectValidationAjvStandalone.ts
+++ b/packages/core/metadata/validation/generateProjectValidationAjvStandalone.ts
@@ -21,7 +21,7 @@ export async function generateProjectValidationAjvStandalone(params: { outfile: 
     validateForm: { schema: formSchema, schemaId: formSchema.$id },
   }
 
-  const entries: Array<{ itemType: string; exportName: string; schema: unknown }> = []
+  const entries: Array<{ itemType: string; exportName: string }> = []
   let index = 0
   for (const [itemType, sourceSchema] of Object.entries(schemaSet.byItemType)) {
     const exportName = `validateProperties${index}`
@@ -30,7 +30,7 @@ export async function generateProjectValidationAjvStandalone(params: { outfile: 
       `nkdk://validation/properties/${encodeURIComponent(itemType)}`
     )
     validators[exportName] = { schema, schemaId: schema.$id }
-    entries.push({ itemType, exportName, schema })
+    entries.push({ itemType, exportName })
     index += 1
   }
 
@@ -39,16 +39,11 @@ export async function generateProjectValidationAjvStandalone(params: { outfile: 
     validatorsCode,
     "",
     "const module = {",
-    '  format: "project-validation-ajv-standalone-v2",',
-    `  context: ${JSON.stringify(schemaSet.context)},`,
-    `  refs: ${JSON.stringify(refs)},`,
-    `  form: { schema: ${JSON.stringify(formSchema)}, validate: validateForm },`,
+    '  format: "project-validation-ajv-standalone-v3",',
+    "  form: { validate: validateForm },",
     "  byItemType: {",
     ...entries.map(
-      (entry) =>
-        `    ${JSON.stringify(entry.itemType)}: { schema: ${JSON.stringify(entry.schema)}, validate: ${
-          entry.exportName
-        } },`
+      (entry) => `    ${JSON.stringify(entry.itemType)}: { validate: ${entry.exportName} },`
     ),
     "  },",
     "}",
@@ -76,7 +71,7 @@ function createStandaloneValidatorsCode(params: {
     discriminator: true,
     inlineRefs: false,
     strict: false,
-    verbose: true,
+    verbose: false,
   })
   addFormats(ajv)
   ajv.addKeyword({

--- a/packages/core/metadata/validation/projectValidationPasses.test.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.test.ts
@@ -162,12 +162,6 @@ describe("validateProjectFileFirstPass references", () => {
 
     const compiled = sharedSchemaCache.properties(spec.rule)
 
-    expect(compiled.Schema()).toMatchObject({
-      properties: {
-        Форма: expect.objectContaining({}),
-      },
-    })
-    expect(compiled.Context()["nkdk://schema/validation/2.20/ru/ClientApplicationForm"]).toBeDefined()
     expect(compiled.Check({ Форма: { Элементы: {} } })).toBe(true)
   }, 20_000)
 

--- a/packages/core/metadata/validation/projectValidationPasses.ts
+++ b/packages/core/metadata/validation/projectValidationPasses.ts
@@ -1,5 +1,4 @@
 import { compileValidationSchema, type ValidationSchemaValidator } from "./compileValidationSchema"
-import { type TSchema } from "typebox"
 import fs from "fs"
 import { performance } from "node:perf_hooks"
 import { dirname, join, resolve } from "path"
@@ -39,7 +38,7 @@ import {
   type LocalValueValidationProfile,
 } from "./yamlFactExtractor"
 
-type CompiledSchema = ValidationSchemaValidator<TSchema>
+type CompiledSchema = ValidationSchemaValidator
 const formSchemaCache = new Map<string, CompiledSchema>()
 const propertiesSchemaCache = new Map<string, CompiledSchema>()
 

--- a/packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts
+++ b/packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts
@@ -61,7 +61,7 @@ describe("project validation standalone build output", () => {
   })
 
   it("loads generated validators from dist when build has produced them", async () => {
-    const modulePath = new URL("../../../dist/projectValidationAjvStandalone.js", import.meta.url).pathname
+    const modulePath = new URL("../../dist/projectValidationAjvStandalone.js", import.meta.url).pathname
     if (!existsSync(modulePath)) return
 
     const script = [
@@ -69,24 +69,26 @@ describe("project validation standalone build output", () => {
       `const module = (await import(pathToFileURL(${JSON.stringify(modulePath)}).href)).default`,
       "console.log(JSON.stringify({",
       "  format: module.format,",
-      "  context: module.context,",
+      "  moduleKeys: Object.keys(module).sort(),",
+      "  formKeys: Object.keys(module.form).sort(),",
+      "  configurationKeys: Object.keys(module.byItemType.MetadataConfiguration).sort(),",
       "  formValidateType: typeof module.form.validate,",
-      "  formValidateResultType: typeof module.form.validate({}),",
+      "  formValidateResultType: typeof module.form.validate(42),",
+      "  formErrorKeys: Object.keys(module.form.validate.errors?.[0] ?? {}).sort(),",
       "  hasConfiguration: module.byItemType.MetadataConfiguration !== undefined,",
       "  hasConfigurationExtension: module.byItemType.MetadataConfigurationExtension !== undefined,",
       "}))",
-    ].join(";")
+    ].join("\n")
     const { stdout } = await execFileAsync(process.execPath, ["-e", script])
 
     expect(JSON.parse(stdout)).toEqual({
-      format: "project-validation-ajv-standalone-v2",
-      context: {
-        version: "2.20",
-        defaultLanguage: "ru",
-        exportToYAML: { toTyped: false },
-      },
+      format: "project-validation-ajv-standalone-v3",
+      moduleKeys: ["byItemType", "form", "format"],
+      formKeys: ["validate"],
+      configurationKeys: ["validate"],
       formValidateType: "function",
       formValidateResultType: "boolean",
+      formErrorKeys: ["instancePath", "keyword", "message", "params", "schemaPath"],
       hasConfiguration: true,
       hasConfigurationExtension: true,
     })

--- a/packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts
+++ b/packages/core/metadata/validation/projectValidationStandaloneBuild.test.ts
@@ -12,8 +12,9 @@ describe("project validation standalone build output", () => {
   let schemaSet: ReturnType<typeof createProjectValidationStandaloneSchemaSet>
   let enumerationSchema: ReturnType<typeof compileValidationSchema>
   let catalogSchema: ReturnType<typeof compileValidationSchema>
+  let generatedValidatorsSummary: unknown
 
-  beforeAll(() => {
+  beforeAll(async () => {
     schemaSet = createProjectValidationStandaloneSchemaSet()
     const enumeration = getValidationProjectSpecByDir("Перечисление")
     const catalog = getValidationProjectSpecByDir("Справочник")
@@ -24,6 +25,27 @@ describe("project validation standalone build output", () => {
     catalogSchema = compileValidationSchema(schemaSet.refs, schemaSet.byItemType[catalog.rule.itemType])
     enumerationSchema.Check(undefined)
     catalogSchema.Check(undefined)
+
+    const modulePath = new URL("../../dist/projectValidationAjvStandalone.js", import.meta.url).pathname
+    if (!existsSync(modulePath)) return
+
+    const script = [
+      "const { pathToFileURL } = await import('node:url')",
+      `const module = (await import(pathToFileURL(${JSON.stringify(modulePath)}).href)).default`,
+      "console.log(JSON.stringify({",
+      "  format: module.format,",
+      "  moduleKeys: Object.keys(module).sort(),",
+      "  formKeys: Object.keys(module.form).sort(),",
+      "  configurationKeys: Object.keys(module.byItemType.MetadataConfiguration).sort(),",
+      "  formValidateType: typeof module.form.validate,",
+      "  formValidateResultType: typeof module.form.validate(42),",
+      "  formErrorKeys: Object.keys(module.form.validate.errors?.[0] ?? {}).sort(),",
+      "  hasConfiguration: module.byItemType.MetadataConfiguration !== undefined,",
+      "  hasConfigurationExtension: module.byItemType.MetadataConfigurationExtension !== undefined,",
+      "}))",
+    ].join("\n")
+    const { stdout } = await execFileAsync(process.execPath, ["-e", script])
+    generatedValidatorsSummary = JSON.parse(stdout)
   })
 
   it("includes refs produced by metadata collection registrations", () => {
@@ -60,28 +82,10 @@ describe("project validation standalone build output", () => {
     )
   })
 
-  it("loads generated validators from dist when build has produced them", async () => {
-    const modulePath = new URL("../../dist/projectValidationAjvStandalone.js", import.meta.url).pathname
-    if (!existsSync(modulePath)) return
+  it("loads generated validators from dist when build has produced them", () => {
+    if (generatedValidatorsSummary === undefined) return
 
-    const script = [
-      "const { pathToFileURL } = await import('node:url')",
-      `const module = (await import(pathToFileURL(${JSON.stringify(modulePath)}).href)).default`,
-      "console.log(JSON.stringify({",
-      "  format: module.format,",
-      "  moduleKeys: Object.keys(module).sort(),",
-      "  formKeys: Object.keys(module.form).sort(),",
-      "  configurationKeys: Object.keys(module.byItemType.MetadataConfiguration).sort(),",
-      "  formValidateType: typeof module.form.validate,",
-      "  formValidateResultType: typeof module.form.validate(42),",
-      "  formErrorKeys: Object.keys(module.form.validate.errors?.[0] ?? {}).sort(),",
-      "  hasConfiguration: module.byItemType.MetadataConfiguration !== undefined,",
-      "  hasConfigurationExtension: module.byItemType.MetadataConfigurationExtension !== undefined,",
-      "}))",
-    ].join("\n")
-    const { stdout } = await execFileAsync(process.execPath, ["-e", script])
-
-    expect(JSON.parse(stdout)).toEqual({
+    expect(generatedValidatorsSummary).toEqual({
       format: "project-validation-ajv-standalone-v3",
       moduleKeys: ["byItemType", "form", "format"],
       formKeys: ["validate"],

--- a/packages/core/metadata/validation/projectValidationStandaloneLoader.test.ts
+++ b/packages/core/metadata/validation/projectValidationStandaloneLoader.test.ts
@@ -14,8 +14,6 @@ const catalogRule = { itemType: "MetadataCatalog", properties: {} } as MetadataI
 
 describe("project validation standalone loader", () => {
   it("creates form and properties validators from a standalone-like module", () => {
-    const formSchema = Type.Object({ Вид: Type.String() })
-    const propertiesSchema = Type.Object({ Имя: Type.String() })
     const formValidate = validWhenHasString("Вид")
     const propertiesValidate = validWhenHasString("Имя")
     const cache = createValidationSchemaCacheFromStandaloneModule({
@@ -25,9 +23,9 @@ describe("project validation standalone loader", () => {
         defaultLanguage: "ru",
         exportToYAML: { toTyped: false },
       },
-      form: { schema: formSchema, validate: formValidate },
+      form: { validate: formValidate },
       byItemType: {
-        MetadataCatalog: { schema: propertiesSchema, validate: propertiesValidate },
+        MetadataCatalog: { validate: propertiesValidate },
       },
     })
 

--- a/packages/core/metadata/validation/projectValidationStandaloneLoader.test.ts
+++ b/packages/core/metadata/validation/projectValidationStandaloneLoader.test.ts
@@ -1,6 +1,5 @@
 import type { ValidateFunction } from "ajv"
 import { describe, expect, it } from "vitest"
-import { Type } from "typebox"
 import { MetadataConfigurationExtensionRules } from "../appliedObjects/configurationExtension/rules"
 import type { MetadataItemRule } from "../orchestration/property/types"
 import { createValidationSchemaCacheFromStandaloneModule } from "./projectValidationStandaloneLoader"
@@ -17,12 +16,7 @@ describe("project validation standalone loader", () => {
     const formValidate = validWhenHasString("Вид")
     const propertiesValidate = validWhenHasString("Имя")
     const cache = createValidationSchemaCacheFromStandaloneModule({
-      format: "project-validation-ajv-standalone-v2",
-      context: {
-        version: "2.20",
-        defaultLanguage: "ru",
-        exportToYAML: { toTyped: false },
-      },
+      format: "project-validation-ajv-standalone-v3",
       form: { validate: formValidate },
       byItemType: {
         MetadataCatalog: { validate: propertiesValidate },
@@ -35,40 +29,22 @@ describe("project validation standalone loader", () => {
     expect(cache.properties(catalogRule).Check({})).toBe(false)
   })
 
-  it("rejects unsupported context instead of silently using wrong schemas", () => {
-    const module = {
-      format: "project-validation-ajv-standalone-v2",
-      context: {
-        version: "2.20",
-        defaultLanguage: "ru",
-        exportToYAML: { toTyped: false },
-      },
-      form: { schema: Type.Any(), validate: validWhenHasString("Вид") },
-      byItemType: {},
-    } satisfies ProjectValidationStandaloneModule
-
+  it("rejects obsolete standalone formats", () => {
     expect(() =>
-      createValidationSchemaCacheFromStandaloneModule(module, {
-        version: "2.21",
-        defaultLanguage: "ru",
-        exportToYAML: { toTyped: false },
-      })
-    ).toThrow("Standalone validation schemas were built for context")
+      createValidationSchemaCacheFromStandaloneModule({
+        format: "project-validation-ajv-standalone-v2",
+      } as never)
+    ).toThrow("Unsupported standalone validation module format")
   })
 
   it("compileAll eagerly checks every root rule including configuration extension", () => {
     const module = {
-      format: "project-validation-ajv-standalone-v2",
-      context: {
-        version: "2.20",
-        defaultLanguage: "ru",
-        exportToYAML: { toTyped: false },
-      },
-      form: { schema: Type.Any(), validate: validAny() },
+      format: "project-validation-ajv-standalone-v3",
+      form: { validate: validAny() },
       byItemType: Object.fromEntries(
         [configurationValidationProjectSpec.rule, ...validationProjectSpecs.map((spec) => spec.rule)].map((rule) => [
           rule.itemType,
-          { schema: Type.Any(), validate: validAny() },
+          { validate: validAny() },
         ])
       ),
     } satisfies ProjectValidationStandaloneModule
@@ -79,7 +55,7 @@ describe("project validation standalone loader", () => {
       'Standalone validation schema was not generated for item type "MetadataConfigurationExtension"'
     )
 
-    module.byItemType[MetadataConfigurationExtensionRules.itemType] = { schema: Type.Any(), validate: validAny() }
+    module.byItemType[MetadataConfigurationExtensionRules.itemType] = { validate: validAny() }
 
     expect(cache.compileAll()).toEqual({
       formMs: expect.any(Number),

--- a/packages/core/metadata/validation/projectValidationStandaloneLoader.ts
+++ b/packages/core/metadata/validation/projectValidationStandaloneLoader.ts
@@ -1,6 +1,5 @@
 import { performance } from "node:perf_hooks"
 import { pathToFileURL } from "node:url"
-import type { ConfigurationContext } from "../context/types"
 import { getMetadataComponentDescriptor } from "../components/descriptor"
 import type { MetadataItemRule } from "../orchestration/property/types"
 import {
@@ -15,18 +14,15 @@ import type {
   ValidationSchemaCache,
   ValidationSchemaCacheCompileProfile,
 } from "./projectValidationPasses"
-import { assertStandaloneValidationContext } from "./projectValidationStandaloneSchemas"
 import type {
   ProjectValidationStandaloneModule,
   ProjectValidationStandaloneValidator,
 } from "./projectValidationStandaloneTypes"
 
 export function createValidationSchemaCacheFromStandaloneModule(
-  module: ProjectValidationStandaloneModule,
-  context: ConfigurationContext = module.context
+  module: ProjectValidationStandaloneModule
 ): ValidationSchemaCache {
   assertProjectValidationStandaloneModule(module)
-  assertStandaloneValidationContext(module.context, context)
 
   const form = createCompiledStandaloneValidator(module.form)
   const properties = new Map<string, ValidationSchemaValidator>()
@@ -71,14 +67,13 @@ export function createValidationSchemaCacheFromStandaloneModule(
 
 export async function loadProjectValidationStandaloneCache(params: {
   modulePath: string
-  context: ConfigurationContext
 }): Promise<ValidationSchemaCache> {
   const loaded = (await import(pathToFileURL(params.modulePath).href)) as {
     default?: ProjectValidationStandaloneModule
   } & Partial<ProjectValidationStandaloneModule>
   const module = loaded.default ?? loaded
 
-  return createValidationSchemaCacheFromStandaloneModule(module as ProjectValidationStandaloneModule, params.context)
+  return createValidationSchemaCacheFromStandaloneModule(module as ProjectValidationStandaloneModule)
 }
 
 function createCompiledStandaloneValidator(
@@ -88,7 +83,7 @@ function createCompiledStandaloneValidator(
 }
 
 function assertProjectValidationStandaloneModule(module: ProjectValidationStandaloneModule): void {
-  if (module.format !== "project-validation-ajv-standalone-v2") {
+  if (module.format !== "project-validation-ajv-standalone-v3") {
     throw new Error(`Unsupported standalone validation module format: ${String(module.format)}`)
   }
 }

--- a/packages/core/metadata/validation/projectValidationStandaloneLoader.ts
+++ b/packages/core/metadata/validation/projectValidationStandaloneLoader.ts
@@ -28,8 +28,7 @@ export function createValidationSchemaCacheFromStandaloneModule(
   assertProjectValidationStandaloneModule(module)
   assertStandaloneValidationContext(module.context, context)
 
-  const schemaContext = module.refs ?? {}
-  const form = createCompiledStandaloneValidator(module.form, schemaContext)
+  const form = createCompiledStandaloneValidator(module.form)
   const properties = new Map<string, ValidationSchemaValidator>()
 
   return {
@@ -45,7 +44,7 @@ export function createValidationSchemaCacheFromStandaloneModule(
         throw new Error(`Standalone validation schema was not generated for item type "${rule.itemType}"`)
       }
 
-      const compiled = createCompiledStandaloneValidator(validator, schemaContext)
+      const compiled = createCompiledStandaloneValidator(validator)
       properties.set(rule.itemType, compiled)
       return compiled
     },
@@ -83,14 +82,9 @@ export async function loadProjectValidationStandaloneCache(params: {
 }
 
 function createCompiledStandaloneValidator(
-  validator: ProjectValidationStandaloneValidator,
-  context: NonNullable<ProjectValidationStandaloneModule["refs"]>
+  validator: ProjectValidationStandaloneValidator
 ): ValidationSchemaValidator {
-  return createValidationSchemaFromAjvFunction({
-    schema: validator.schema,
-    context,
-    validate: validator.validate,
-  })
+  return createValidationSchemaFromAjvFunction(validator.validate)
 }
 
 function assertProjectValidationStandaloneModule(module: ProjectValidationStandaloneModule): void {

--- a/packages/core/metadata/validation/projectValidationStandaloneTypes.ts
+++ b/packages/core/metadata/validation/projectValidationStandaloneTypes.ts
@@ -1,16 +1,11 @@
 import type { ValidateFunction } from "ajv"
-import type { TSchema } from "typebox"
-import type { ConfigurationContext } from "../context/types"
 
 export interface ProjectValidationStandaloneValidator {
-  schema: TSchema
   validate: ValidateFunction
 }
 
 export interface ProjectValidationStandaloneModule {
-  format: "project-validation-ajv-standalone-v2"
-  context: ConfigurationContext
-  refs?: Record<string, TSchema>
+  format: "project-validation-ajv-standalone-v3"
   form: ProjectValidationStandaloneValidator
   byItemType: Record<string, ProjectValidationStandaloneValidator>
 }

--- a/packages/core/metadata/validation/projectValidationWorkerSchemaCache.test.ts
+++ b/packages/core/metadata/validation/projectValidationWorkerSchemaCache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it } from "vitest"
 import { createProjectValidationWorkerSchemaCache } from "./projectValidationWorkerSchemaCache"
 import { configurationValidationProjectSpec } from "./projectSpecs"
 
@@ -9,12 +9,19 @@ const context = {
 } as const
 
 describe("projectValidationWorkerSchemaCache", () => {
-  it("uses runtime schema cache for source TypeScript workers", async () => {
+  let acceptsConfigurationNameOnly: boolean
+
+  beforeAll(async () => {
     const cache = await createProjectValidationWorkerSchemaCache({
       context,
       workerUrl: "file:///project/metadata/validation/projectValidationWorker.ts",
     })
+    acceptsConfigurationNameOnly = cache
+      .properties(configurationValidationProjectSpec.rule)
+      .Check({ Имя: "Конфигурация" })
+  })
 
-    expect(cache.properties(configurationValidationProjectSpec.rule).Check({ Имя: "Конфигурация" })).toBe(false)
+  it("uses runtime schema cache for source TypeScript workers", () => {
+    expect(acceptsConfigurationNameOnly).toBe(false)
   })
 })

--- a/packages/core/metadata/validation/projectValidationWorkerSchemaCache.ts
+++ b/packages/core/metadata/validation/projectValidationWorkerSchemaCache.ts
@@ -22,8 +22,5 @@ export async function createProjectValidationWorkerSchemaCache(params: {
     throw new Error(`Standalone validation schema module was not found next to worker: ${modulePath}`)
   }
 
-  return loadProjectValidationStandaloneCache({
-    modulePath,
-    context: params.context,
-  })
+  return loadProjectValidationStandaloneCache({ modulePath })
 }

--- a/packages/core/metadata/validation/schemaCache.ts
+++ b/packages/core/metadata/validation/schemaCache.ts
@@ -14,14 +14,14 @@ import { exportMetadataItemToJSONSchema } from "../orchestration/metadataItem/to
 import { MetadataKind } from "./types"
 
 export interface SchemaCache {
-  get(kind: MetadataKind): ValidationSchemaValidator<TSchema>
+  get(kind: MetadataKind): ValidationSchemaValidator
 }
 
 export function createSchemaCache(context: ConfigurationContext): SchemaCache {
-  const cache = new Map<MetadataKind, ValidationSchemaValidator<TSchema>>()
+  const cache = new Map<MetadataKind, ValidationSchemaValidator>()
 
   return {
-    get(kind: MetadataKind): ValidationSchemaValidator<TSchema> {
+    get(kind: MetadataKind): ValidationSchemaValidator {
       const cached = cache.get(kind)
       if (cached) return cached
 

--- a/packages/core/metadata/validation/schemaRegistry.test.ts
+++ b/packages/core/metadata/validation/schemaRegistry.test.ts
@@ -19,10 +19,10 @@ const context = {
 } as const
 
 const schemaCache = new Map<string, TSchema>()
-const compiledSchemaCache = new Map<string, ValidationSchemaValidator<TSchema>>()
+const compiledSchemaCache = new Map<string, ValidationSchemaValidator>()
 const graphCache = new Map<string, ReturnType<typeof exportJSONSchemaGraph>>()
-const compiledGraphCache = new Map<string, ValidationSchemaValidator<TSchema>>()
-let configurationSchema: ValidationSchemaValidator<TSchema>
+const compiledGraphCache = new Map<string, ValidationSchemaValidator>()
+let configurationSchema: ValidationSchemaValidator
 let inlineClientApplicationFormJSON = ""
 let inlineClientApplicationFormHasDcsArrays = false
 let inlineUsualGroupJSON = ""
@@ -64,7 +64,7 @@ function commonFormValidationGraph(): ReturnType<typeof exportJSONSchemaGraph> {
   return graph
 }
 
-function compiledClientApplicationFormGraph(): ValidationSchemaValidator<TSchema> {
+function compiledClientApplicationFormGraph(): ValidationSchemaValidator {
   const cacheKey = "ClientApplicationForm:withNestedChildItems"
   const cached = compiledGraphCache.get(cacheKey)
   if (cached !== undefined) return cached
@@ -79,7 +79,7 @@ function compiledClientApplicationFormGraph(): ValidationSchemaValidator<TSchema
   return compiled
 }
 
-function eagerCompiledSchemaForName(name: string, mode?: "externalRefs" | "inline"): ValidationSchemaValidator<TSchema> {
+function eagerCompiledSchemaForName(name: string, mode?: "externalRefs" | "inline"): ValidationSchemaValidator {
   const cacheKey = `eager:${name}:${mode ?? "externalRefs"}`
   const cached = compiledSchemaCache.get(cacheKey)
   if (cached !== undefined) return cached
@@ -655,7 +655,7 @@ describe("JSON Schema registry", { timeout: 60_000 }, () => {
   })
 })
 
-function compiledSchemaForName(name: string, mode?: "externalRefs" | "inline"): ValidationSchemaValidator<TSchema> {
+function compiledSchemaForName(name: string, mode?: "externalRefs" | "inline"): ValidationSchemaValidator {
   const cacheKey = `${name}:${mode ?? "externalRefs"}`
   const cached = compiledSchemaCache.get(cacheKey)
   if (cached !== undefined) return cached

--- a/packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts
+++ b/packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts
@@ -1,5 +1,3 @@
-import type { ValidationSchemaValidator } from "./compileValidationSchema"
-import type { TSchema } from "typebox"
 import { ParsedYaml } from "../../yaml/parseMetadataYaml"
 import { Diagnostic } from "./types"
 import { diagnosticAtYamlPath } from "./yamlLocations"
@@ -10,8 +8,6 @@ export type ValidationError = {
   instancePath: string
   params: Record<string, unknown>
   message: string
-  schema?: TSchema
-  value?: unknown
   diagnosticLocation?: "key"
 }
 
@@ -113,8 +109,7 @@ function normalizedErrors(errors: ValidationError[]): ValidationError[] {
 export function typeboxErrorsToDiagnostics(
   errors: ValidationError[],
   parsed: ParsedYaml,
-  filePath: string,
-  _schema?: ValidationSchemaValidator
+  filePath: string
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = []
   const expandedErrors = normalizedErrors(errors)

--- a/packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts
+++ b/packages/core/metadata/validation/typeboxErrorsToDiagnostics.ts
@@ -114,7 +114,7 @@ export function typeboxErrorsToDiagnostics(
   errors: ValidationError[],
   parsed: ParsedYaml,
   filePath: string,
-  _schema?: ValidationSchemaValidator<TSchema>
+  _schema?: ValidationSchemaValidator
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = []
   const expandedErrors = normalizedErrors(errors)

--- a/packages/core/metadata/validation/validateFile.test.ts
+++ b/packages/core/metadata/validation/validateFile.test.ts
@@ -188,7 +188,7 @@ describe("validateFile", () => {
     const parsed = parseMetadataYaml(`НесуществующееПоле: значение\n`)
     let checkCalls = 0
     let errorsCalls = 0
-    const countedSchema: ValidationSchemaValidator<TSchema> = {
+    const countedSchema: ValidationSchemaValidator = {
       Check(value) {
         checkCalls += 1
         return simpleSchema.Check(value)
@@ -196,12 +196,6 @@ describe("validateFile", () => {
       Errors(value) {
         errorsCalls += 1
         return simpleSchema.Errors(value)
-      },
-      Schema() {
-        return simpleSchema.Schema()
-      },
-      Context() {
-        return simpleSchema.Context()
       },
     }
 

--- a/packages/core/metadata/validation/validateFile.ts
+++ b/packages/core/metadata/validation/validateFile.ts
@@ -1,5 +1,4 @@
 import type { ValidationSchemaValidator } from "./compileValidationSchema"
-import type { TSchema } from "typebox"
 import { parseMetadataYaml, type ParsedYaml } from "../../yaml/parseMetadataYaml"
 import { typeboxErrorsToDiagnostics } from "./typeboxErrorsToDiagnostics"
 import { Diagnostic } from "./types"
@@ -7,13 +6,13 @@ import { Diagnostic } from "./types"
 export interface ValidateFileParams {
   filePath: string
   text: string
-  schema: ValidationSchemaValidator<TSchema>
+  schema: ValidationSchemaValidator
 }
 
 export interface ValidateParsedFileParams {
   filePath: string
   parsed: ParsedYaml
-  schema: ValidationSchemaValidator<TSchema>
+  schema: ValidationSchemaValidator
 }
 
 export function validateFile({ filePath, text, schema }: ValidateFileParams): Diagnostic[] {

--- a/packages/core/metadata/validation/validateFile.ts
+++ b/packages/core/metadata/validation/validateFile.ts
@@ -36,14 +36,7 @@ export function validateParsedFile({ filePath, parsed, schema }: ValidateParsedF
 
   // Структурная валидация
   const [valid, errors] = schema.Errors(parsed.data)
-  if (!valid) {
-    return typeboxErrorsToDiagnostics(
-      errors.map((error) => ({ ...error, value: parsed.data })),
-      parsed,
-      filePath,
-      schema
-    )
-  }
+  if (!valid) return typeboxErrorsToDiagnostics(errors, parsed, filePath)
 
   return []
 }

--- a/packages/core/metadata/validation/validateItem.ts
+++ b/packages/core/metadata/validation/validateItem.ts
@@ -1,5 +1,4 @@
 import type { ValidationSchemaValidator } from "./compileValidationSchema"
-import type { TSchema } from "typebox"
 import { existsSync, readdirSync, readFileSync } from "fs"
 import { basename, dirname, join, resolve } from "path"
 import { Diagnostic } from "./types"
@@ -10,7 +9,7 @@ import { createOwnerMetadataCache } from "./dataPath/ownerCache"
 
 export interface ValidateItemParams {
   itemDir: string
-  schema: ValidationSchemaValidator<TSchema>
+  schema: ValidationSchemaValidator
 }
 
 export function validateItem({ itemDir, schema }: ValidateItemParams): Diagnostic[] {

--- a/packages/core/metadata/validation/yamlFactExtractor.test.ts
+++ b/packages/core/metadata/validation/yamlFactExtractor.test.ts
@@ -283,6 +283,24 @@ describe("extractValidationYamlFacts", () => {
     expect(facts.localIndexes?.metadata.ownerFacts?.["chartOfAccounts"]).toBe("ChartOfAccounts.Хозрасчетный")
   })
 
+  it("не сохраняет журнал обхода при сборе validation-фактов", () => {
+    const projectDir = "/project"
+    const filePath = "/project/Документ/Операция/Свойства.yaml"
+    const file = resolveValidationProjectFile(projectDir, filePath)
+    if (file === undefined) throw new Error("file not resolved")
+
+    const facts = extractValidationYamlFacts({
+      file,
+      parsed: parseMetadataYaml("Движения:\n  - РегистрБухгалтерии.Хозрасчетный\n"),
+      rulesSnapshot: createValidationRulesSnapshot(mockContext),
+    })
+
+    expect(facts.localIndexes?.metadata.events).toEqual([])
+    expect(facts.localIndexes?.metadata.ownerFacts?.["registerRecords"]).toEqual([
+      "AccountingRegister.Хозрасчетный",
+    ])
+  })
+
   it("can collect index facts without forming validation diagnostics", () => {
     const projectDir = "/project"
     const filePath = "/project/Справочник/Товары/Свойства.yaml"

--- a/packages/core/metadata/validation/yamlFactExtractor.ts
+++ b/packages/core/metadata/validation/yamlFactExtractor.ts
@@ -90,7 +90,7 @@ export function extractValidationYamlFacts(params: {
       profile: localValueValidationProfile,
     })
   }
-  const localIndexesCollector = createLocalIndexesCollector()
+  const localIndexesCollector = createLocalIndexesCollector({ recordEvents: false })
   const pendingReferences =
     spec === undefined
       ? []


### PR DESCRIPTION
## Изменения
- перевести standalone validation на строгий functions-only формат v3
- удалить legacy Schema()/Context() и тяжёлые schema/value из ошибок
- не сохранять журнал обхода свойств, сохранив индексы, диагностику и точные YAML-позиции
- стабилизировать проверки с лимитом 50 мс

## Проверки
- `pnpm type-check`
- `pnpm test`: core 4884, platform 165, mcp 137; все прошли
- `git diff --check`

## Профиль /Users/nikita/git/nkdk-yaml
- 38 455 YAML-файлов, 4 workers
- cold: 69,60 с
- warm avg: 48,19 с (min 42,46; max 59,26)
- peak RSS: 4 237 MiB
- диагностика стабильна: 2 449 ошибок, 0 предупреждений