### PR TITLE
feat: :sparkles: добавить live-перезапуск MCP

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,4 +1,5 @@
-import { realpathSync } from "fs"
+import { spawn } from "node:child_process"
+import { realpathSync, unwatchFile, watchFile } from "node:fs"
 import { resolve } from "path"
 import { pathToFileURL } from "url"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
@@ -6,6 +7,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { registerNkdkCapabilities } from "./tools/registerTools"
 import { projectStateHandle } from "./services/projectStateHandle"
 import { closePlatformSessionManager } from "./services/platformSessionHandle"
+import { createMcpWatchHost } from "./watchHost"
 
 declare const __NKDK_MCP_VERSION__: string | undefined
 
@@ -25,6 +27,46 @@ export async function runStdioServer(): Promise<void> {
   const server = createNkdkMcpServer()
   const transport = new StdioServerTransport()
   await runServerUntilTransportCloses(server, transport)
+}
+
+export function runWatchServer(entrypoint: string): void {
+  const host = createMcpWatchHost({
+    createWorker() {
+      const child = spawn(process.execPath, [entrypoint, "--worker"], {
+        stdio: ["pipe", "pipe", "inherit"],
+      })
+      return {
+        stdout: child.stdout,
+        write(message) {
+          child.stdin.write(message)
+        },
+        kill() {
+          child.kill()
+        },
+      }
+    },
+    writeOutput(message) {
+      process.stdout.write(`${message}\n`)
+    },
+  })
+  host.start()
+
+  let input = ""
+  process.stdin.setEncoding("utf8")
+  process.stdin.on("data", (chunk: string) => {
+    input += chunk
+    const lines = input.split(/\r?\n/)
+    input = lines.pop() ?? ""
+    for (const line of lines) {
+      if (line.length > 0) host.receive(line)
+    }
+  })
+
+  const onBuild = (current: { size: number; mtimeMs: number }, previous: { mtimeMs: number }) => {
+    if (current.size > 0 && current.mtimeMs !== previous.mtimeMs) host.reload()
+  }
+  watchFile(entrypoint, { interval: 500 }, onBuild)
+  process.stdin.once("end", () => unwatchFile(entrypoint, onBuild))
 }
 
 export async function runServerUntilTransportCloses(
@@ -69,11 +111,15 @@ function isMainEntrypoint(): boolean {
 
 if (isMainEntrypoint()) {
   installShutdownHooks()
-  runStdioServer().catch((err: unknown) => {
-    const message = err instanceof Error ? err.message : String(err)
-    process.stderr.write(`${message}\n`)
-    process.exitCode = 1
-  })
+  if (process.argv.includes("--watch")) {
+    runWatchServer(process.argv[1]!)
+  } else {
+    runStdioServer().catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err)
+      process.stderr.write(`${message}\n`)
+      process.exitCode = 1
+    })
+  }
 }
 
 function installShutdownHooks(): void {

--- a/packages/mcp/src/watchHost.test.ts
+++ b/packages/mcp/src/watchHost.test.ts
@@ -1,0 +1,56 @@
+import { EventEmitter } from "node:events"
+import { describe, expect, it } from "vitest"
+import { createMcpWatchHost } from "./watchHost"
+
+describe("MCP watch host", () => {
+  it("keeps the client channel while a reloaded worker is initialized", async () => {
+    const workers: FakeWorker[] = []
+    const output: string[] = []
+    const host = createMcpWatchHost({
+      createWorker() {
+        const worker = new FakeWorker()
+        workers.push(worker)
+        return worker
+      },
+      writeOutput(message) {
+        output.push(message)
+      },
+    })
+
+    host.start()
+    host.receive('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}')
+    workers[0]!.respond({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "nkdk", version: "1" } } })
+    host.receive('{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}')
+
+    host.reload()
+    host.receive('{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"nkdk.list_infobases","arguments":{}}}')
+
+    expect(workers).toHaveLength(2)
+    expect(workers[1]!.written).toHaveLength(1)
+
+    workers[1]!.respond({ jsonrpc: "2.0", id: "nkdk-watch-initialize-2", result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "nkdk", version: "1" } } })
+
+    expect(workers[1]!.written).toHaveLength(3)
+    workers[1]!.respond({ jsonrpc: "2.0", id: 2, result: { content: [{ type: "text", text: "ok" }] } })
+
+    expect(output).toEqual([
+      '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"nkdk","version":"1"}}}',
+      '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"ok"}]}}',
+    ])
+  })
+})
+
+class FakeWorker {
+  readonly stdout = new EventEmitter()
+  readonly written: string[] = []
+
+  write(message: string): void {
+    this.written.push(message)
+  }
+
+  respond(message: unknown): void {
+    this.stdout.emit("data", `${JSON.stringify(message)}\n`)
+  }
+
+  kill(): void {}
+}

