### PR TITLE
test: отделить проверку сборки MCP

### DIFF
--- a/.agents/skills/finish-pr-cycle/SKILL.md
+++ b/.agents/skills/finish-pr-cycle/SKILL.md
@@ -27,25 +27,35 @@ git merge --no-edit origin/develop
 
 If the merge conflicts, stop and report the conflicted files. Do not resolve conflicts silently. This is required because stale feature branches can rediscover round-trip diffs that were already fixed and merged in another branch.
 
-3. Verify tests if they were not just run in this session. Prefer the project's normal focused or full test command. In `nkdk-core`, use:
+3. Review the tests added by the branch before verification:
+
+```bash
+git diff --name-status --diff-filter=A origin/develop...HEAD
+```
+
+Identify the added test files in this diff. Remove tests that only lock in implementation details and do not protect observable behavior or an explicit architectural contract. Keep behavior-driven tests that exercise stable public interfaces.
+
+Do not automatically remove round-trip, fixture-based, snapshot, architecture, or issue-linked regression tests; follow the project's test architecture. For every removed test, identify the remaining test that protects the behavior. If the review changes files, run the relevant tests, commit the removal, and verify that the worktree is clean before continuing.
+
+4. Verify tests if they were not just run in this session. Prefer the project's normal focused or full test command. In `nkdk-core`, use:
 
 ```bash
 pnpm --filter '@nkdk/core' test
 ```
 
-4. Push the current branch:
+5. Push the current branch:
 
 ```bash
 git push -u origin <branch>
 ```
 
-5. Create a PR into `develop`. The PR base branch must be exactly `develop`; do not target `main`, `master`, or any other branch unless the user explicitly overrides this in the current request:
+6. Create a PR into `develop`. The PR base branch must be exactly `develop`; do not target `main`, `master`, or any other branch unless the user explicitly overrides this in the current request:
 
 ```bash
 gh pr create --base develop --head <branch> --title "<title>" --body "<summary and test plan>"
 ```
 
-6. Merge the PR with a regular merge commit unless the user requested another merge method:
+7. Merge the PR with a regular merge commit unless the user requested another merge method:
 
 ```bash
 gh pr merge <number> --merge --delete-branch
@@ -59,20 +69,20 @@ gh pr view <number> --json state,mergedAt,mergeCommit,url,headRefName,baseRefNam
 
 If the PR is already `MERGED`, continue cleanup.
 
-7. Confirm the remote branch is gone. If it remains, delete it:
+8. Confirm the remote branch is gone. If it remains, delete it:
 
 ```bash
 git ls-remote --heads origin <branch>
 git push origin --delete <branch>
 ```
 
-8. Remove the feature worktree:
+9. Remove the feature worktree:
 
 ```bash
 git worktree remove <absolute-worktree-path>
 ```
 
-9. Delete the local branch:
+10. Delete the local branch:
 
 ```bash
 git branch -D <branch>
@@ -80,7 +90,7 @@ git branch -D <branch>
 
 Use `-D` only after confirming the PR is merged.
 
-10. Verify cleanup:
+11. Verify cleanup:
 
 ```bash
 git worktree list

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -33,6 +33,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm type-check
       - run: pnpm test
+      - run: pnpm --filter @nkdk/mcp smoke:packed
 
   duplicates:
     runs-on: ubuntu-latest

--- a/packages/core/metadata/commonObjects/dataCompositionSystem/settingsParameterValueCollection/dcscorItemsXML.test.ts
+++ b/packages/core/metadata/commonObjects/dataCompositionSystem/settingsParameterValueCollection/dcscorItemsXML.test.ts
@@ -5,7 +5,7 @@ import {
   exportSettingsParameterValueDcscorItemsToXML,
   getDcscorItemExportValueForXmlParents,
   importSettingsParameterValueDcscorItemsFromXML,
-} from "./dcscorItemsXML"
+} from "./index"
 
 describe("settingsParameterValueCollection dcscor items", () => {
   const ruleSet: SettingsParameterValueCollectionPropertyRule = {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -8,6 +8,7 @@ const coreMetadataTests = [
   "metadata/commonObjects/metadataExternalDataSource*/**/*.test.ts",
   "metadata/commonObjects/metadataPath/**/*.test.ts",
   "metadata/components/**/*.test.ts",
+  "metadata/configurationIndex/projectFiles.test.ts",
   "metadata/forms/clientApplicationForm/**/*.test.ts",
   "metadata/forms/commonObjects/scrollBarUse/**/*.test.ts",
   "metadata/forms/elements/**/*.test.ts",

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -160,17 +160,6 @@ describe("MCP server", () => {
     expect(packageJson.dependencies).toHaveProperty("structurae", "4.0.2")
   })
 
-  it("публикует universal worker без standalone-схем", { timeout: 30_000 }, async () => {
-    const { access } = await import("node:fs/promises")
-    const buildUrl = new URL(`../scripts/build.mjs?test=${Date.now()}`, import.meta.url)
-
-    await import(/* @vite-ignore */ buildUrl.href)
-
-    await expect(access(new URL("../dist/bin/worker.js", import.meta.url))).resolves.toBeUndefined()
-    await expect(access(new URL("../dist/bin/projectValidationAjvStandalone.js", import.meta.url)))
-      .rejects.toMatchObject({ code: "ENOENT" })
-  })
-
   it("uses package version for MCP server metadata", async () => {
     const { createNkdkMcpServer } = await import("./server")
     const packageJson = await import("../package.json", { with: { type: "json" } })


### PR DESCRIPTION
## Что изменено
- finish-pr-cycle проверяет добавленные тесты на привязку к деталям реализации
- production-сборка MCP удалена из Vitest и проверяется отдельным smoke:packed шагом CI
- два metadata-теста больше не зависят от порядка запуска

## Проверки
- pnpm test
- pnpm type-check
- pnpm test:architecture:rules
- pnpm test:architecture
- pnpm duplicates -- --base origin/develop
- pnpm --filter @nkdk/mcp smoke:packed
- валидация finish-pr-cycle