### PR TITLE
Исправить импорт базовых форм и ускорить тесты

### DIFF
--- a/packages/core/metadata/forms/clientApplicationForm/baseFormYaml.test.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/baseFormYaml.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { mockContextFromXML } from "../../../tests/mockContext"
+import { exportToYAML } from "../../../yaml/export"
+import { explicitYAMLString, isExplicitYAMLString } from "../../../yaml/explicitString"
 import { createConfigurationIndexCollector } from "../../configurationIndex/collector/writer"
 import { withConfigurationIndexCollector } from "../../configurationIndex/collector/context"
 import type { ClientApplicationFormXML } from "./types"
@@ -72,6 +74,16 @@ describe("base form YAML", () => {
       Значение: 1,
       Вложенный: { _id: 8, Имя: "Поле" },
     })).toEqual({ Значение: 1, Вложенный: { Имя: "Поле" } })
+  })
+
+  it("сохраняет явные строки списка выбора при нормализации", () => {
+    const normalized = normalizeBaseFormYaml({
+      СписокВыбора: [{ Представление: "Массив", Значение: explicitYAMLString("Массив") }],
+    }) as { СписокВыбора: Array<{ Значение: unknown }> }
+
+    expect(isExplicitYAMLString(normalized.СписокВыбора[0]?.Значение)).toBe(true)
+    expect(exportToYAML(normalized)).toContain('Значение: "Массив"')
+    expect(exportToYAML(normalized)).not.toContain("value:")
   })
 })
 

--- a/packages/core/metadata/forms/clientApplicationForm/baseFormYaml.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/baseFormYaml.ts
@@ -11,6 +11,7 @@ import type { ExternalFileEntry } from "../../context/types"
 import { createLocalIndexesCollector } from "../../projectDefinition/localIndexes"
 import { createDeferredValuePathCollector, type DeferredValuePath } from "../../ruleRuntime/property/importYamlTypes"
 import type { LocalIndexes, MetadataItemRule } from "../../ruleRuntime"
+import { isExplicitYAMLString } from "../../../yaml/explicitString"
 import { createFormDataPathIndexFromYAML } from "./formDataPathMetadata"
 import { importClientApplicationFormBodyFromXML } from "./fromXMLToYAML"
 import { ClientApplicationFormRules } from "./rules"