--- a/packages/mcp/src/watchHost.ts
+++ b/packages/mcp/src/watchHost.ts
@@ -1,0 +1,106 @@
+import type { EventEmitter } from "node:events"
+
+export interface McpWatchWorker {
+  readonly stdout: Pick<EventEmitter, "on">
+  write(message: string): void
+  kill(): void
+}
+
+interface McpWatchHostOptions {
+  readonly createWorker: () => McpWatchWorker
+  readonly writeOutput: (message: string) => void
+}
+
+export interface McpWatchHost {
+  start(): void
+  receive(message: string): void
+  reload(): void
+}
+
+export function createMcpWatchHost(options: McpWatchHostOptions): McpWatchHost {
+  let worker: McpWatchWorker | undefined
+  let initialization: Record<string, unknown> | undefined
+  let initializedNotification: string | undefined
+  let ready = false
+  let generation = 0
+  const queued: string[] = []
+
+  return {
+    start() {
+      if (worker !== undefined) return
+      startWorker()
+    },
+    receive(message) {
+      const parsed = parseMessage(message)
+      if (isInitializeRequest(parsed)) initialization = parsed
+      if (isInitializedNotification(parsed)) initializedNotification = message
+      if (worker === undefined) startWorker()
+      if (!ready && !isInitializeRequest(parsed)) {
+        queued.push(message)
+        return
+      }
+      send(message)
+    },
+    reload() {
+      worker?.kill()
+      worker = undefined
+      ready = false
+      startWorker()
+    },
+  }
+
+  function startWorker(): void {
+    generation += 1
+    worker = options.createWorker()
+    worker.stdout.on("data", onWorkerOutput)
+    if (initialization === undefined) {
+      ready = true
+      drainQueue()
+      return
+    }
+    ready = false
+    const request = { ...initialization, id: `nkdk-watch-initialize-${generation}` }
+    send(JSON.stringify(request))
+  }
+
+  function onWorkerOutput(chunk: unknown): void {
+    for (const line of String(chunk).split(/\r?\n/)) {
+      if (line.length === 0) continue
+      const parsed = parseMessage(line)
+      if (parsed?.id === `nkdk-watch-initialize-${generation}`) {
+        ready = true
+        if (initializedNotification !== undefined) send(initializedNotification)
+        drainQueue()
+        continue
+      }
+      options.writeOutput(line)
+    }
+  }
+
+  function drainQueue(): void {
+    for (const message of queued.splice(0)) send(message)
+  }
+
+  function send(message: string): void {
+    worker?.write(`${message}\n`)
+  }
+}
+
+function parseMessage(message: string): Record<string, unknown> | undefined {
+  try {
+    const value: unknown = JSON.parse(message)
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isInitializeRequest(message: Record<string, unknown> | undefined): boolean {
+  return message?.method === "initialize" && "id" in message
+}
+
+function isInitializedNotification(message: Record<string, unknown> | undefined): boolean {
+  return message?.method === "notifications/initialized"
+}


### PR DESCRIPTION
## Что изменено
- Добавлен режим 
kdk-mcp --watch с постоянным stdio-хостом.
- Внутренний MCP-worker перезапускается после пересборки без разрыва канала Codex.
- Добавлен тест повторной инициализации worker.

## Проверки
- pnpm test
- tsc --noEmit -p packages/mcp/tsconfig.json
- scripts/check-new-duplicates.mjs --base ca06996e8
- реальная проверка MCP-протокола и live-перезапуска