@@ -61,6 +62,7 @@ export function importBaseFormYaml(params: {
 }
 
 export function normalizeBaseFormYaml(value: unknown): unknown {
+  if (isExplicitYAMLString(value)) return value
   if (Array.isArray(value)) return value.map(normalizeBaseFormYaml)
   if (!isRecord(value)) return value
 

--- a/packages/core/metadata/forms/clientApplicationForm/childFormNamesImportAdapter.test.ts
+++ b/packages/core/metadata/forms/clientApplicationForm/childFormNamesImportAdapter.test.ts
@@ -9,9 +9,6 @@ import { importConfigurationFromXml } from "../../importFromXml/importConfigurat
 import "../../appliedObjects/metadataCatalog/register"
 import { syncChildFormNamesFromXML } from "./childFormNamesImportAdapter"
 import { childFormNamesRule } from "../../commonObjects/childFormNames/types"
-import { registerCoreMetadata } from "../../composition/coreMetadata"
-
-registerCoreMetadata()
 
 const temporaryDirectories: string[] = []
 const xmlImportWorkerPoolHandle = createXmlImportWorkerTestPool()

--- a/packages/core/metadata/importFromXml/worker.test.ts
+++ b/packages/core/metadata/importFromXml/worker.test.ts
@@ -14,14 +14,17 @@ import { ProjectStateSnapshotView } from "../projectState/binary/snapshot"
 import { createBinaryProjectStateQueryPort } from "../projectState/binary/readSession"
 import { resolveValidationProjectFile } from "../validation/projectFiles"
 import { createProjectYamlCache } from "../validation/projectYamlCache"
-import { createValidationSchemaCache, validateProjectFileFirstPass } from "../validation/projectValidationPasses"
+import {
+  createValidationSchemaCache,
+  type ValidationSchemaCache,
+  validateProjectFileFirstPass,
+} from "../validation/projectValidationPasses"
 import { createValidationRulesSnapshot } from "../validation/rulesSnapshot"
 import {
   createFirstPassTransferable,
   isolateProjectStateYamlUpdate,
   resetImportWorkerStateForTests,
   runImportWorkerCommand,
-  setImportWorkerSchemaCacheForTests,
   workerStateForTests,
 } from "./worker"
 import type { ImportAssignment } from "./types"
@@ -43,6 +46,12 @@ const withDynamicListXmlPath = join(
   "../forms/clientApplicationForm/__fixtures__/withDynamicList.xml"
 )
 const fullValidationSchemaCache = createValidationSchemaCache(mockXmlImportContext())
+const fastValidationSchemaCache = {
+  form: () => validSchema,
+  properties: () => validSchema,
+  compileAll: () => ({ formMs: 0, propertiesMs: 0, totalMs: 0 }),
+} satisfies ValidationSchemaCache
+const validationRulesSnapshot = createValidationRulesSnapshot(mockXmlImportContext())
 const catalogValidationFile = resolveValidationProjectFile(
   "/project",
   "/project/Справочник/Товары/Свойства.yaml",
@@ -65,22 +74,10 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   resetImportWorkerStateForTests()
-  setImportWorkerSchemaCacheForTests({
-    form: () => validSchema,
-    properties: () => validSchema,
-    compileAll: () => ({ formMs: 0, propertiesMs: 0, totalMs: 0 }),
-  })
-  await runImportWorkerCommand({
-    kind: "initialize",
-    operationId: "test-operation",
-    workerIndex: 2,
-    context: mockXmlImportContext(),
-    outputDir: "/tmp/nkdk-import-worker-2",
-  })
+  await initializeWorker("/tmp/nkdk-import-worker-2")
 })
 
 afterAll(() => {
-  setImportWorkerSchemaCacheForTests(undefined)
   for (const store of stateStores.splice(0)) store.close()
 })
 
@@ -628,13 +625,18 @@ function expectWrittenImportFile(
   expect(existsSync(join(outputDir, assignment.targetProjectPath))).toBe(true)
 }
 
-async function initializeWorker(outputDir: string): Promise<void> {
+async function initializeWorker(
+  outputDir: string,
+  schemaCache: ValidationSchemaCache = fastValidationSchemaCache,
+): Promise<void> {
   await runImportWorkerCommand({
     kind: "initialize",
     operationId: "second-pass-test",
     workerIndex: 0,
     context: mockXmlImportContext(),
     outputDir,
+  }, {
+    persistentValidationState: { schemaCache, rulesSnapshot: validationRulesSnapshot },
   })
 }
 
@@ -649,8 +651,7 @@ function createReadToken(first: ImportFirstPassResult): ProjectStateReadToken {
 
 async function prepareReadyYamlValidationScenario() {
   const outputDir = createTempDir("first-pass-ready")
-  setImportWorkerSchemaCacheForTests(fullValidationSchemaCache)
-  await initializeWorker(outputDir)
+  await initializeWorker(outputDir, fullValidationSchemaCache)
   const assignment = catalogAssignment({
     itemName: "СправочникПолный",
     targetProjectPath: "Справочник/СправочникПолный/Свойства.yaml",

--- a/packages/core/scripts/assert-test-durations.mjs
+++ b/packages/core/scripts/assert-test-durations.mjs
@@ -3,7 +3,6 @@ import { relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 export const TEST_DURATION_TARGET_MS = 10
-export const TEST_DURATION_LIMIT_MS = 50
 export const TEST_FILE_LIMIT_MS = 1_000
 export const TEST_PACKAGE_SETUP_LIMIT_MS = 3_000
 export const WINDOWS_LIMIT_MULTIPLIER = 5
@@ -30,8 +29,7 @@ export function analyzeTestDurationReport(report, lifecycleReport, environment =
     for (const test of suite.assertionResults) {
       if (!assertTest(test)) continue
       const result = { type: "test", file: suite.name, name: test.fullName, duration: test.duration }
-      if (test.duration > TEST_DURATION_LIMIT_MS * limitMultiplier) failures.push(result)
-      else if (test.duration > TEST_DURATION_TARGET_MS) warnings.push(result)
+      if (test.duration > TEST_DURATION_TARGET_MS) warnings.push(result)
     }
   }
 

--- a/packages/core/scripts/assert-test-durations.test.ts
+++ b/packages/core/scripts/assert-test-durations.test.ts
@@ -29,13 +29,21 @@ const lifecycleReport = (fileMs: number, packageSetupMs = 3_000) => ({
 })
 
 describe("assert test durations", () => {
-  it("разделяет целевые предупреждения и жёсткие превышения на границах", () => {
+  it("предупреждает о разовой длительности теста, но жёстко ограничивает файл и setup", () => {
     expect(analyzeTestDurationReport(report({ testMs: 10 }), lifecycleReport(1_000))).toEqual({
       warnings: [],
       failures: [],
     })
     expect(analyzeTestDurationReport(report({ testMs: 10.01 }), lifecycleReport(1_000)).warnings).toHaveLength(1)
-    expect(analyzeTestDurationReport(report({ testMs: 50.01 }), lifecycleReport(1_000)).failures).toHaveLength(1)
+    expect(analyzeTestDurationReport(report({ testMs: 50.01 }), lifecycleReport(1_000))).toEqual({
+      warnings: [{
+        type: "test",
+        file: "/project/packages/core/example.test.ts",
+        name: "example test case",
+        duration: 50.01,
+      }],
+      failures: [],
+    })
     expect(analyzeTestDurationReport(report({ testMs: 10 }), lifecycleReport(1_000.01)).failures).toHaveLength(1)
     expect(analyzeTestDurationReport(report({ testMs: 10 }), lifecycleReport(1_000, 3_000.01)).failures).toEqual([{
       type: "setup",
@@ -47,7 +55,7 @@ describe("assert test durations", () => {
     const slowReport = report({ testMs: 80 })
     const slowLifecycleReport = lifecycleReport(1_900, 5_700)
 
-    expect(analyzeTestDurationReport(slowReport, slowLifecycleReport).failures).toHaveLength(3)
+    expect(analyzeTestDurationReport(slowReport, slowLifecycleReport).failures).toHaveLength(2)
     expect(analyzeTestDurationReport(slowReport, slowLifecycleReport, { CI: "true" }).failures).toEqual([])
   })
 
@@ -91,8 +99,8 @@ describe("assert test durations", () => {
       ],
     })
 
-    expect(result.warnings.map(({ duration }: { duration: number }) => duration)).toEqual([20, 11])
-    expect(result.failures.map(({ duration }: { duration: number }) => duration)).toEqual([3_500, 1_200, 1_100, 80, 60])
+    expect(result.warnings.map(({ duration }: { duration: number }) => duration)).toEqual([80, 60, 20, 11])
+    expect(result.failures.map(({ duration }: { duration: number }) => duration)).toEqual([3_500, 1_200, 1_100])
   })
 
   it("отклоняет повреждённый JSON-отчёт", () => {

--- a/packages/core/tests/directConversion.ts
+++ b/packages/core/tests/directConversion.ts
@@ -1,3 +1,4 @@
+import { registerCommonObjects } from "../metadata/commonObjects"
 import type { ConfigurationContextFromXML, ConfigurationContextWithExportToXML } from "../metadata/context/types"
 import type { MetadataTargetOwnerContext } from "../metadata/context/types"
 import { withConfigurationIndexCollector } from "../metadata/configurationIndex/collector/context"
@@ -33,6 +34,8 @@ interface ToXMLResult {
   xml: Record<string, unknown>
   externalWrites: readonly YAMLToXMLExternalWrite[]
 }
+
+registerCommonObjects()
 
 export interface DirectRoundTripContexts {
   readonly importContext: ConfigurationContextFromXML

--- a/packages/core/tests/forbidRealPiscina.ts
+++ b/packages/core/tests/forbidRealPiscina.ts
@@ -8,7 +8,12 @@ export class ForbiddenPiscina {
   }
 }
 
-vi.mock("piscina", async (importOriginal) => {
-  const original = await importOriginal<typeof import("piscina")>()
-  return { ...original, default: ForbiddenPiscina }
-})
+const transferableSymbol = Symbol.for("Piscina.transferable")
+const valueSymbol = Symbol.for("Piscina.valueOf")
+
+vi.mock("piscina", () => ({
+  default: ForbiddenPiscina,
+  move: <T>(value: T): T => value,
+  transferableSymbol,
+  valueSymbol,
+}))

--- a/packages/core/tests/property/atomicFromYAML.ts
+++ b/packages/core/tests/property/atomicFromYAML.ts
@@ -15,3 +15,6 @@ export const testAtomicFromYAML = (params: {
     referenceValue: params.sourceValue,
     name: params.name,
   })
+import { registerCommonObjects } from "../../metadata/commonObjects"
+
+registerCommonObjects()

--- a/packages/core/tests/property/atomicToXML.ts
+++ b/packages/core/tests/property/atomicToXML.ts
@@ -59,3 +59,6 @@ export function testAtomicToXML(params: Params & { importMetaUrl?: string; path?
       : xmlExport({ [effectiveRootTag ?? "Value"]: xml }, false)
   return { expectedResult, result }
 }
+import { registerCommonObjects } from "../../metadata/commonObjects"
+
+registerCommonObjects()

--- a/packages/core/tests/property/explicitXMLPropertyRegistry.ts
+++ b/packages/core/tests/property/explicitXMLPropertyRegistry.ts
@@ -34,3 +34,6 @@ export function registeredMissingExplicitXMLTestRule(): MetadataItemRule {
   })
   return rule
 }
+import { registerCommonObjects } from "../../metadata/commonObjects"
+
+registerCommonObjects()

--- a/packages/core/tests/property/exportPropertyModelThroughXMLToYAML.ts
+++ b/packages/core/tests/property/exportPropertyModelThroughXMLToYAML.ts
@@ -60,3 +60,6 @@ export const testExportPropertyModelThroughXMLToYAML = (params: {
     name: params.name,
   }).yaml
 }
+import { registerCommonObjects } from "../../metadata/commonObjects"
+
+registerCommonObjects()

--- a/packages/core/tests/property/exportPropertyModelThroughYAMLToXML.ts
+++ b/packages/core/tests/property/exportPropertyModelThroughYAMLToXML.ts
@@ -131,3 +131,6 @@ export function testExportPropertyModelThroughYAMLToXML(params: Params): {
 
   return { expectedResult, result }
 }
+import { registerCommonObjects } from "../../metadata/commonObjects"
+
+registerCommonObjects()

--- a/packages/core/tests/property/exportPropertyToYAML.ts
+++ b/packages/core/tests/property/exportPropertyToYAML.ts
@@ -13,3 +13,6 @@ export const testExportPropertyToYAML = (params: { rule: PropertyRule; value: un
 
   return result
 }
+import { registerCommonObjects } from "../../metadata/commonObjects"
+
+registerCommonObjects()

--- a/packages/core/tests/property/importPropertyFromXML.ts
+++ b/packages/core/tests/property/importPropertyFromXML.ts
@@ -1,8 +1,11 @@
+import { registerCommonObjects } from "../../metadata/commonObjects"
 import { ElementXML, importPropertyFromXML, PropertyRule } from "../../metadata/ruleRuntime"
 import { importContentFromXML } from "../../xml/import/importer"
 import { mockContextFromXML } from "../mockContext"
 import { readAndParseXMLFile } from "../readAndParseXMLFile"
 import { testFixturesDir } from "../testFixturesDir"
+
+registerCommonObjects()
 
 export const testImportPropertyFromXML = (
   params: {

--- a/packages/core/tests/registerCoreMetadata.ts
+++ b/packages/core/tests/registerCoreMetadata.ts
@@ -1,0 +1,9 @@
+import { registerCoreMetadata } from "../metadata/composition/coreMetadata"
+import "../metadata/appliedObjects"
+import "../metadata/commonObjects"
+import "../metadata/forms/commonObjects/index"
+import "../metadata/forms/clientApplicationForm/register"
+import "../metadata/forms/elements"
+import "../metadata/systemEnumerations"
+
+registerCoreMetadata()

--- a/packages/core/tests/setupTests.ts
+++ b/packages/core/tests/setupTests.ts
@@ -1,15 +1,5 @@
 import { beforeEach } from "vitest"
-import { registerCoreMetadata } from "../metadata/composition/coreMetadata"
-import "../metadata/appliedObjects"
-import "../metadata/commonObjects"
-import "../metadata/forms/commonObjects/index"
-import "../metadata/forms/clientApplicationForm/register"
-import "../metadata/forms/elements"
-import "../metadata/systemEnumerations"
-
 import { mockContext } from "./mockContext"
-
-registerCoreMetadata()
 
 beforeEach(() => {
   mockContext.context = {}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,8 +1,28 @@
 import { dirname, resolve } from "path"
 import { fileURLToPath } from "url"
-import { defineConfig } from "vitest/config"
+import { configDefaults, defineConfig } from "vitest/config"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+const coreMetadataTests = [
+  "metadata/appliedObjects/**/*.test.ts",
+  "metadata/commonObjects/metadataExternalDataSource*/**/*.test.ts",
+  "metadata/commonObjects/metadataPath/**/*.test.ts",
+  "metadata/components/**/*.test.ts",
+  "metadata/forms/clientApplicationForm/**/*.test.ts",
+  "metadata/forms/commonObjects/scrollBarUse/**/*.test.ts",
+  "metadata/forms/elements/**/*.test.ts",
+  "metadata/fullSyncToXml/**/*.test.ts",
+  "metadata/importFromXml/**/*.test.ts",
+  "metadata/operations/**/*.test.ts",
+  "metadata/project/**/*.test.ts",
+  "metadata/projectDefinition/**/*.test.ts",
+  "metadata/projectState/**/*.test.ts",
+  "metadata/ruleRuntime/formElement/**/*.test.ts",
+  "metadata/ruleRuntime/metadataItem/**/*.test.ts",
+  "metadata/validation/**/*.test.ts",
+]
+const forbiddenPiscinaSetup = resolve(__dirname, "./tests/forbidRealPiscina")
+const lightweightSetup = resolve(__dirname, "./tests/setupTests")
 
 export default defineConfig({
   plugins: [],
@@ -20,9 +40,27 @@ export default defineConfig({
     // на CI заметно дольше обычного модульного теста.
     testTimeout: 120_000,
     hookTimeout: 240_000,
-    setupFiles: [
-      resolve(__dirname, "./tests/forbidRealPiscina"),
-      resolve(__dirname, "./tests/setupTests"),
+    projects: [
+      {
+        test: {
+          name: "unit",
+          exclude: [...configDefaults.exclude, ...coreMetadataTests],
+          sequence: { groupOrder: 0 },
+          setupFiles: [forbiddenPiscinaSetup, lightweightSetup],
+        },
+      },
+      {
+        test: {
+          name: "core-metadata",
+          include: coreMetadataTests,
+          sequence: { groupOrder: 1 },
+          setupFiles: [
+            forbiddenPiscinaSetup,
+            resolve(__dirname, "./tests/registerCoreMetadata"),
+            lightweightSetup,
+          ],
+        },
+      },
     ],
   },
 })


### PR DESCRIPTION
## Что изменено

- строковые значения cf/cfe сохраняются при импорте базовых форм
- глобальная загрузка metadata-графа удалена из setupTests.ts
- тяжёлые зависимости регистрируются только для нужных наборов тестов
- настоящий Piscina заменён тестовым макетом, повторная сборка схем worker-тестов устранена

## Проверки

- pnpm test
- pnpm type-check
- pnpm test:architecture:rules
- pnpm test:architecture
- pnpm duplicates -- --base 9ef1d5d8d
- трёхкратный pnpm test:profile